### PR TITLE
feat(audit): add global audit center and timeline

### DIFF
--- a/yak-ops-boot/src/main/java/io/yak/ops/boot/audit/AuditQueryController.java
+++ b/yak-ops-boot/src/main/java/io/yak/ops/boot/audit/AuditQueryController.java
@@ -1,0 +1,69 @@
+package io.yak.ops.boot.audit;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import io.yak.framework.common.PageData;
+import io.yak.framework.common.PagingData;
+import io.yak.framework.common.Result;
+import io.yak.framework.security.common.constant.SecurityPermissionCode;
+import io.yak.framework.security.web.RequiresPermission;
+import io.yak.ops.business.audit.AuditFilterOptions;
+import io.yak.ops.business.audit.AuditOperationDetail;
+import io.yak.ops.business.audit.AuditOperationQuery;
+import io.yak.ops.business.audit.AuditOperationSummary;
+import io.yak.ops.business.audit.AuditPage;
+import io.yak.ops.business.audit.AuditQueryService;
+import java.util.Optional;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+/** Administrator-facing read API for end-to-end business audit operations. */
+@Tag(name = "Yak Ops 审计中心")
+@RestController
+@RequestMapping("/api/v1/audit")
+@RequiresPermission(SecurityPermissionCode.OperationLog.READ)
+@ConditionalOnProperty(
+    prefix = "yak.database",
+    name = "enabled",
+    havingValue = "true",
+    matchIfMissing = true)
+public class AuditQueryController {
+
+  private final AuditQueryService auditQueryService;
+
+  public AuditQueryController(AuditQueryService auditQueryService) {
+    this.auditQueryService = auditQueryService;
+  }
+
+  @Operation(summary = "分页查询审计操作")
+  @PostMapping("/operations/page")
+  public Result<PagingData<AuditOperationSummary>> page(
+      @RequestBody(required = false) AuditOperationQuery query) {
+    AuditPage<AuditOperationSummary> page =
+        auditQueryService.page(query == null ? AuditOperationQuery.empty() : query);
+    PageData<AuditOperationSummary> pageData =
+        PageData.of(page.records(), page.total(), page.page(), page.size());
+    return Result.success(PagingData.from(pageData));
+  }
+
+  @Operation(summary = "查询审计操作详情和时间线")
+  @GetMapping("/operations/{operationId}")
+  public Result<AuditOperationDetail> detail(@PathVariable String operationId) {
+    Optional<AuditOperationDetail> detail = auditQueryService.detail(operationId);
+    if (detail.isEmpty()) {
+      return Result.buildNotExist("审计操作不存在");
+    }
+    return Result.success(detail.get());
+  }
+
+  @Operation(summary = "查询审计中心筛选选项")
+  @GetMapping("/options")
+  public Result<AuditFilterOptions> options() {
+    return Result.success(auditQueryService.options());
+  }
+}

--- a/yak-ops-boot/src/test/java/io/yak/ops/boot/audit/AuditQueryControllerContractTest.java
+++ b/yak-ops-boot/src/test/java/io/yak/ops/boot/audit/AuditQueryControllerContractTest.java
@@ -1,0 +1,30 @@
+package io.yak.ops.boot.audit;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.yak.framework.security.common.constant.SecurityPermissionCode;
+import io.yak.framework.security.web.RequiresPermission;
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.web.bind.annotation.RequestMapping;
+
+class AuditQueryControllerContractTest {
+
+  @Test
+  void reusesExistingOperationLogRbacAndDatabaseEnablementContract() {
+    RequiresPermission permission = AuditQueryController.class.getAnnotation(RequiresPermission.class);
+    RequestMapping mapping = AuditQueryController.class.getAnnotation(RequestMapping.class);
+    ConditionalOnProperty conditional =
+        AuditQueryController.class.getAnnotation(ConditionalOnProperty.class);
+
+    assertThat(permission).isNotNull();
+    assertThat(permission.value()).isEqualTo(SecurityPermissionCode.OperationLog.READ);
+    assertThat(mapping).isNotNull();
+    assertThat(mapping.value()).containsExactly("/api/v1/audit");
+    assertThat(conditional).isNotNull();
+    assertThat(conditional.prefix()).isEqualTo("yak.database");
+    assertThat(conditional.name()).containsExactly("enabled");
+    assertThat(conditional.havingValue()).isEqualTo("true");
+    assertThat(conditional.matchIfMissing()).isTrue();
+  }
+}

--- a/yak-ops-business/yak-ops-business-audit/src/main/java/io/yak/ops/business/audit/AuditConfiguration.java
+++ b/yak-ops-business/yak-ops-business-audit/src/main/java/io/yak/ops/business/audit/AuditConfiguration.java
@@ -55,4 +55,11 @@ public class AuditConfiguration {
     return new JdbcBusinessAuditService(
         dataSource, transactionManager, currentProject, objectMapper, actorResolver);
   }
+
+  @Bean
+  public AuditQueryService auditQueryService(
+      @Qualifier("yakBusinessDataSource") DataSource dataSource, ObjectMapper objectMapper) {
+    return new JdbcAuditQueryService(
+        dataSource, objectMapper, new AuditTimelineRendererRegistry());
+  }
 }

--- a/yak-ops-business/yak-ops-business-audit/src/main/java/io/yak/ops/business/audit/AuditEventPresentation.java
+++ b/yak-ops-business/yak-ops-business-audit/src/main/java/io/yak/ops/business/audit/AuditEventPresentation.java
@@ -1,0 +1,4 @@
+package io.yak.ops.business.audit;
+
+/** Business-facing presentation derived from a stable audit event. */
+public record AuditEventPresentation(String title, String description) {}

--- a/yak-ops-business/yak-ops-business-audit/src/main/java/io/yak/ops/business/audit/AuditFilterOption.java
+++ b/yak-ops-business/yak-ops-business-audit/src/main/java/io/yak/ops/business/audit/AuditFilterOption.java
@@ -1,0 +1,4 @@
+package io.yak.ops.business.audit;
+
+/** One stable value/label option used by Audit Center filters. */
+public record AuditFilterOption(String value, String label) {}

--- a/yak-ops-business/yak-ops-business-audit/src/main/java/io/yak/ops/business/audit/AuditFilterOptions.java
+++ b/yak-ops-business/yak-ops-business-audit/src/main/java/io/yak/ops/business/audit/AuditFilterOptions.java
@@ -1,0 +1,30 @@
+package io.yak.ops.business.audit;
+
+import java.util.List;
+
+/** Filter catalog derived from persisted operation snapshots. */
+public record AuditFilterOptions(
+    List<AuditFilterOption> actors,
+    List<AuditFilterOption> projects,
+    List<AuditFilterOption> operationTypes,
+    List<AuditFilterOption> resourceTypes,
+    List<AuditFilterOption> statuses,
+    List<AuditFilterOption> sources) {
+
+  public AuditFilterOptions {
+    actors = immutable(actors);
+    projects = immutable(projects);
+    operationTypes = immutable(operationTypes);
+    resourceTypes = immutable(resourceTypes);
+    statuses = immutable(statuses);
+    sources = immutable(sources);
+  }
+
+  public static AuditFilterOptions empty() {
+    return new AuditFilterOptions(List.of(), List.of(), List.of(), List.of(), List.of(), List.of());
+  }
+
+  private static List<AuditFilterOption> immutable(List<AuditFilterOption> values) {
+    return values == null ? List.of() : List.copyOf(values);
+  }
+}

--- a/yak-ops-business/yak-ops-business-audit/src/main/java/io/yak/ops/business/audit/AuditOperationDetail.java
+++ b/yak-ops-business/yak-ops-business-audit/src/main/java/io/yak/ops/business/audit/AuditOperationDetail.java
@@ -1,0 +1,21 @@
+package io.yak.ops.business.audit;
+
+import java.util.Collections;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+/** Full Audit Center drawer model: immutable operation snapshot plus ordered Timeline. */
+public record AuditOperationDetail(
+    AuditOperationSummary operation,
+    Map<String, Object> metadata,
+    List<AuditTimelineEvent> events) {
+
+  public AuditOperationDetail {
+    metadata =
+        metadata == null || metadata.isEmpty()
+            ? Map.of()
+            : Collections.unmodifiableMap(new LinkedHashMap<>(metadata));
+    events = events == null ? List.of() : List.copyOf(events);
+  }
+}

--- a/yak-ops-business/yak-ops-business-audit/src/main/java/io/yak/ops/business/audit/AuditOperationQuery.java
+++ b/yak-ops-business/yak-ops-business-audit/src/main/java/io/yak/ops/business/audit/AuditOperationQuery.java
@@ -1,0 +1,49 @@
+package io.yak.ops.business.audit;
+
+import java.time.LocalDateTime;
+
+/** Read-side filters for the administrator Audit Center. */
+public record AuditOperationQuery(
+    int page,
+    int size,
+    String keyword,
+    String actor,
+    Long projectId,
+    String operationType,
+    String resourceType,
+    String status,
+    String source,
+    LocalDateTime startTime,
+    LocalDateTime endTime) {
+
+  private static final int DEFAULT_PAGE_SIZE = 20;
+  private static final int MAX_PAGE_SIZE = 200;
+
+  public AuditOperationQuery {
+    page = page <= 0 ? 1 : page;
+    size = size <= 0 ? DEFAULT_PAGE_SIZE : Math.min(size, MAX_PAGE_SIZE);
+    keyword = normalize(keyword);
+    actor = normalize(actor);
+    projectId = projectId != null && projectId <= 0L ? null : projectId;
+    operationType = normalize(operationType);
+    resourceType = normalize(resourceType);
+    status = normalize(status);
+    source = normalize(source);
+    if (startTime != null && endTime != null && startTime.isAfter(endTime)) {
+      LocalDateTime swap = startTime;
+      startTime = endTime;
+      endTime = swap;
+    }
+  }
+
+  public static AuditOperationQuery empty() {
+    return new AuditOperationQuery(
+        1, DEFAULT_PAGE_SIZE, null, null, null, null, null, null, null, null, null);
+  }
+
+  private static String normalize(String value) {
+    if (value == null) return null;
+    String normalized = value.trim();
+    return normalized.isEmpty() ? null : normalized;
+  }
+}

--- a/yak-ops-business/yak-ops-business-audit/src/main/java/io/yak/ops/business/audit/AuditOperationSummary.java
+++ b/yak-ops-business/yak-ops-business-audit/src/main/java/io/yak/ops/business/audit/AuditOperationSummary.java
@@ -1,0 +1,24 @@
+package io.yak.ops.business.audit;
+
+import java.time.LocalDateTime;
+
+/** One row in the Audit Center operation list. */
+public record AuditOperationSummary(
+    String operationId,
+    String operationType,
+    String operationName,
+    String actorId,
+    String actorName,
+    Long projectId,
+    String projectName,
+    String resourceType,
+    String resourceId,
+    String resourceName,
+    String status,
+    String source,
+    LocalDateTime startedAt,
+    LocalDateTime finishedAt,
+    Long durationMillis,
+    String rootTraceId,
+    String errorCode,
+    String summary) {}

--- a/yak-ops-business/yak-ops-business-audit/src/main/java/io/yak/ops/business/audit/AuditPage.java
+++ b/yak-ops-business/yak-ops-business-audit/src/main/java/io/yak/ops/business/audit/AuditPage.java
@@ -1,0 +1,12 @@
+package io.yak.ops.business.audit;
+
+import java.util.List;
+
+/** Persistence-framework-neutral page used by the audit read side. */
+public record AuditPage<T>(List<T> records, long total, int page, int size) {
+  public AuditPage {
+    records = records == null ? List.of() : List.copyOf(records);
+    page = page <= 0 ? 1 : page;
+    size = size <= 0 ? 20 : size;
+  }
+}

--- a/yak-ops-business/yak-ops-business-audit/src/main/java/io/yak/ops/business/audit/AuditQueryService.java
+++ b/yak-ops-business/yak-ops-business-audit/src/main/java/io/yak/ops/business/audit/AuditQueryService.java
@@ -1,0 +1,13 @@
+package io.yak.ops.business.audit;
+
+import java.util.Optional;
+
+/** Read-side contract consumed by the administrator Audit Center. */
+public interface AuditQueryService {
+
+  AuditPage<AuditOperationSummary> page(AuditOperationQuery query);
+
+  Optional<AuditOperationDetail> detail(String operationId);
+
+  AuditFilterOptions options();
+}

--- a/yak-ops-business/yak-ops-business-audit/src/main/java/io/yak/ops/business/audit/AuditTimelineEvent.java
+++ b/yak-ops-business/yak-ops-business-audit/src/main/java/io/yak/ops/business/audit/AuditTimelineEvent.java
@@ -1,0 +1,33 @@
+package io.yak.ops.business.audit;
+
+import java.time.LocalDateTime;
+import java.util.Collections;
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+/** One ordered event in an AuditOperation Timeline. */
+public record AuditTimelineEvent(
+    Long id,
+    String eventType,
+    String eventCategory,
+    String eventStatus,
+    LocalDateTime occurredAt,
+    String actorId,
+    String resourceType,
+    String resourceId,
+    String traceId,
+    String spanId,
+    Long parentEventId,
+    String reasonCode,
+    String message,
+    String title,
+    String description,
+    Map<String, Object> payload) {
+
+  public AuditTimelineEvent {
+    payload =
+        payload == null || payload.isEmpty()
+            ? Map.of()
+            : Collections.unmodifiableMap(new LinkedHashMap<>(payload));
+  }
+}

--- a/yak-ops-business/yak-ops-business-audit/src/main/java/io/yak/ops/business/audit/AuditTimelineRendererRegistry.java
+++ b/yak-ops-business/yak-ops-business-audit/src/main/java/io/yak/ops/business/audit/AuditTimelineRendererRegistry.java
@@ -1,0 +1,124 @@
+package io.yak.ops.business.audit;
+
+import java.util.LinkedHashMap;
+import java.util.Map;
+import java.util.function.Function;
+
+/**
+ * Maps stable event vocabulary to business-facing Timeline copy.
+ *
+ * <p>Keeping renderers in a registry prevents Audit Center UI from growing a giant event-type
+ * switch.
+ */
+public final class AuditTimelineRendererRegistry {
+
+  private static final Map<String, String> REASON_LABELS = reasonLabels();
+  private static final Map<String, String> PERMISSION_LABELS = permissionLabels();
+
+  private final Map<String, Function<RenderContext, AuditEventPresentation>> renderers;
+
+  public AuditTimelineRendererRegistry() {
+    Map<String, Function<RenderContext, AuditEventPresentation>> values = new LinkedHashMap<>();
+    values.put("AUTHORIZATION_DECISION", this::authorization);
+    values.put("OPERATION_STARTED", fixed("操作开始"));
+    values.put("RESOURCE_CREATED", fixed("资源已创建"));
+    values.put("RESOURCE_UPDATED", fixed("资源已更新"));
+    values.put("RESOURCE_DELETED", fixed("资源已删除"));
+    values.put("TASK_SUBMITTED", fixed("任务已提交"));
+    values.put("TASK_QUEUED", fixed("任务已进入队列"));
+    values.put("WORKER_STARTED", fixed("执行器开始处理"));
+    values.put("TASK_SUCCEEDED", fixed("任务执行成功"));
+    values.put("TASK_FAILED", fixed("任务执行失败"));
+    values.put("TASK_CANCELED", fixed("任务已取消"));
+    values.put("OPERATION_SUCCEEDED", fixed("操作完成"));
+    values.put("OPERATION_FAILED", fixed("操作失败"));
+    this.renderers = Map.copyOf(values);
+  }
+
+  public AuditEventPresentation render(
+      String eventType,
+      String eventStatus,
+      String reasonCode,
+      String message,
+      Map<String, Object> payload) {
+    RenderContext context =
+        new RenderContext(
+            eventType,
+            eventStatus,
+            reasonCode,
+            message,
+            payload == null ? Map.of() : payload);
+    Function<RenderContext, AuditEventPresentation> renderer = renderers.get(eventType);
+    if (renderer != null) return renderer.apply(context);
+    return new AuditEventPresentation(humanize(eventType), description(context));
+  }
+
+  private Function<RenderContext, AuditEventPresentation> fixed(String title) {
+    return context -> new AuditEventPresentation(title, description(context));
+  }
+
+  private AuditEventPresentation authorization(RenderContext context) {
+    String decision = stringValue(context.payload().get("decision"));
+    boolean denied =
+        "DENY".equalsIgnoreCase(decision)
+            || "FAILURE".equalsIgnoreCase(context.eventStatus());
+    String permission = permissionLabel(stringValue(context.payload().get("permission")));
+    String reason = reasonLabel(context.reasonCode());
+    String detail =
+        permission == null ? reason : permission + (reason == null ? "" : " · " + reason);
+    return new AuditEventPresentation(denied ? "权限检查拒绝" : "权限检查通过", detail);
+  }
+
+  private String description(RenderContext context) {
+    String reason = reasonLabel(context.reasonCode());
+    if (reason != null) return reason;
+    if (context.message() != null && !context.message().isBlank()) return context.message();
+    return null;
+  }
+
+  private String permissionLabel(String permission) {
+    if (permission == null || permission.isBlank()) return null;
+    return PERMISSION_LABELS.getOrDefault(permission, permission);
+  }
+
+  private String reasonLabel(String reasonCode) {
+    if (reasonCode == null || reasonCode.isBlank()) return null;
+    return REASON_LABELS.getOrDefault(reasonCode, reasonCode);
+  }
+
+  private String humanize(String value) {
+    if (value == null || value.isBlank()) return "审计事件";
+    return value.toLowerCase().replace('_', ' ');
+  }
+
+  private String stringValue(Object value) {
+    if (value == null) return null;
+    String text = String.valueOf(value).trim();
+    return text.isEmpty() ? null : text;
+  }
+
+  private static Map<String, String> permissionLabels() {
+    return Map.of("PROJECT_ACCESS", "项目空间访问");
+  }
+
+  private static Map<String, String> reasonLabels() {
+    Map<String, String> labels = new LinkedHashMap<>();
+    labels.put("PROJECT_REQUIRED", "需要选择项目空间");
+    labels.put("PROJECT_ID_INVALID", "项目空间标识无效");
+    labels.put("PROJECT_ACCESS_INPUT_INVALID", "项目访问上下文无效");
+    labels.put("PROJECT_NOT_FOUND", "项目空间不存在或不可访问");
+    labels.put("PROJECT_ACTOR_NOT_FOUND", "未找到有效的访问主体");
+    labels.put("PROJECT_MEMBERSHIP_REQUIRED", "当前用户不是项目成员");
+    labels.put("PROJECT_UNAVAILABLE", "项目空间当前不可用");
+    labels.put("PROJECT_OWNER_ACCESS_ALLOWED", "项目所有者权限通过");
+    labels.put("PROJECT_MEMBER_ACCESS_ALLOWED", "项目成员权限通过");
+    return Map.copyOf(labels);
+  }
+
+  private record RenderContext(
+      String eventType,
+      String eventStatus,
+      String reasonCode,
+      String message,
+      Map<String, Object> payload) {}
+}

--- a/yak-ops-business/yak-ops-business-audit/src/main/java/io/yak/ops/business/audit/JdbcAuditQueryService.java
+++ b/yak-ops-business/yak-ops-business-audit/src/main/java/io/yak/ops/business/audit/JdbcAuditQueryService.java
@@ -1,0 +1,291 @@
+package io.yak.ops.business.audit;
+
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.sql.Timestamp;
+import java.time.Duration;
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import javax.sql.DataSource;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.jdbc.core.namedparam.MapSqlParameterSource;
+import org.springframework.jdbc.core.namedparam.NamedParameterJdbcTemplate;
+
+/** JDBC read model for the global Audit Center. */
+final class JdbcAuditQueryService implements AuditQueryService {
+
+  private static final Logger log = LoggerFactory.getLogger(JdbcAuditQueryService.class);
+  private static final TypeReference<Map<String, Object>> MAP_TYPE = new TypeReference<>() {};
+
+  private static final String OPERATION_COLUMNS =
+      """
+      operation_id, operation_type, operation_name, actor_id, actor_name,
+      project_id, project_name, resource_type, resource_id, resource_name,
+      status, source, started_at, finished_at, root_trace_id, error_code, summary, metadata_json
+      """;
+
+  private final NamedParameterJdbcTemplate jdbcTemplate;
+  private final ObjectMapper objectMapper;
+  private final AuditTimelineRendererRegistry rendererRegistry;
+
+  JdbcAuditQueryService(
+      DataSource dataSource,
+      ObjectMapper objectMapper,
+      AuditTimelineRendererRegistry rendererRegistry) {
+    this.jdbcTemplate = new NamedParameterJdbcTemplate(dataSource);
+    this.objectMapper = objectMapper;
+    this.rendererRegistry = rendererRegistry;
+  }
+
+  @Override
+  public AuditPage<AuditOperationSummary> page(AuditOperationQuery suppliedQuery) {
+    AuditOperationQuery query =
+        suppliedQuery == null ? AuditOperationQuery.empty() : suppliedQuery;
+    QuerySpec spec = operationWhere(query);
+    Long totalValue =
+        jdbcTemplate.queryForObject(
+            "SELECT COUNT(*) FROM yak_audit_operation" + spec.where(),
+            spec.params(),
+            Long.class);
+    long total = totalValue == null ? 0L : totalValue;
+
+    spec.params().addValue("limit", query.size());
+    spec.params().addValue("offset", (long) (query.page() - 1) * query.size());
+    List<AuditOperationSummary> records =
+        jdbcTemplate.query(
+            "SELECT "
+                + OPERATION_COLUMNS
+                + " FROM yak_audit_operation"
+                + spec.where()
+                + " ORDER BY started_at DESC, id DESC LIMIT :limit OFFSET :offset",
+            spec.params(),
+            (resultSet, rowNum) -> operationSummary(resultSet));
+    return new AuditPage<>(records, total, query.page(), query.size());
+  }
+
+  @Override
+  public Optional<AuditOperationDetail> detail(String operationId) {
+    String normalizedId = normalize(operationId);
+    if (normalizedId == null) return Optional.empty();
+
+    MapSqlParameterSource params = new MapSqlParameterSource("operationId", normalizedId);
+    List<OperationRow> operations =
+        jdbcTemplate.query(
+            "SELECT "
+                + OPERATION_COLUMNS
+                + " FROM yak_audit_operation WHERE operation_id = :operationId LIMIT 1",
+            params,
+            (resultSet, rowNum) ->
+                new OperationRow(
+                    operationSummary(resultSet),
+                    jsonMap(resultSet.getString("metadata_json"))));
+    if (operations.isEmpty()) return Optional.empty();
+
+    List<AuditTimelineEvent> events =
+        jdbcTemplate.query(
+            """
+            SELECT id, event_type, event_category, event_status, occurred_at, actor_id,
+                   resource_type, resource_id, trace_id, span_id, parent_event_id,
+                   reason_code, message, payload_json
+              FROM yak_audit_event
+             WHERE operation_id = :operationId
+             ORDER BY occurred_at ASC, id ASC
+            """,
+            params,
+            (resultSet, rowNum) -> timelineEvent(resultSet));
+    OperationRow operation = operations.get(0);
+    return Optional.of(
+        new AuditOperationDetail(operation.summary(), operation.metadata(), events));
+  }
+
+  @Override
+  public AuditFilterOptions options() {
+    return new AuditFilterOptions(
+        optionQuery(
+            """
+            SELECT actor_id AS option_value,
+                   COALESCE(MAX(NULLIF(actor_name, '')), actor_id) AS option_label
+              FROM yak_audit_operation
+             WHERE actor_id IS NOT NULL AND actor_id <> ''
+             GROUP BY actor_id
+             ORDER BY option_label ASC
+             LIMIT 200
+            """),
+        optionQuery(
+            """
+            SELECT CAST(project_id AS CHAR) AS option_value,
+                   COALESCE(MAX(NULLIF(project_name, '')), CAST(project_id AS CHAR)) AS option_label
+              FROM yak_audit_operation
+             WHERE project_id IS NOT NULL
+             GROUP BY project_id
+             ORDER BY option_label ASC
+             LIMIT 200
+            """),
+        simpleDistinctOptions("operation_type"),
+        simpleDistinctOptions("resource_type"),
+        simpleDistinctOptions("status"),
+        simpleDistinctOptions("source"));
+  }
+
+  private QuerySpec operationWhere(AuditOperationQuery query) {
+    StringBuilder where = new StringBuilder(" WHERE 1 = 1");
+    MapSqlParameterSource params = new MapSqlParameterSource();
+    if (query.keyword() != null) {
+      where.append(
+          " AND (operation_id LIKE :keyword OR operation_name LIKE :keyword"
+              + " OR resource_name LIKE :keyword OR resource_id LIKE :keyword"
+              + " OR summary LIKE :keyword)");
+      params.addValue("keyword", "%" + query.keyword() + "%");
+    }
+    if (query.actor() != null) {
+      where.append(" AND (actor_id = :actor OR actor_name = :actor)");
+      params.addValue("actor", query.actor());
+    }
+    if (query.projectId() != null) {
+      where.append(" AND project_id = :projectId");
+      params.addValue("projectId", query.projectId());
+    }
+    addEquals(where, params, "operation_type", "operationType", query.operationType());
+    addEquals(where, params, "resource_type", "resourceType", query.resourceType());
+    addEquals(where, params, "status", "status", query.status());
+    addEquals(where, params, "source", "source", query.source());
+    if (query.startTime() != null) {
+      where.append(" AND started_at >= :startTime");
+      params.addValue("startTime", query.startTime());
+    }
+    if (query.endTime() != null) {
+      where.append(" AND started_at <= :endTime");
+      params.addValue("endTime", query.endTime());
+    }
+    return new QuerySpec(where.toString(), params);
+  }
+
+  private void addEquals(
+      StringBuilder where,
+      MapSqlParameterSource params,
+      String column,
+      String parameter,
+      String value) {
+    if (value == null) return;
+    where.append(" AND ").append(column).append(" = :").append(parameter);
+    params.addValue(parameter, value);
+  }
+
+  private AuditOperationSummary operationSummary(ResultSet resultSet) throws SQLException {
+    LocalDateTime startedAt = localDateTime(resultSet, "started_at");
+    LocalDateTime finishedAt = localDateTime(resultSet, "finished_at");
+    return new AuditOperationSummary(
+        resultSet.getString("operation_id"),
+        resultSet.getString("operation_type"),
+        resultSet.getString("operation_name"),
+        resultSet.getString("actor_id"),
+        resultSet.getString("actor_name"),
+        nullableLong(resultSet, "project_id"),
+        resultSet.getString("project_name"),
+        resultSet.getString("resource_type"),
+        resultSet.getString("resource_id"),
+        resultSet.getString("resource_name"),
+        resultSet.getString("status"),
+        resultSet.getString("source"),
+        startedAt,
+        finishedAt,
+        startedAt == null || finishedAt == null
+            ? null
+            : Duration.between(startedAt, finishedAt).toMillis(),
+        resultSet.getString("root_trace_id"),
+        resultSet.getString("error_code"),
+        resultSet.getString("summary"));
+  }
+
+  private AuditTimelineEvent timelineEvent(ResultSet resultSet) throws SQLException {
+    Map<String, Object> payload = jsonMap(resultSet.getString("payload_json"));
+    String eventType = resultSet.getString("event_type");
+    String eventStatus = resultSet.getString("event_status");
+    String reasonCode = resultSet.getString("reason_code");
+    String message = resultSet.getString("message");
+    AuditEventPresentation presentation =
+        rendererRegistry.render(eventType, eventStatus, reasonCode, message, payload);
+    return new AuditTimelineEvent(
+        resultSet.getLong("id"),
+        eventType,
+        resultSet.getString("event_category"),
+        eventStatus,
+        localDateTime(resultSet, "occurred_at"),
+        resultSet.getString("actor_id"),
+        resultSet.getString("resource_type"),
+        resultSet.getString("resource_id"),
+        resultSet.getString("trace_id"),
+        resultSet.getString("span_id"),
+        nullableLong(resultSet, "parent_event_id"),
+        reasonCode,
+        message,
+        presentation.title(),
+        presentation.description(),
+        payload);
+  }
+
+  private List<AuditFilterOption> simpleDistinctOptions(String column) {
+    String safeColumn =
+        switch (column) {
+          case "operation_type", "resource_type", "status", "source" -> column;
+          default ->
+              throw new IllegalArgumentException("Unsupported audit option column: " + column);
+        };
+    return optionQuery(
+        "SELECT DISTINCT "
+            + safeColumn
+            + " AS option_value, "
+            + safeColumn
+            + " AS option_label FROM yak_audit_operation WHERE "
+            + safeColumn
+            + " IS NOT NULL AND "
+            + safeColumn
+            + " <> '' ORDER BY option_label ASC");
+  }
+
+  private List<AuditFilterOption> optionQuery(String sql) {
+    return jdbcTemplate.query(
+        sql,
+        (resultSet, rowNum) ->
+            new AuditFilterOption(
+                resultSet.getString("option_value"),
+                resultSet.getString("option_label")));
+  }
+
+  private Map<String, Object> jsonMap(String value) {
+    if (value == null || value.isBlank()) return Map.of();
+    try {
+      Map<String, Object> parsed = objectMapper.readValue(value, MAP_TYPE);
+      return parsed == null ? Map.of() : parsed;
+    } catch (Exception exception) {
+      log.debug("Unable to parse persisted audit JSON", exception);
+      return Map.of();
+    }
+  }
+
+  private LocalDateTime localDateTime(ResultSet resultSet, String column) throws SQLException {
+    Timestamp value = resultSet.getTimestamp(column);
+    return value == null ? null : value.toLocalDateTime();
+  }
+
+  private Long nullableLong(ResultSet resultSet, String column) throws SQLException {
+    Number value = (Number) resultSet.getObject(column);
+    return value == null ? null : value.longValue();
+  }
+
+  private String normalize(String value) {
+    if (value == null) return null;
+    String normalized = value.trim();
+    return normalized.isEmpty() ? null : normalized;
+  }
+
+  private record QuerySpec(String where, MapSqlParameterSource params) {}
+
+  private record OperationRow(
+      AuditOperationSummary summary, Map<String, Object> metadata) {}
+}

--- a/yak-ops-business/yak-ops-business-audit/src/test/java/io/yak/ops/business/audit/AuditOperationQueryTest.java
+++ b/yak-ops-business/yak-ops-business-audit/src/test/java/io/yak/ops/business/audit/AuditOperationQueryTest.java
@@ -1,0 +1,38 @@
+package io.yak.ops.business.audit;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.time.LocalDateTime;
+import org.junit.jupiter.api.Test;
+
+class AuditOperationQueryTest {
+
+  @Test
+  void normalizesPagingWhitespaceAndReversedTimeRange() {
+    LocalDateTime later = LocalDateTime.of(2026, 9, 2, 12, 0);
+    LocalDateTime earlier = LocalDateTime.of(2026, 9, 1, 12, 0);
+
+    AuditOperationQuery query =
+        new AuditOperationQuery(
+            0,
+            1000,
+            "  offline  ",
+            "  alice  ",
+            -7L,
+            "  OFFLINE_SYNC_RUN  ",
+            "  OFFLINE_SYNC  ",
+            "  FAILED  ",
+            "  WEB  ",
+            later,
+            earlier);
+
+    assertThat(query.page()).isEqualTo(1);
+    assertThat(query.size()).isEqualTo(200);
+    assertThat(query.keyword()).isEqualTo("offline");
+    assertThat(query.actor()).isEqualTo("alice");
+    assertThat(query.projectId()).isNull();
+    assertThat(query.operationType()).isEqualTo("OFFLINE_SYNC_RUN");
+    assertThat(query.startTime()).isEqualTo(earlier);
+    assertThat(query.endTime()).isEqualTo(later);
+  }
+}

--- a/yak-ops-business/yak-ops-business-audit/src/test/java/io/yak/ops/business/audit/AuditReadModelSnapshotTest.java
+++ b/yak-ops-business/yak-ops-business-audit/src/test/java/io/yak/ops/business/audit/AuditReadModelSnapshotTest.java
@@ -1,0 +1,49 @@
+package io.yak.ops.business.audit;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import java.time.LocalDateTime;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import org.junit.jupiter.api.Test;
+
+class AuditReadModelSnapshotTest {
+
+  @Test
+  void nullableJsonValuesRemainReadableAndSnapshotsStayImmutable() {
+    Map<String, Object> payload = new LinkedHashMap<>();
+    payload.put("optional", null);
+    AuditTimelineEvent event =
+        new AuditTimelineEvent(
+            1L,
+            "TASK_SUBMITTED",
+            "BUSINESS",
+            "INFO",
+            LocalDateTime.now(),
+            "1",
+            "OFFLINE_SYNC",
+            "7",
+            null,
+            null,
+            99L,
+            null,
+            "submitted",
+            "任务已提交",
+            null,
+            payload);
+
+    Map<String, Object> metadata = new LinkedHashMap<>();
+    metadata.put("optional", null);
+    AuditOperationDetail detail = new AuditOperationDetail(null, metadata, List.of(event));
+
+    assertThat(event.parentEventId()).isEqualTo(99L);
+    assertThat(event.payload()).containsEntry("optional", null);
+    assertThat(detail.metadata()).containsEntry("optional", null);
+    assertThatThrownBy(() -> event.payload().put("new", "value"))
+        .isInstanceOf(UnsupportedOperationException.class);
+    assertThatThrownBy(() -> detail.metadata().put("new", "value"))
+        .isInstanceOf(UnsupportedOperationException.class);
+  }
+}

--- a/yak-ops-business/yak-ops-business-audit/src/test/java/io/yak/ops/business/audit/AuditTimelineRendererRegistryTest.java
+++ b/yak-ops-business/yak-ops-business-audit/src/test/java/io/yak/ops/business/audit/AuditTimelineRendererRegistryTest.java
@@ -1,0 +1,42 @@
+package io.yak.ops.business.audit;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.Map;
+import org.junit.jupiter.api.Test;
+
+class AuditTimelineRendererRegistryTest {
+
+  private final AuditTimelineRendererRegistry registry = new AuditTimelineRendererRegistry();
+
+  @Test
+  void authorizationDecisionUsesBusinessCopyAndStableReasonLabel() {
+    AuditEventPresentation presentation =
+        registry.render(
+            "AUTHORIZATION_DECISION",
+            "FAILURE",
+            "PROJECT_MEMBERSHIP_REQUIRED",
+            "Authorization denied",
+            Map.of("permission", "PROJECT_ACCESS", "decision", "DENY"));
+
+    assertThat(presentation.title()).isEqualTo("权限检查拒绝");
+    assertThat(presentation.description()).contains("项目空间访问").contains("当前用户不是项目成员");
+  }
+
+  @Test
+  void knownBusinessEventUsesRegistryWithoutLeakingTechnicalTypeAsTitle() {
+    AuditEventPresentation presentation =
+        registry.render("TASK_QUEUED", "INFO", null, "Queued", Map.of());
+
+    assertThat(presentation.title()).isEqualTo("任务已进入队列");
+    assertThat(presentation.description()).isEqualTo("Queued");
+  }
+
+  @Test
+  void unknownEventHasSafeFallback() {
+    AuditEventPresentation presentation =
+        registry.render("CUSTOM_EVENT", "INFO", null, null, Map.of());
+
+    assertThat(presentation.title()).isEqualTo("custom event");
+  }
+}

--- a/yak-ops-ui/src/pages/system/oplogs/components/AuditOperationDetailDrawer.tsx
+++ b/yak-ops-ui/src/pages/system/oplogs/components/AuditOperationDetailDrawer.tsx
@@ -1,0 +1,171 @@
+import { Drawer, Descriptions, Empty, Spin, Tag, Typography, message } from 'antd';
+import dayjs from 'dayjs';
+import { useEffect, useMemo, useState } from 'react';
+
+import YakTab from '@/components/YakTab';
+import {
+  getAuditOperation,
+  type AuditOperationDetail,
+  type AuditOperationSummary,
+} from '@/services/audit';
+
+import AuditTimeline from './AuditTimeline';
+
+interface AuditOperationDetailDrawerProps {
+  operationId?: string;
+  open: boolean;
+  onClose: () => void;
+}
+
+const statusMeta = (status?: string) => {
+  if (status === 'FAILED') return { label: '失败', color: 'error' as const };
+  if (status === 'SUCCEEDED') return { label: '成功', color: 'success' as const };
+  if (status === 'RUNNING') return { label: '运行中', color: 'processing' as const };
+  return { label: status || '-', color: 'default' as const };
+};
+
+const operationDisplayName = (operation: AuditOperationSummary) =>
+  operation.operationType === 'AUTHORIZATION_CHECK'
+    ? '权限检查'
+    : operation.operationName || operation.operationType;
+
+const formatDuration = (durationMillis?: number) => {
+  if (durationMillis == null) return '-';
+  if (durationMillis < 1000) return `${durationMillis} ms`;
+  if (durationMillis < 60_000) return `${(durationMillis / 1000).toFixed(1)} s`;
+  const minutes = Math.floor(durationMillis / 60_000);
+  const seconds = Math.floor((durationMillis % 60_000) / 1000);
+  return `${minutes}m ${seconds}s`;
+};
+
+const formatJson = (value: unknown) => {
+  try {
+    return JSON.stringify(value ?? {}, null, 2);
+  } catch {
+    return '{}';
+  }
+};
+
+export default function AuditOperationDetailDrawer({
+  operationId,
+  open,
+  onClose,
+}: AuditOperationDetailDrawerProps) {
+  const [detail, setDetail] = useState<AuditOperationDetail>();
+  const [loading, setLoading] = useState(false);
+
+  useEffect(() => {
+    if (!open || !operationId) return;
+
+    let active = true;
+    setLoading(true);
+    setDetail(undefined);
+    void getAuditOperation(operationId)
+      .then((data) => {
+        if (active) setDetail(data);
+      })
+      .catch(() => {
+        if (active) void message.error('加载审计详情失败');
+      })
+      .finally(() => {
+        if (active) setLoading(false);
+      });
+
+    return () => {
+      active = false;
+    };
+  }, [open, operationId]);
+
+  const tabs = useMemo(() => {
+    if (!detail) return [];
+    return [
+      {
+        key: 'timeline',
+        label: '业务时间线',
+        children: <AuditTimeline events={detail.events} />,
+      },
+      {
+        key: 'snapshot',
+        label: '原始快照',
+        children: (
+          <pre className="max-h-[56vh] overflow-auto whitespace-pre-wrap break-all rounded-lg bg-slate-50 p-4 text-xs leading-6 text-slate-600">
+            {formatJson({ operation: detail.operation, metadata: detail.metadata })}
+          </pre>
+        ),
+      },
+    ];
+  }, [detail]);
+
+  const operation = detail?.operation;
+  const status = statusMeta(operation?.status);
+
+  return (
+    <Drawer
+      title="审计详情"
+      width={840}
+      open={open}
+      onClose={onClose}
+      destroyOnClose
+    >
+      <Spin spinning={loading}>
+        {!loading && !detail ? (
+          <Empty image={Empty.PRESENTED_IMAGE_SIMPLE} description="暂无审计详情" />
+        ) : null}
+
+        {detail && operation ? (
+          <div>
+            <div className="mb-4 rounded-lg border border-slate-200 bg-white p-4">
+              <div className="mb-3 flex flex-wrap items-start justify-between gap-3">
+                <div>
+                  <div className="text-base font-semibold text-slate-800">
+                    {operationDisplayName(operation)}
+                  </div>
+                  <Typography.Text copyable type="secondary" className="text-xs">
+                    {operation.operationId}
+                  </Typography.Text>
+                </div>
+                <Tag bordered={false} color={status.color} className="m-0">
+                  {status.label}
+                </Tag>
+              </div>
+
+              <Descriptions size="small" column={2} colon={false}>
+                <Descriptions.Item label="操作人">
+                  {operation.actorName || operation.actorId || '-'}
+                </Descriptions.Item>
+                <Descriptions.Item label="项目空间">
+                  {operation.projectName || (operation.projectId ? `#${operation.projectId}` : '全局')}
+                </Descriptions.Item>
+                <Descriptions.Item label="资源">
+                  {operation.resourceName || operation.resourceId || '-'}
+                  {operation.resourceType ? ` · ${operation.resourceType}` : ''}
+                </Descriptions.Item>
+                <Descriptions.Item label="来源">{operation.source || '-'}</Descriptions.Item>
+                <Descriptions.Item label="开始时间">
+                  {operation.startedAt
+                    ? dayjs(operation.startedAt).format('YYYY-MM-DD HH:mm:ss.SSS')
+                    : '-'}
+                </Descriptions.Item>
+                <Descriptions.Item label="耗时">
+                  {formatDuration(operation.durationMillis)}
+                </Descriptions.Item>
+                {operation.errorCode ? (
+                  <Descriptions.Item label="错误码" span={2}>
+                    {operation.errorCode}
+                  </Descriptions.Item>
+                ) : null}
+                {operation.summary ? (
+                  <Descriptions.Item label="摘要" span={2}>
+                    {operation.summary}
+                  </Descriptions.Item>
+                ) : null}
+              </Descriptions>
+            </div>
+
+            <YakTab defaultActiveKey="timeline" items={tabs} />
+          </div>
+        ) : null}
+      </Spin>
+    </Drawer>
+  );
+}

--- a/yak-ops-ui/src/pages/system/oplogs/components/AuditTimeline.tsx
+++ b/yak-ops-ui/src/pages/system/oplogs/components/AuditTimeline.tsx
@@ -1,0 +1,140 @@
+import {
+  CheckCircleOutlined,
+  ClockCircleOutlined,
+  CloseCircleOutlined,
+} from '@ant-design/icons';
+import { Collapse, Descriptions, Empty, Tag, Timeline, Typography } from 'antd';
+import dayjs from 'dayjs';
+
+import type { AuditTimelineEvent } from '@/services/audit';
+
+interface AuditTimelineProps {
+  events: AuditTimelineEvent[];
+}
+
+const statusMeta = (status?: string) => {
+  if (status === 'FAILURE') {
+    return {
+      label: '失败',
+      color: 'error' as const,
+      icon: <CloseCircleOutlined className="text-red-500" />,
+    };
+  }
+  if (status === 'SUCCESS') {
+    return {
+      label: '成功',
+      color: 'success' as const,
+      icon: <CheckCircleOutlined className="text-emerald-600" />,
+    };
+  }
+  return {
+    label: '记录',
+    color: 'default' as const,
+    icon: <ClockCircleOutlined className="text-slate-400" />,
+  };
+};
+
+const formatJson = (value: unknown) => {
+  try {
+    return JSON.stringify(value ?? {}, null, 2);
+  } catch {
+    return '{}';
+  }
+};
+
+export default function AuditTimeline({ events }: AuditTimelineProps) {
+  if (!events.length) {
+    return <Empty image={Empty.PRESENTED_IMAGE_SIMPLE} description="暂无审计事件" />;
+  }
+
+  return (
+    <Timeline
+      className="pt-2"
+      items={events.map((event) => {
+        const status = statusMeta(event.eventStatus);
+        const technical = {
+          eventType: event.eventType,
+          eventCategory: event.eventCategory,
+          eventStatus: event.eventStatus,
+          actorId: event.actorId,
+          resourceType: event.resourceType,
+          resourceId: event.resourceId,
+          traceId: event.traceId,
+          spanId: event.spanId,
+          parentEventId: event.parentEventId,
+          reasonCode: event.reasonCode,
+          rawMessage: event.message,
+          payload: event.payload,
+        };
+
+        return {
+          dot: status.icon,
+          children: (
+            <div className="pb-3">
+              <div className="rounded-lg border border-slate-200 bg-white px-4 py-3">
+                <div className="flex flex-wrap items-center justify-between gap-2">
+                  <div className="flex min-w-0 items-center gap-2">
+                    <span className="font-medium text-slate-800">{event.title}</span>
+                    <Tag bordered={false} color={status.color} className="m-0">
+                      {status.label}
+                    </Tag>
+                    {event.eventCategory === 'AUTHORIZATION' ? (
+                      <Tag bordered={false} className="m-0">
+                        授权
+                      </Tag>
+                    ) : null}
+                  </div>
+                  <Typography.Text type="secondary" className="text-xs">
+                    {dayjs(event.occurredAt).format('YYYY-MM-DD HH:mm:ss.SSS')}
+                  </Typography.Text>
+                </div>
+
+                {event.description ? (
+                  <div className="mt-2 text-sm leading-6 text-slate-600">
+                    {event.description}
+                  </div>
+                ) : null}
+
+                <Collapse
+                  ghost
+                  size="small"
+                  className="mt-1 [&_.ant-collapse-header]:px-0"
+                  items={[
+                    {
+                      key: 'technical',
+                      label: <span className="text-xs text-slate-500">技术详情</span>,
+                      children: (
+                        <div className="rounded-md bg-slate-50 p-3">
+                          <Descriptions size="small" column={1} colon={false}>
+                            <Descriptions.Item label="Event Type">
+                              {event.eventType}
+                            </Descriptions.Item>
+                            <Descriptions.Item label="Trace / Span">
+                              {event.traceId || '-'} / {event.spanId || '-'}
+                            </Descriptions.Item>
+                            <Descriptions.Item label="Parent Event">
+                              {event.parentEventId ?? '-'}
+                            </Descriptions.Item>
+                            <Descriptions.Item label="Resource">
+                              {event.resourceType || '-'} / {event.resourceId || '-'}
+                            </Descriptions.Item>
+                            <Descriptions.Item label="Reason Code">
+                              {event.reasonCode || '-'}
+                            </Descriptions.Item>
+                          </Descriptions>
+                          <pre className="mb-0 mt-2 max-h-64 overflow-auto whitespace-pre-wrap break-all rounded bg-white p-3 text-xs text-slate-600">
+                            {formatJson(technical)}
+                          </pre>
+                        </div>
+                      ),
+                    },
+                  ]}
+                />
+              </div>
+            </div>
+          ),
+        };
+      })}
+    />
+  );
+}

--- a/yak-ops-ui/src/pages/system/oplogs/components/BusinessAuditPanel.tsx
+++ b/yak-ops-ui/src/pages/system/oplogs/components/BusinessAuditPanel.tsx
@@ -1,0 +1,400 @@
+import { ReloadOutlined, SearchOutlined } from '@ant-design/icons';
+import { history } from '@umijs/max';
+import {
+  Button,
+  DatePicker,
+  Input,
+  Select,
+  Space,
+  Tag,
+  Typography,
+  message,
+  type TableProps,
+} from 'antd';
+import dayjs, { type Dayjs } from 'dayjs';
+import { useCallback, useEffect, useMemo, useState } from 'react';
+
+import {
+  SecurityPagination,
+  SecurityQueryTable,
+} from '@/components/security';
+import {
+  getAuditFilterOptions,
+  queryAuditOperations,
+  type AuditFilterOption,
+  type AuditFilterOptions,
+  type AuditOperationQuery,
+  type AuditOperationSummary,
+} from '@/services/audit';
+
+import AuditOperationDetailDrawer from './AuditOperationDetailDrawer';
+
+interface FilterState {
+  keyword?: string;
+  actor?: string;
+  projectId?: string;
+  operationType?: string;
+  resourceType?: string;
+  status?: string;
+  source?: string;
+  timeRange?: [Dayjs, Dayjs];
+}
+
+const EMPTY_OPTIONS: AuditFilterOptions = {
+  actors: [],
+  projects: [],
+  operationTypes: [],
+  resourceTypes: [],
+  statuses: [],
+  sources: [],
+};
+
+const statusMeta = (status?: string) => {
+  if (status === 'FAILED') return { label: '失败', color: 'error' as const };
+  if (status === 'SUCCEEDED') return { label: '成功', color: 'success' as const };
+  if (status === 'RUNNING') return { label: '运行中', color: 'processing' as const };
+  return { label: status || '-', color: 'default' as const };
+};
+
+const formatDuration = (durationMillis?: number) => {
+  if (durationMillis == null) return '-';
+  if (durationMillis < 1000) return `${durationMillis} ms`;
+  if (durationMillis < 60_000) return `${(durationMillis / 1000).toFixed(1)} s`;
+  const minutes = Math.floor(durationMillis / 60_000);
+  const seconds = Math.floor((durationMillis % 60_000) / 1000);
+  return `${minutes}m ${seconds}s`;
+};
+
+const selectOptions = (
+  options: AuditFilterOption[],
+  labeler?: (option: AuditFilterOption) => string,
+) =>
+  options.map((option) => ({
+    value: option.value,
+    label: labeler ? labeler(option) : option.label,
+  }));
+
+const buildQuery = (
+  filters: FilterState,
+  page: number,
+  size: number,
+): AuditOperationQuery => ({
+  page,
+  size,
+  keyword: filters.keyword?.trim() || undefined,
+  actor: filters.actor,
+  projectId: filters.projectId ? Number(filters.projectId) : undefined,
+  operationType: filters.operationType,
+  resourceType: filters.resourceType,
+  status: filters.status,
+  source: filters.source,
+  startTime: filters.timeRange?.[0]
+    .startOf('day')
+    .format('YYYY-MM-DDTHH:mm:ss'),
+  endTime: filters.timeRange?.[1]
+    .endOf('day')
+    .format('YYYY-MM-DDTHH:mm:ss'),
+});
+
+export default function BusinessAuditPanel() {
+  const [rows, setRows] = useState<AuditOperationSummary[]>([]);
+  const [options, setOptions] = useState<AuditFilterOptions>(EMPTY_OPTIONS);
+  const [filters, setFilters] = useState<FilterState>({});
+  const [loading, setLoading] = useState(false);
+  const [selectedOperationId, setSelectedOperationId] = useState<string>();
+  const [pagination, setPagination] = useState({ current: 1, pageSize: 20, total: 0 });
+
+  const loadOptions = useCallback(async () => {
+    try {
+      setOptions(await getAuditFilterOptions());
+    } catch {
+      void message.error('加载审计筛选项失败');
+    }
+  }, []);
+
+  const loadPage = useCallback(
+    async (
+      page: number,
+      pageSize: number,
+      nextFilters: FilterState,
+    ) => {
+      setLoading(true);
+      try {
+        const data = await queryAuditOperations(buildQuery(nextFilters, page, pageSize));
+        setRows(data.bizData ?? []);
+        setPagination({
+          current: Number(data.pagination?.pageNo ?? page),
+          pageSize: Number(data.pagination?.pageSize ?? pageSize),
+          total: Number(data.pagination?.total ?? 0),
+        });
+      } catch {
+        void message.error('加载业务审计记录失败');
+      } finally {
+        setLoading(false);
+      }
+    },
+    [],
+  );
+
+  useEffect(() => {
+    void loadOptions();
+    void loadPage(1, 20, {});
+
+    const deepLinkOperationId = new URLSearchParams(history.location.search)
+      .get('operationId')
+      ?.trim();
+    if (deepLinkOperationId) {
+      setSelectedOperationId(deepLinkOperationId);
+    }
+  }, [loadOptions, loadPage]);
+
+  const columns: TableProps<AuditOperationSummary>['columns'] = useMemo(
+    () => [
+      {
+        title: '时间',
+        dataIndex: 'startedAt',
+        width: 170,
+        render: (value: string) => dayjs(value).format('YYYY-MM-DD HH:mm:ss'),
+      },
+      {
+        title: '操作',
+        key: 'operation',
+        width: 250,
+        render: (_, record) => (
+          <div className="min-w-0">
+            <div className="truncate font-medium text-slate-800">
+              {record.operationName || record.operationType}
+            </div>
+            <Typography.Text type="secondary" className="text-xs">
+              {record.operationType}
+            </Typography.Text>
+          </div>
+        ),
+      },
+      {
+        title: '操作人',
+        key: 'actor',
+        width: 150,
+        render: (_, record) => (
+          <div>
+            <div>{record.actorName || record.actorId || '-'}</div>
+            {record.actorName && record.actorId ? (
+              <div className="text-xs text-slate-400">{record.actorId}</div>
+            ) : null}
+          </div>
+        ),
+      },
+      {
+        title: '项目空间',
+        key: 'project',
+        width: 160,
+        render: (_, record) =>
+          record.projectName || (record.projectId ? `#${record.projectId}` : '全局'),
+      },
+      {
+        title: '资源',
+        key: 'resource',
+        width: 220,
+        render: (_, record) => (
+          <div className="min-w-0">
+            <div className="truncate">
+              {record.resourceName || record.resourceId || '-'}
+            </div>
+            {record.resourceType ? (
+              <div className="text-xs text-slate-400">{record.resourceType}</div>
+            ) : null}
+          </div>
+        ),
+      },
+      {
+        title: '状态',
+        dataIndex: 'status',
+        width: 100,
+        render: (value: string) => {
+          const meta = statusMeta(value);
+          return (
+            <Tag bordered={false} color={meta.color} className="m-0">
+              {meta.label}
+            </Tag>
+          );
+        },
+      },
+      {
+        title: '来源',
+        dataIndex: 'source',
+        width: 100,
+      },
+      {
+        title: '耗时',
+        dataIndex: 'durationMillis',
+        width: 100,
+        render: (value?: number) => formatDuration(value),
+      },
+      {
+        title: '操作',
+        key: 'action',
+        fixed: 'right',
+        width: 80,
+        render: (_, record) => (
+          <Button
+            type="link"
+            size="small"
+            onClick={() => setSelectedOperationId(record.operationId)}
+          >
+            查看
+          </Button>
+        ),
+      },
+    ],
+    [],
+  );
+
+  const search = () => {
+    void loadPage(1, pagination.pageSize, filters);
+  };
+
+  const reset = () => {
+    const empty: FilterState = {};
+    setFilters(empty);
+    void loadPage(1, pagination.pageSize, empty);
+  };
+
+  const refresh = () => {
+    void loadOptions();
+    void loadPage(pagination.current, pagination.pageSize, filters);
+  };
+
+  return (
+    <div className="flex min-h-0 flex-1 flex-col">
+      <div className="mb-3 rounded-lg border border-slate-200 bg-white p-3">
+        <div className="flex flex-wrap items-center gap-2">
+          <Input
+            allowClear
+            value={filters.keyword}
+            onChange={(event) =>
+              setFilters((current) => ({ ...current, keyword: event.target.value }))
+            }
+            onPressEnter={search}
+            placeholder="操作名 / Operation ID / 资源 / 摘要"
+            className="w-[260px]"
+          />
+          <DatePicker.RangePicker
+            value={filters.timeRange}
+            onChange={(value) =>
+              setFilters((current) => ({
+                ...current,
+                timeRange:
+                  value?.[0] && value?.[1] ? [value[0], value[1]] : undefined,
+              }))
+            }
+            className="w-[260px]"
+          />
+          <Select
+            allowClear
+            showSearch
+            optionFilterProp="label"
+            value={filters.projectId}
+            options={selectOptions(options.projects)}
+            onChange={(value) =>
+              setFilters((current) => ({ ...current, projectId: value }))
+            }
+            placeholder="项目空间"
+            className="w-[150px]"
+          />
+          <Select
+            allowClear
+            showSearch
+            optionFilterProp="label"
+            value={filters.actor}
+            options={selectOptions(options.actors)}
+            onChange={(value) =>
+              setFilters((current) => ({ ...current, actor: value }))
+            }
+            placeholder="操作人"
+            className="w-[140px]"
+          />
+          <Select
+            allowClear
+            showSearch
+            optionFilterProp="label"
+            value={filters.operationType}
+            options={selectOptions(options.operationTypes)}
+            onChange={(value) =>
+              setFilters((current) => ({ ...current, operationType: value }))
+            }
+            placeholder="操作类型"
+            className="w-[170px]"
+          />
+          <Select
+            allowClear
+            showSearch
+            optionFilterProp="label"
+            value={filters.resourceType}
+            options={selectOptions(options.resourceTypes)}
+            onChange={(value) =>
+              setFilters((current) => ({ ...current, resourceType: value }))
+            }
+            placeholder="资源类型"
+            className="w-[150px]"
+          />
+          <Select
+            allowClear
+            value={filters.status}
+            options={selectOptions(options.statuses, (option) => statusMeta(option.value).label)}
+            onChange={(value) =>
+              setFilters((current) => ({ ...current, status: value }))
+            }
+            placeholder="状态"
+            className="w-[110px]"
+          />
+          <Select
+            allowClear
+            value={filters.source}
+            options={selectOptions(options.sources)}
+            onChange={(value) =>
+              setFilters((current) => ({ ...current, source: value }))
+            }
+            placeholder="来源"
+            className="w-[110px]"
+          />
+          <Space size={6}>
+            <Button type="primary" icon={<SearchOutlined />} onClick={search}>
+              查询
+            </Button>
+            <Button onClick={reset}>重置</Button>
+            <Button icon={<ReloadOutlined />} onClick={refresh} loading={loading}>
+              刷新
+            </Button>
+          </Space>
+        </div>
+      </div>
+
+      <div className="min-h-0 flex-1 overflow-hidden rounded-lg border border-slate-200 bg-white">
+        <SecurityQueryTable<AuditOperationSummary>
+          rowKey="operationId"
+          columns={columns}
+          dataSource={rows}
+          loading={loading}
+          pagination={false}
+          scroll={{ x: 'max-content' }}
+        />
+      </div>
+
+      <SecurityPagination
+        current={pagination.current}
+        pageSize={pagination.pageSize}
+        total={pagination.total}
+        disabled={loading}
+        onChange={(page, pageSize) => {
+          void loadPage(page, pageSize, filters);
+        }}
+      />
+
+      <AuditOperationDetailDrawer
+        operationId={selectedOperationId}
+        open={Boolean(selectedOperationId)}
+        onClose={() => setSelectedOperationId(undefined)}
+      />
+    </div>
+  );
+}

--- a/yak-ops-ui/src/pages/system/oplogs/components/SecurityOperationLogsPanel.tsx
+++ b/yak-ops-ui/src/pages/system/oplogs/components/SecurityOperationLogsPanel.tsx
@@ -1,0 +1,80 @@
+import { history } from '@umijs/max';
+import { useCallback, useEffect, useRef } from 'react';
+
+import {
+  SecurityPagination,
+  SecurityQueryTable,
+} from '@/components/security';
+import type { OperationLog } from '@/services/security/operationLogs';
+
+import OperationLogDetailDrawer, {
+  type OperationLogDetailDrawerRef,
+} from './OperationLogDetailDrawer';
+import OperationLogFilterBar from './OperationLogFilterBar';
+import { useOperationLogColumns } from '../hooks/useOperationLogColumns';
+import { useOperationLogs } from '../hooks/useOperationLogs';
+
+/** Existing Yak Security HTTP/page operation log preserved as a secondary Audit Center view. */
+export default function SecurityOperationLogsPanel() {
+  const detailRef = useRef<OperationLogDetailDrawerRef>(null);
+  const {
+    logs,
+    options,
+    isLoading,
+    pagination,
+    refreshLogs,
+    searchLogs,
+    changePage,
+  } = useOperationLogs();
+
+  useEffect(() => {
+    const value = new URLSearchParams(history.location.search).get('messageLogId');
+    if (!value) return;
+
+    const logId = Number(value);
+    if (Number.isSafeInteger(logId) && logId > 0) {
+      void detailRef.current?.open(logId);
+    }
+  }, []);
+
+  const showDetail = useCallback((log: OperationLog) => {
+    void detailRef.current?.open(log.id);
+  }, []);
+
+  const columns = useOperationLogColumns({ onDetail: showDetail });
+
+  return (
+    <div className="flex min-h-0 flex-1 flex-col">
+      <div className="shrink-0">
+        <OperationLogFilterBar
+          options={options}
+          loading={isLoading}
+          onSearch={searchLogs}
+          onRefresh={refreshLogs}
+        />
+
+        <SecurityQueryTable<OperationLog>
+          rowKey="id"
+          columns={columns}
+          dataSource={logs}
+          loading={isLoading}
+          pagination={false}
+          bordered
+          scroll={{ x: 'max-content' }}
+        />
+      </div>
+
+      <div className="min-h-6 flex-1" />
+
+      <SecurityPagination
+        current={pagination.current}
+        pageSize={pagination.pageSize}
+        total={pagination.total}
+        disabled={isLoading}
+        onChange={changePage}
+      />
+
+      <OperationLogDetailDrawer ref={detailRef} />
+    </div>
+  );
+}

--- a/yak-ops-ui/src/pages/system/oplogs/index.tsx
+++ b/yak-ops-ui/src/pages/system/oplogs/index.tsx
@@ -1,94 +1,49 @@
-import { FileSearchOutlined } from '@ant-design/icons';
+import { SafetyCertificateOutlined } from '@ant-design/icons';
 import { history } from '@umijs/max';
-import {
-  useCallback,
-  useEffect,
-  useRef,
-} from 'react';
+import { useMemo, useState } from 'react';
 
-import {
-  SecurityPagination,
-  SecurityQueryTable,
-} from '@/components/security';
-import type { OperationLog } from '@/services/security/operationLogs';
+import YakTab from '@/components/YakTab';
 
 import SystemManagementPage from '../components/SystemManagementPage';
-import OperationLogDetailDrawer, {
-  type OperationLogDetailDrawerRef,
-} from './components/OperationLogDetailDrawer';
-import OperationLogFilterBar from './components/OperationLogFilterBar';
-import { useOperationLogColumns } from './hooks/useOperationLogColumns';
-import { useOperationLogs } from './hooks/useOperationLogs';
+import BusinessAuditPanel from './components/BusinessAuditPanel';
+import SecurityOperationLogsPanel from './components/SecurityOperationLogsPanel';
 
-export default function OperationLogsPage() {
-  const detailRef = useRef<OperationLogDetailDrawerRef>(null);
-  const {
-    logs,
-    options,
-    isLoading,
-    pagination,
-    refreshLogs,
-    searchLogs,
-    changePage,
-  } = useOperationLogs();
-
-  useEffect(() => {
-    const value = new URLSearchParams(
-      history.location.search,
-    ).get('messageLogId');
-    if (!value) return;
-
-    const logId = Number(value);
-    if (Number.isSafeInteger(logId) && logId > 0) {
-      void detailRef.current?.open(logId);
-    }
-  }, []);
-
-  const showDetail = useCallback((log: OperationLog) => {
-    void detailRef.current?.open(log.id);
-  }, []);
-
-  const columns = useOperationLogColumns({
-    onDetail: showDetail,
-  });
+export default function AuditCenterPage() {
+  const initialTab = useMemo(
+    () =>
+      new URLSearchParams(history.location.search).has('messageLogId')
+        ? 'security'
+        : 'business',
+    [],
+  );
+  const [activeTab, setActiveTab] = useState(initialTab);
 
   return (
     <SystemManagementPage
-      title="操作日志"
+      title="审计中心"
       titleId="system-operation-logs-title"
-      icon={<FileSearchOutlined className="text-slate-500" />}
+      icon={<SafetyCertificateOutlined className="text-slate-500" />}
       className="min-h-[calc(100vh-64px)] overflow-hidden"
     >
-      <div className="shrink-0">
-        <OperationLogFilterBar
-          options={options}
-          loading={isLoading}
-          onSearch={searchLogs}
-          onRefresh={refreshLogs}
-        />
-
-        <SecurityQueryTable<OperationLog>
-          rowKey="id"
-          columns={columns}
-          dataSource={logs}
-          loading={isLoading}
-          pagination={false}
-          bordered
-          scroll={{ x: 'max-content' }}
+      <div className="flex min-h-0 flex-1 flex-col rounded-lg border border-slate-200 bg-white px-4 pt-1">
+        <YakTab
+          activeKey={activeTab}
+          onChange={setActiveTab}
+          className="flex min-h-0 flex-1 flex-col [&_.ant-tabs-content]:h-full [&_.ant-tabs-content-holder]:min-h-0 [&_.ant-tabs-content-holder]:flex-1 [&_.ant-tabs-tabpane]:h-full"
+          items={[
+            {
+              key: 'business',
+              label: '业务审计',
+              children: <BusinessAuditPanel />,
+            },
+            {
+              key: 'security',
+              label: 'Security 操作日志',
+              children: <SecurityOperationLogsPanel />,
+            },
+          ]}
         />
       </div>
-
-      <div className="min-h-6 flex-1" />
-
-      <SecurityPagination
-        current={pagination.current}
-        pageSize={pagination.pageSize}
-        total={pagination.total}
-        disabled={isLoading}
-        onChange={changePage}
-      />
-
-      <OperationLogDetailDrawer ref={detailRef} />
     </SystemManagementPage>
   );
 }

--- a/yak-ops-ui/src/services/audit.ts
+++ b/yak-ops-ui/src/services/audit.ts
@@ -1,0 +1,111 @@
+import type { ApiResponse } from '@/services/http/response';
+import request from '@/utils/request';
+
+const AUDIT_API = '/api/v1/audit';
+
+export interface AuditFilterOption {
+  value: string;
+  label: string;
+}
+
+export interface AuditFilterOptions {
+  actors: AuditFilterOption[];
+  projects: AuditFilterOption[];
+  operationTypes: AuditFilterOption[];
+  resourceTypes: AuditFilterOption[];
+  statuses: AuditFilterOption[];
+  sources: AuditFilterOption[];
+}
+
+export interface AuditOperationQuery {
+  page?: number;
+  size?: number;
+  keyword?: string;
+  actor?: string;
+  projectId?: number;
+  operationType?: string;
+  resourceType?: string;
+  status?: string;
+  source?: string;
+  startTime?: string;
+  endTime?: string;
+}
+
+export interface AuditOperationSummary {
+  operationId: string;
+  operationType: string;
+  operationName: string;
+  actorId?: string;
+  actorName?: string;
+  projectId?: number;
+  projectName?: string;
+  resourceType?: string;
+  resourceId?: string;
+  resourceName?: string;
+  status: string;
+  source: string;
+  startedAt: string;
+  finishedAt?: string;
+  durationMillis?: number;
+  rootTraceId?: string;
+  errorCode?: string;
+  summary?: string;
+}
+
+export interface AuditTimelineEvent {
+  id: number;
+  eventType: string;
+  eventCategory: string;
+  eventStatus: string;
+  occurredAt: string;
+  actorId?: string;
+  resourceType?: string;
+  resourceId?: string;
+  traceId?: string;
+  spanId?: string;
+  parentEventId?: number;
+  reasonCode?: string;
+  message?: string;
+  title: string;
+  description?: string;
+  payload: Record<string, unknown>;
+}
+
+export interface AuditOperationDetail {
+  operation: AuditOperationSummary;
+  metadata: Record<string, unknown>;
+  events: AuditTimelineEvent[];
+}
+
+export interface AuditPagingData<T> {
+  bizData: T[];
+  pagination: {
+    total: number;
+    pages: number;
+    pageNo: number;
+    pageSize: number;
+  };
+}
+
+const getData = async <T>(path: string): Promise<T> =>
+  (await request<ApiResponse<T>>(path, { method: 'GET', protocol: 'yak-ops' })).data;
+
+const postData = async <T>(path: string, data: unknown): Promise<T> =>
+  (
+    await request<ApiResponse<T>>(path, {
+      method: 'POST',
+      data,
+      protocol: 'yak-ops',
+    })
+  ).data;
+
+export const queryAuditOperations = (query: AuditOperationQuery) =>
+  postData<AuditPagingData<AuditOperationSummary>>(`${AUDIT_API}/operations/page`, query);
+
+export const getAuditOperation = (operationId: string) =>
+  getData<AuditOperationDetail>(
+    `${AUDIT_API}/operations/${encodeURIComponent(operationId)}`,
+  );
+
+export const getAuditFilterOptions = () =>
+  getData<AuditFilterOptions>(`${AUDIT_API}/options`);


### PR DESCRIPTION
## Summary

Implements **PR 3** for #921: turn the existing System Operation Logs entry into a reusable administrator-facing **Audit Center** backed by the end-to-end `AuditOperation / AuditEvent` model introduced in PR 1, PR 2.1 and PR 2.2.

This PR is intentionally a **read/query + presentation layer**. It does not expand audit producer coverage to additional business modules.

## 1. Keep one operation as one row

The Audit Center list reads `yak_audit_operation`, not a flattened event stream.

Each row answers the high-level questions first:

- when did it happen;
- what operation was executed;
- who executed it;
- in which Project Space;
- which business resource was affected;
- current historical result (`RUNNING / SUCCEEDED / FAILED`);
- source and duration.

Retry / worker / authorization / lifecycle events remain inside the operation detail Timeline instead of turning one business operation into many table rows.

## 2. Global Audit Center filters

Adds read-side filters for:

```text
time range
keyword (operation id / operation name / resource / summary)
actor
project
operation type
resource type
status
source
```

Filter option labels come from the **persisted operation snapshots**. The Audit Center does not look up today's user/project state to reinterpret historical records.

Actor/project options use stable IDs as values and are deduplicated by those IDs, so historical renames do not produce duplicate Select values.

## 3. Operation detail + business Timeline

Selecting one operation opens a detail drawer with:

- operation snapshot: actor, Project, resource, status, source, start time, duration, summary/error;
- default `业务时间线` tab;
- secondary `原始快照` tab.

Timeline events are ordered by:

```text
occurred_at ASC, id ASC
```

and retain technical correlation fields such as:

```text
traceId
spanId
parentEventId
reasonCode
resourceType/resourceId
payload
```

Those fields are kept under a collapsible **技术详情** section instead of dominating the primary audit view.

## 4. Renderer Registry instead of a giant frontend switch

Adds `AuditTimelineRendererRegistry` on the read side.

Stable event vocabulary is translated into business-facing copy, for example:

```text
AUTHORIZATION_DECISION -> 权限检查通过 / 权限检查拒绝
TASK_SUBMITTED         -> 任务已提交
TASK_QUEUED            -> 任务已进入队列
WORKER_STARTED         -> 执行器开始处理
OPERATION_SUCCEEDED    -> 操作完成
OPERATION_FAILED       -> 操作失败
```

Project authorization reason codes are also rendered as business copy, while the original stable reason code remains available in technical details.

Unknown future event types have a safe fallback, so adding a producer event does not require changing the Audit Center component structure first.

## 5. Authorization decisions are shown without audit noise

PR 2.2 semantics are preserved:

- successful Project authorization is shown as the first event of the corresponding business AuditOperation;
- authorization DENY remains visible as its standalone failed `AUTHORIZATION_CHECK` operation;
- read-only successful Project checks that never create an AuditOperation are not turned into heartbeat-style rows.

Example Timeline:

```text
权限检查通过
  项目空间访问 · 项目成员权限通过
        ↓
操作开始
        ↓
任务已提交
        ↓
任务已进入队列
        ↓
执行器开始处理
        ↓
操作完成 / 操作失败
```

## 6. Reuse existing System Operation Log RBAC

The new read API is protected with the existing stable permission:

```text
security:operation-log:read
```

via:

```java
@RequiresPermission(SecurityPermissionCode.OperationLog.READ)
```

No second audit permission/menu contract is introduced in this PR.

The query controller uses the same `yak.database.enabled` condition as `AuditConfiguration`. When the business database is explicitly disabled, the Audit query API is not registered, preserving the existing database-disabled startup mode without relying on Spring bean-definition processing order.

## 7. Preserve the existing Yak Security operation logs

The existing `/system/oplogs` capability is not deleted.

The page becomes an Audit Center with `YakTab`:

```text
业务审计              (default)
Security 操作日志      (existing HTTP/page logs)
```

The old filters/table/detail drawer are extracted into the second tab without changing their data source.

Existing deep link compatibility is preserved:

```text
/system/oplogs?messageLogId=123
```

automatically opens the Security log tab/detail as before.

PR 3 also adds a stable business-audit deep link:

```text
/system/oplogs?operationId=AUD-...
```

which opens the corresponding AuditOperation drawer for future Notification / Alert integrations.

## 8. Read APIs

Adds three read-only APIs:

```text
POST /api/v1/audit/operations/page
GET  /api/v1/audit/operations/{operationId}
GET  /api/v1/audit/options
```

The page endpoint continues to use Yak Ops' existing `Result<PagingData<T>>` HTTP contract.

The Audit module itself stays free of Web dependencies: query contracts/JDBC read model live in `yak-ops-business-audit`; the HTTP controller lives in `yak-ops-boot`.

## 9. Historical JSON robustness

Persisted `metadata_json / payload_json` are treated as historical snapshots:

- malformed historical JSON degrades to an empty map instead of breaking the whole Timeline;
- nullable JSON values are preserved;
- returned snapshot maps/lists are immutable;
- raw payloads stay secondary to business-facing Timeline copy.

## Schema

**No Flyway migration is introduced.**

PR 3 reuses the Audit V1 columns already reserved for the read side, including operation snapshots, event category/status/reason, trace/span and `parent_event_id`.

## Tests / validation

Added contract/unit coverage for:

- query paging normalization and max page size;
- invalid Project filter normalization;
- reversed time-range normalization;
- authorization renderer + stable business reason labels;
- known/unknown Timeline renderer behavior;
- nullable immutable historical JSON snapshots;
- parent-event read-model shape;
- Audit query API route/RBAC contract;
- database-disabled controller property contract.

Additional validation performed on the final implementation:

- final branch is directly based on current `main` (`behind_by=0`);
- final branch is squashed to one commit;
- no Flyway files are changed;
- final Java 21 Audit read model + JDBC query service compile successfully in a syntax/generic validation harness using minimal Spring/Jackson interfaces;
- final Audit query controller compiles with the `yak.database.enabled` conditional contract in the same validation harness;
- existing `SecurityPagination` contract was checked and the new panel uses its `(current, pageSize)` callback correctly.

A full Maven reactor build and full frontend dependency-backed TypeScript build are **not claimed** from this execution environment. Run the normal local/CI build before marking this Draft ready.

Recommended verification:

```bash
mvn -pl yak-ops-business/yak-ops-business-audit,yak-ops-boot -am test
cd yak-ops-ui && npm run typecheck
```

Suggested smoke flow:

1. Execute an Offline Sync operation as a Project owner/member.
2. Open `/system/oplogs` and confirm one business row is created for the operation.
3. Open the row and verify authorization appears before `OPERATION_STARTED` in the Timeline.
4. Verify submitted/queued/worker/final events stay under the same `operationId`.
5. Execute a Project-scoped request as a non-member and verify a failed `权限检查` operation appears with the business reason while outward API anti-enumeration behavior remains unchanged.
6. Filter by Project, actor, operation/resource type, status and time range.
7. Open `/system/oplogs?operationId=AUD-...` and verify the business drawer opens directly.
8. Open `/system/oplogs?messageLogId=...` and verify the existing Security log detail still opens in the second tab.

## Non-goals

- expanding audit producer coverage to every remaining menu/module;
- changing PR 2.1/2.2 event collection semantics;
- audit export / retention / purge policies;
- SIEM integration;
- alert/rule engine on top of audit events;
- changing the existing `security:operation-log:read` RBAC model.

Refs #921