### PR TITLE
feat(audit): cover workflow definition lifecycle

### DIFF
--- a/yak-ops-business/yak-ops-business-audit/src/main/java/io/yak/ops/business/audit/AuditTimelineRendererRegistry.java
+++ b/yak-ops-business/yak-ops-business-audit/src/main/java/io/yak/ops/business/audit/AuditTimelineRendererRegistry.java
@@ -22,7 +22,7 @@ public final class AuditTimelineRendererRegistry {
     values.put("AUTHORIZATION_DECISION", this::authorization);
     values.put("OPERATION_STARTED", fixed("操作开始"));
     values.put("RESOURCE_CREATED", fixed("资源已创建"));
-    values.put("RESOURCE_UPDATED", fixed("资源已更新"));
+    values.put("RESOURCE_UPDATED", this::resourceUpdated);
     values.put("RESOURCE_DELETED", fixed("资源已删除"));
     values.put("TASK_SUBMITTED", fixed("任务已提交"));
     values.put("TASK_QUEUED", fixed("任务已进入队列"));
@@ -55,6 +55,19 @@ public final class AuditTimelineRendererRegistry {
 
   private Function<RenderContext, AuditEventPresentation> fixed(String title) {
     return context -> new AuditEventPresentation(title, description(context));
+  }
+
+  private AuditEventPresentation resourceUpdated(RenderContext context) {
+    String changeType = stringValue(context.payload().get("changeType"));
+    String title =
+        switch (changeType == null ? "" : changeType) {
+          case "VERSION_PUBLISHED" -> "版本已发布";
+          case "RESOURCE_ENABLED" -> "资源已启用";
+          case "RESOURCE_DISABLED" -> "资源已停用";
+          case "TASK_REVISION_UPGRADE" -> "任务版本已升级";
+          default -> "资源已更新";
+        };
+    return new AuditEventPresentation(title, description(context));
   }
 
   private AuditEventPresentation authorization(RenderContext context) {

--- a/yak-ops-business/yak-ops-business-audit/src/test/java/io/yak/ops/business/audit/AuditTimelineRendererRegistryTest.java
+++ b/yak-ops-business/yak-ops-business-audit/src/test/java/io/yak/ops/business/audit/AuditTimelineRendererRegistryTest.java
@@ -33,6 +33,40 @@ class AuditTimelineRendererRegistryTest {
   }
 
   @Test
+  void resourceUpdateUsesStableBusinessChangeTypeWhenAvailable() {
+    assertThat(
+            registry
+                .render(
+                    "RESOURCE_UPDATED",
+                    "SUCCESS",
+                    null,
+                    "Workflow version published",
+                    Map.of("changeType", "VERSION_PUBLISHED"))
+                .title())
+        .isEqualTo("版本已发布");
+    assertThat(
+            registry
+                .render(
+                    "RESOURCE_UPDATED",
+                    "SUCCESS",
+                    null,
+                    "Workflow enabled",
+                    Map.of("changeType", "RESOURCE_ENABLED"))
+                .title())
+        .isEqualTo("资源已启用");
+    assertThat(
+            registry
+                .render(
+                    "RESOURCE_UPDATED",
+                    "SUCCESS",
+                    null,
+                    "Workflow disabled",
+                    Map.of("changeType", "RESOURCE_DISABLED"))
+                .title())
+        .isEqualTo("资源已停用");
+  }
+
+  @Test
   void unknownEventHasSafeFallback() {
     AuditEventPresentation presentation =
         registry.render("CUSTOM_EVENT", "INFO", null, null, Map.of());

--- a/yak-ops-business/yak-ops-business-workflow/DEPENDENCIES.md
+++ b/yak-ops-business/yak-ops-business-workflow/DEPENDENCIES.md
@@ -28,7 +28,8 @@ Workflow production 内部允许的 top-level 依赖：
 Controller 只能进入稳定业务/运行入口：
 
 ```text
-definition -> WorkflowDefinitionManager
+definition -> WorkflowDefinitionManager (read/control)
+           -> WorkflowDefinitionAuditCoordinator (audited definition mutations)
 execution  -> WorkflowLauncher / WorkflowExecutionManager / WorkflowExecutionReactivator
 runtime    -> WorkflowRuntime
 schedule   -> create/revision/lifecycle/query + trigger query
@@ -36,6 +37,27 @@ backfill   -> WorkflowBackfillManager / WorkflowBackfillQuery
 ```
 
 Controller 不直接依赖 DAO、Repository、Schedule Engine Bridge 或 Trigger Admission/Coordinator。
+
+### Definition Audit Corridor
+
+Definition mutation 的审计入口固定为：
+
+```text
+WorkflowDefinitionController
+    -> WorkflowDefinitionAuditCoordinator
+    -> WorkflowDefinitionManager
+
+WorkflowDefinitionAuditCoordinator
+    -> shared BusinessAuditService
+```
+
+约束：
+
+- Audit 是 fail-open side effect，不能改变 Workflow command 结果；
+- Domain / Repository / DAO 不依赖 Audit；
+- Audit payload 只保存显式 allowlist 的业务差异，不复制 `input`、`editorMeta`、节点完整配置或 TaskVersionSnapshot；
+- 无实际 Definition 变化的保存不创建 AuditOperation；
+- Runtime / Schedule / Backfill 审计不属于这一 corridor，分别由后续 execution/schedule owner 接入。
 
 ## 3. Definition -> Runtime
 

--- a/yak-ops-business/yak-ops-business-workflow/pom.xml
+++ b/yak-ops-business/yak-ops-business-workflow/pom.xml
@@ -27,6 +27,10 @@
         </dependency>
         <dependency>
             <groupId>io.yak.ops</groupId>
+            <artifactId>yak-ops-business-audit</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.yak.ops</groupId>
             <artifactId>yak-ops-business-job</artifactId>
         </dependency>
         <dependency>

--- a/yak-ops-business/yak-ops-business-workflow/src/main/java/io/yak/ops/business/workflow/controller/v1/WorkflowDefinitionController.java
+++ b/yak-ops-business/yak-ops-business-workflow/src/main/java/io/yak/ops/business/workflow/controller/v1/WorkflowDefinitionController.java
@@ -3,8 +3,9 @@ package io.yak.ops.business.workflow.controller.v1;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import io.yak.framework.common.Result;
-import io.yak.ops.business.workflow.domain.WorkflowTriggerContext;
+import io.yak.ops.business.workflow.definition.WorkflowDefinitionAuditCoordinator;
 import io.yak.ops.business.workflow.definition.WorkflowDefinitionManager;
+import io.yak.ops.business.workflow.domain.WorkflowTriggerContext;
 import io.yak.ops.business.workflow.execution.WorkflowLauncher;
 import io.yak.ops.business.workflow.schedule.WorkflowDefinitionScheduleGuard;
 import io.yak.ops.common.bean.dto.workflow.WorkflowDefinitionCreateDTO;
@@ -14,6 +15,7 @@ import io.yak.ops.common.bean.vo.workflow.WorkflowVersionVO;
 import io.yak.ops.core.project.ProjectScope;
 import jakarta.validation.Valid;
 import java.util.List;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
@@ -32,14 +34,29 @@ import org.springframework.web.bind.annotation.RestController;
 public class WorkflowDefinitionController {
 
   private final WorkflowDefinitionManager definitionService;
+  private final WorkflowDefinitionAuditCoordinator definitionAudit;
   private final WorkflowLauncher launchService;
   private final WorkflowDefinitionScheduleGuard scheduleGuard;
 
+  @Autowired
+  public WorkflowDefinitionController(
+      WorkflowDefinitionManager definitionService,
+      WorkflowDefinitionAuditCoordinator definitionAudit,
+      WorkflowLauncher launchService,
+      WorkflowDefinitionScheduleGuard scheduleGuard) {
+    this.definitionService = definitionService;
+    this.definitionAudit = definitionAudit;
+    this.launchService = launchService;
+    this.scheduleGuard = scheduleGuard;
+  }
+
+  /** Focused compatibility constructor for tests that do not wire business audit. */
   public WorkflowDefinitionController(
       WorkflowDefinitionManager definitionService,
       WorkflowLauncher launchService,
       WorkflowDefinitionScheduleGuard scheduleGuard) {
     this.definitionService = definitionService;
+    this.definitionAudit = null;
     this.launchService = launchService;
     this.scheduleGuard = scheduleGuard;
   }
@@ -56,7 +73,8 @@ public class WorkflowDefinitionController {
   @PostMapping
   public Result<WorkflowDefinitionVO> create(
       @Valid @RequestBody WorkflowDefinitionCreateDTO request) {
-    return Result.success(definitionService.create(request));
+    return Result.success(
+        definitionAudit == null ? definitionService.create(request) : definitionAudit.create(request));
   }
 
   @Operation(summary = "查询工作流定义详情")
@@ -70,7 +88,10 @@ public class WorkflowDefinitionController {
   public Result<WorkflowDefinitionVO> update(
       @PathVariable("id") String id,
       @Valid @RequestBody WorkflowDefinitionUpdateDTO request) {
-    return Result.success(definitionService.update(id, request));
+    return Result.success(
+        definitionAudit == null
+            ? definitionService.update(id, request)
+            : definitionAudit.update(id, request));
   }
 
   @Operation(summary = "显式升级工作流节点到任务资产最新版本")
@@ -78,20 +99,25 @@ public class WorkflowDefinitionController {
   public Result<WorkflowDefinitionVO> upgradeTaskRevision(
       @PathVariable("id") String id,
       @PathVariable("nodeId") String nodeId) {
-    return Result.success(definitionService.upgradeTaskRevision(id, nodeId));
+    return Result.success(
+        definitionAudit == null
+            ? definitionService.upgradeTaskRevision(id, nodeId)
+            : definitionAudit.upgradeTaskRevision(id, nodeId));
   }
 
   @Operation(summary = "删除工作流定义")
   @DeleteMapping("/{id}")
   public Result<Boolean> delete(@PathVariable("id") String id) {
-    definitionService.delete(id);
+    if (definitionAudit == null) definitionService.delete(id);
+    else definitionAudit.delete(id);
     return Result.success(Boolean.TRUE);
   }
 
   @Operation(summary = "发布或重新启用工作流版本")
   @PostMapping("/{id}/online")
   public Result<WorkflowDefinitionVO> online(@PathVariable("id") String id) {
-    WorkflowDefinitionVO workflow = definitionService.online(id);
+    WorkflowDefinitionVO workflow =
+        definitionAudit == null ? definitionService.online(id) : definitionAudit.online(id);
     scheduleGuard.activateConfiguredSchedules(id);
     return Result.success(workflow);
   }
@@ -100,7 +126,8 @@ public class WorkflowDefinitionController {
   @PostMapping("/{id}/offline")
   public Result<WorkflowDefinitionVO> offline(@PathVariable("id") String id) {
     scheduleGuard.deactivateConfiguredSchedules(id);
-    return Result.success(definitionService.offline(id));
+    return Result.success(
+        definitionAudit == null ? definitionService.offline(id) : definitionAudit.offline(id));
   }
 
   @Operation(summary = "执行当前启用的已发布版本")

--- a/yak-ops-business/yak-ops-business-workflow/src/main/java/io/yak/ops/business/workflow/definition/WorkflowDefinitionAuditCoordinator.java
+++ b/yak-ops-business/yak-ops-business-workflow/src/main/java/io/yak/ops/business/workflow/definition/WorkflowDefinitionAuditCoordinator.java
@@ -1,0 +1,441 @@
+package io.yak.ops.business.workflow.definition;
+
+import io.yak.ops.business.audit.AuditEventType;
+import io.yak.ops.business.audit.AuditOperationHandle;
+import io.yak.ops.business.audit.AuditOperationRequest;
+import io.yak.ops.business.audit.BusinessAuditService;
+import io.yak.ops.common.bean.dto.workflow.WorkflowDefinitionCreateDTO;
+import io.yak.ops.common.bean.dto.workflow.WorkflowDefinitionUpdateDTO;
+import io.yak.ops.common.bean.dto.workflow.WorkflowDefinitionUpdateDTO.EdgeDTO;
+import io.yak.ops.common.bean.dto.workflow.WorkflowDefinitionUpdateDTO.NodeDTO;
+import io.yak.ops.common.bean.vo.workflow.WorkflowDefinitionVO;
+import io.yak.ops.common.bean.vo.workflow.WorkflowDefinitionVO.EdgeVO;
+import io.yak.ops.common.bean.vo.workflow.WorkflowDefinitionVO.NodeVO;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import org.springframework.beans.factory.ObjectProvider;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Component;
+
+/** Adds business audit semantics around Workflow definition lifecycle commands. */
+@Component
+public class WorkflowDefinitionAuditCoordinator {
+
+  private static final String RESOURCE_TYPE = "WORKFLOW";
+  private static final String SOURCE = "WEB";
+  private static final BusinessAuditService NOOP_AUDIT =
+      request -> AuditOperationHandle.noop(null);
+
+  private final WorkflowDefinitionManager definitions;
+  private final BusinessAuditService auditService;
+
+  @Autowired
+  public WorkflowDefinitionAuditCoordinator(
+      WorkflowDefinitionManager definitions,
+      ObjectProvider<BusinessAuditService> auditServiceProvider) {
+    this(definitions, auditServiceProvider.getIfAvailable(() -> NOOP_AUDIT));
+  }
+
+  WorkflowDefinitionAuditCoordinator(
+      WorkflowDefinitionManager definitions, BusinessAuditService auditService) {
+    this.definitions = definitions;
+    this.auditService = auditService == null ? NOOP_AUDIT : auditService;
+  }
+
+  public WorkflowDefinitionVO create(WorkflowDefinitionCreateDTO request) {
+    AuditOperationHandle audit =
+        start(
+            "WORKFLOW_CREATE",
+            "Create workflow",
+            null,
+            request == null ? null : trimToNull(request.name()),
+            Map.of("initialStatus", "DRAFT"));
+    try {
+      WorkflowDefinitionVO created = definitions.create(request);
+      audit.resource(created.id(), created.name());
+      audit.event(
+          AuditEventType.RESOURCE_CREATED,
+          "Workflow draft created",
+          Map.of(
+              "status", created.status(),
+              "nodeCount", created.nodeCount(),
+              "edgeCount", created.edgeCount()));
+      audit.success("Workflow created");
+      return created;
+    } catch (RuntimeException exception) {
+      audit.failure("WORKFLOW_CREATE_FAILED", exception);
+      throw exception;
+    }
+  }
+
+  public WorkflowDefinitionVO update(String id, WorkflowDefinitionUpdateDTO request) {
+    WorkflowDefinitionVO before = definitions.get(id);
+    UpdateChanges changes = updateChanges(before, request);
+    if (!changes.changed()) {
+      return definitions.update(id, request);
+    }
+
+    AuditOperationHandle audit =
+        start(
+            "WORKFLOW_UPDATE",
+            "Update workflow draft",
+            before.id(),
+            before.name(),
+            operationMetadata(before));
+    try {
+      WorkflowDefinitionVO updated = definitions.update(id, request);
+      audit.resource(updated.id(), updated.name());
+      audit.event(
+          AuditEventType.RESOURCE_UPDATED,
+          "Workflow draft updated",
+          changes.payload());
+      audit.success("Workflow updated");
+      return updated;
+    } catch (RuntimeException exception) {
+      audit.failure("WORKFLOW_UPDATE_FAILED", exception);
+      throw exception;
+    }
+  }
+
+  public WorkflowDefinitionVO upgradeTaskRevision(String id, String nodeId) {
+    WorkflowDefinitionVO before = definitions.get(id);
+    NodeVO current = findNode(before.nodes(), nodeId);
+    if (current != null
+        && current.taskAssetId() != null
+        && !current.taskRevisionUpdateAvailable()) {
+      return definitions.upgradeTaskRevision(id, nodeId);
+    }
+
+    Map<String, Object> metadata = new LinkedHashMap<>(operationMetadata(before));
+    putIfNotNull(metadata, "nodeId", nodeId);
+    AuditOperationHandle audit =
+        start(
+            "WORKFLOW_TASK_REVISION_UPGRADE",
+            "Upgrade workflow task revision",
+            before.id(),
+            before.name(),
+            Map.copyOf(metadata));
+    try {
+      WorkflowDefinitionVO updated = definitions.upgradeTaskRevision(id, nodeId);
+      NodeVO next = findNode(updated.nodes(), nodeId);
+      Map<String, Object> payload = new LinkedHashMap<>();
+      payload.put("changeType", "TASK_REVISION_UPGRADE");
+      putIfNotNull(payload, "nodeId", nodeId);
+      if (current != null) {
+        putIfNotNull(payload, "taskAssetId", current.taskAssetId());
+        putIfNotNull(payload, "fromTaskRevisionNo", current.taskRevisionNo());
+      }
+      if (next != null) {
+        putIfNotNull(payload, "toTaskRevisionNo", next.taskRevisionNo());
+      }
+      audit.event(
+          AuditEventType.RESOURCE_UPDATED,
+          "Workflow task revision upgraded",
+          Map.copyOf(payload));
+      audit.success("Workflow task revision upgraded");
+      return updated;
+    } catch (RuntimeException exception) {
+      audit.failure("WORKFLOW_TASK_REVISION_UPGRADE_FAILED", exception);
+      throw exception;
+    }
+  }
+
+  public WorkflowDefinitionVO online(String id) {
+    WorkflowDefinitionVO before = definitions.get(id);
+    boolean publish = before.activeVersionId() == null || before.draftChanged();
+    boolean enable = !"ONLINE".equals(before.status());
+    if (!publish && !enable) {
+      return definitions.online(id);
+    }
+
+    String operationType = publish ? "WORKFLOW_PUBLISH" : "WORKFLOW_ENABLE";
+    String operationName = publish ? "Publish workflow" : "Enable workflow";
+    AuditOperationHandle audit =
+        start(
+            operationType,
+            operationName,
+            before.id(),
+            before.name(),
+            operationMetadata(before));
+    try {
+      WorkflowDefinitionVO updated = definitions.online(id);
+      audit.resource(updated.id(), updated.name());
+      if (publish) {
+        Map<String, Object> payload = new LinkedHashMap<>();
+        payload.put("changeType", "VERSION_PUBLISHED");
+        putIfNotNull(payload, "workflowVersionId", updated.activeVersionId());
+        putIfNotNull(payload, "workflowVersionNo", updated.activeVersionNo());
+        payload.put("nodeCount", updated.nodeCount());
+        payload.put("edgeCount", updated.edgeCount());
+        audit.event(
+            AuditEventType.RESOURCE_UPDATED,
+            "Workflow version published",
+            Map.copyOf(payload));
+      }
+      if (enable) {
+        audit.event(
+            AuditEventType.RESOURCE_UPDATED,
+            "Workflow enabled",
+            lifecyclePayload("RESOURCE_ENABLED", updated));
+      }
+      audit.success(publish ? "Workflow published" : "Workflow enabled");
+      return updated;
+    } catch (RuntimeException exception) {
+      audit.failure(publish ? "WORKFLOW_PUBLISH_FAILED" : "WORKFLOW_ENABLE_FAILED", exception);
+      throw exception;
+    }
+  }
+
+  public WorkflowDefinitionVO offline(String id) {
+    WorkflowDefinitionVO before = definitions.get(id);
+    if ("OFFLINE".equals(before.status())) {
+      return definitions.offline(id);
+    }
+
+    AuditOperationHandle audit =
+        start(
+            "WORKFLOW_DISABLE",
+            "Disable workflow",
+            before.id(),
+            before.name(),
+            operationMetadata(before));
+    try {
+      WorkflowDefinitionVO updated = definitions.offline(id);
+      audit.resource(updated.id(), updated.name());
+      audit.event(
+          AuditEventType.RESOURCE_UPDATED,
+          "Workflow disabled",
+          lifecyclePayload("RESOURCE_DISABLED", updated));
+      audit.success("Workflow disabled");
+      return updated;
+    } catch (RuntimeException exception) {
+      audit.failure("WORKFLOW_DISABLE_FAILED", exception);
+      throw exception;
+    }
+  }
+
+  public void delete(String id) {
+    WorkflowDefinitionVO before = definitions.get(id);
+    AuditOperationHandle audit =
+        start(
+            "WORKFLOW_DELETE",
+            "Delete workflow",
+            before.id(),
+            before.name(),
+            operationMetadata(before));
+    try {
+      definitions.delete(id);
+      Map<String, Object> payload = new LinkedHashMap<>();
+      payload.put("status", before.status());
+      putIfNotNull(payload, "activeVersionId", before.activeVersionId());
+      putIfNotNull(payload, "activeVersionNo", before.activeVersionNo());
+      audit.event(
+          AuditEventType.RESOURCE_DELETED,
+          "Workflow deleted",
+          Map.copyOf(payload));
+      audit.success("Workflow deleted");
+    } catch (RuntimeException exception) {
+      audit.failure("WORKFLOW_DELETE_FAILED", exception);
+      throw exception;
+    }
+  }
+
+  private AuditOperationHandle start(
+      String operationType,
+      String operationName,
+      String resourceId,
+      String resourceName,
+      Map<String, ?> metadata) {
+    return auditService.start(
+        new AuditOperationRequest(
+            operationType,
+            operationName,
+            RESOURCE_TYPE,
+            resourceId,
+            resourceName,
+            SOURCE,
+            metadata));
+  }
+
+  private UpdateChanges updateChanges(
+      WorkflowDefinitionVO before, WorkflowDefinitionUpdateDTO request) {
+    if (request == null) return new UpdateChanges(true, Map.of());
+
+    String nextName = request.name() == null ? null : request.name().trim();
+    String nextDescription = trimToNull(request.description());
+    boolean nameChanged = !Objects.equals(before.name(), nextName);
+    boolean descriptionChanged = !Objects.equals(before.description(), nextDescription);
+    boolean nodesChanged =
+        !draftViewNodes(before.nodes()).equals(draftRequestNodes(request.nodes()));
+    boolean edgesChanged =
+        !draftViewEdges(before.edges()).equals(draftRequestEdges(request.edges()));
+    boolean inputChanged = !Objects.equals(before.input(), request.input());
+    boolean editorMetaChanged = !Objects.equals(before.editorMeta(), request.editorMeta());
+    boolean timeoutChanged = before.workflowTimeoutSeconds() != request.workflowTimeoutSeconds();
+    boolean failureStrategyChanged =
+        !Objects.equals(before.failureStrategy(), request.failureStrategy());
+
+    boolean changed =
+        nameChanged
+            || descriptionChanged
+            || nodesChanged
+            || edgesChanged
+            || inputChanged
+            || editorMetaChanged
+            || timeoutChanged
+            || failureStrategyChanged;
+    if (!changed) return new UpdateChanges(false, Map.of());
+
+    Map<String, Object> payload = new LinkedHashMap<>();
+    addValueChange(payload, "name", before.name(), nextName);
+    if (descriptionChanged) payload.put("descriptionChanged", true);
+    if (nodesChanged || edgesChanged) {
+      payload.put("graphChanged", true);
+      payload.put(
+          "nodeCount",
+          Map.of("before", before.nodeCount(), "after", request.nodes().size()));
+      payload.put(
+          "edgeCount",
+          Map.of("before", before.edgeCount(), "after", request.edges().size()));
+    }
+    if (inputChanged) payload.put("inputChanged", true);
+    if (editorMetaChanged) payload.put("editorMetaChanged", true);
+    addValueChange(
+        payload,
+        "workflowTimeoutSeconds",
+        before.workflowTimeoutSeconds(),
+        request.workflowTimeoutSeconds());
+    addValueChange(
+        payload,
+        "failureStrategy",
+        before.failureStrategy(),
+        request.failureStrategy());
+    return new UpdateChanges(true, Map.copyOf(payload));
+  }
+
+  private Map<String, Object> operationMetadata(WorkflowDefinitionVO workflow) {
+    Map<String, Object> metadata = new LinkedHashMap<>();
+    metadata.put("previousStatus", workflow.status());
+    putIfNotNull(metadata, "activeVersionId", workflow.activeVersionId());
+    putIfNotNull(metadata, "activeVersionNo", workflow.activeVersionNo());
+    return Map.copyOf(metadata);
+  }
+
+  private Map<String, Object> lifecyclePayload(
+      String changeType, WorkflowDefinitionVO workflow) {
+    Map<String, Object> payload = new LinkedHashMap<>();
+    payload.put("changeType", changeType);
+    payload.put("status", workflow.status());
+    putIfNotNull(payload, "workflowVersionId", workflow.activeVersionId());
+    putIfNotNull(payload, "workflowVersionNo", workflow.activeVersionNo());
+    return Map.copyOf(payload);
+  }
+
+  private List<DraftNode> draftViewNodes(List<NodeVO> nodes) {
+    return nodes == null ? List.of() : nodes.stream().map(DraftNode::from).toList();
+  }
+
+  private List<DraftNode> draftRequestNodes(List<NodeDTO> nodes) {
+    return nodes == null ? List.of() : nodes.stream().map(DraftNode::from).toList();
+  }
+
+  private List<DraftEdge> draftViewEdges(List<EdgeVO> edges) {
+    return edges == null ? List.of() : edges.stream().map(DraftEdge::from).toList();
+  }
+
+  private List<DraftEdge> draftRequestEdges(List<EdgeDTO> edges) {
+    return edges == null ? List.of() : edges.stream().map(DraftEdge::from).toList();
+  }
+
+  private NodeVO findNode(List<NodeVO> nodes, String nodeId) {
+    if (nodes == null) return null;
+    return nodes.stream()
+        .filter(node -> Objects.equals(node.id(), nodeId))
+        .findFirst()
+        .orElse(null);
+  }
+
+  private static void addValueChange(
+      Map<String, Object> payload, String field, Object before, Object after) {
+    if (!Objects.equals(before, after)) {
+      payload.put(field, Map.of("before", before, "after", after));
+    }
+  }
+
+  private static void putIfNotNull(Map<String, Object> values, String key, Object value) {
+    if (value != null) values.put(key, value);
+  }
+
+  private static String trimToNull(String value) {
+    if (value == null) return null;
+    String normalized = value.trim();
+    return normalized.isEmpty() ? null : normalized;
+  }
+
+  private record UpdateChanges(boolean changed, Map<String, Object> payload) {}
+
+  private record DraftEdge(String source, String target) {
+    static DraftEdge from(EdgeVO edge) {
+      return new DraftEdge(edge.source(), edge.target());
+    }
+
+    static DraftEdge from(EdgeDTO edge) {
+      return new DraftEdge(edge.source(), edge.target());
+    }
+  }
+
+  private record DraftNode(
+      String id,
+      String taskId,
+      Long taskAssetId,
+      Long taskRevisionId,
+      Integer taskRevisionNo,
+      double positionX,
+      double positionY,
+      int maxAttempts,
+      long retryDelaySeconds,
+      long dispatchTimeoutSeconds,
+      long executionTimeoutSeconds,
+      Map<String, String> inputMapping,
+      String triggerRule,
+      String failurePolicy) {
+
+    static DraftNode from(NodeVO node) {
+      return new DraftNode(
+          node.id(),
+          node.taskId(),
+          node.taskAssetId(),
+          node.taskRevisionId(),
+          node.taskRevisionNo(),
+          node.positionX(),
+          node.positionY(),
+          node.maxAttempts(),
+          node.retryDelaySeconds(),
+          node.dispatchTimeoutSeconds(),
+          node.executionTimeoutSeconds(),
+          node.inputMapping(),
+          node.triggerRule(),
+          node.failurePolicy());
+    }
+
+    static DraftNode from(NodeDTO node) {
+      return new DraftNode(
+          node.id(),
+          node.taskId(),
+          node.taskAssetId(),
+          node.taskRevisionId(),
+          node.taskRevisionNo(),
+          node.positionX(),
+          node.positionY(),
+          node.maxAttempts(),
+          node.retryDelaySeconds(),
+          node.dispatchTimeoutSeconds(),
+          node.executionTimeoutSeconds(),
+          node.inputMapping(),
+          node.triggerRule(),
+          node.failurePolicy());
+    }
+  }
+}

--- a/yak-ops-business/yak-ops-business-workflow/src/test/java/io/yak/ops/business/workflow/architecture/WorkflowRoleConventionTest.java
+++ b/yak-ops-business/yak-ops-business-workflow/src/test/java/io/yak/ops/business/workflow/architecture/WorkflowRoleConventionTest.java
@@ -7,6 +7,7 @@ import io.yak.ops.business.workflow.backfill.WorkflowBackfillPlanner;
 import io.yak.ops.business.workflow.backfill.WorkflowBackfillQuery;
 import io.yak.ops.business.workflow.backfill.WorkflowBackfillReconciler;
 import io.yak.ops.business.workflow.backfill.WorkflowBackfillTriggerAdapter;
+import io.yak.ops.business.workflow.definition.WorkflowDefinitionAuditCoordinator;
 import io.yak.ops.business.workflow.definition.WorkflowDefinitionManager;
 import io.yak.ops.business.workflow.execution.WorkflowExecutionManager;
 import io.yak.ops.business.workflow.execution.WorkflowExecutionReactivator;
@@ -48,6 +49,7 @@ class WorkflowRoleConventionTest {
   @Test
   void internalRolesRemainExplicitComponents() {
     for (Class<?> role : List.of(
+        WorkflowDefinitionAuditCoordinator.class,
         WorkflowPublishedVersionRunner.class,
         WorkflowRuntimeRecovery.class,
         WorkflowEventStream.class,

--- a/yak-ops-business/yak-ops-business-workflow/src/test/java/io/yak/ops/business/workflow/definition/WorkflowDefinitionAuditCoordinatorTest.java
+++ b/yak-ops-business/yak-ops-business-workflow/src/test/java/io/yak/ops/business/workflow/definition/WorkflowDefinitionAuditCoordinatorTest.java
@@ -1,0 +1,266 @@
+package io.yak.ops.business.workflow.definition;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import io.yak.ops.business.audit.AuditEventType;
+import io.yak.ops.business.audit.AuditOperationHandle;
+import io.yak.ops.business.audit.AuditOperationRequest;
+import io.yak.ops.business.audit.BusinessAuditService;
+import io.yak.ops.common.bean.dto.workflow.WorkflowDefinitionUpdateDTO;
+import io.yak.ops.common.bean.vo.workflow.WorkflowDefinitionVO;
+import io.yak.ops.common.bean.vo.workflow.WorkflowDefinitionVO.NodeVO;
+import java.time.Instant;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import org.junit.jupiter.api.Test;
+
+class WorkflowDefinitionAuditCoordinatorTest {
+
+  @Test
+  void unchangedDraftDoesNotCreateAuditNoise() {
+    WorkflowDefinitionManager definitions = mock(WorkflowDefinitionManager.class);
+    RecordingAuditService audit = new RecordingAuditService();
+    WorkflowDefinitionAuditCoordinator coordinator =
+        new WorkflowDefinitionAuditCoordinator(definitions, audit);
+    WorkflowDefinitionVO before = workflow("DRAFT", null, null, false, Map.of(), Map.of(), List.of());
+    WorkflowDefinitionUpdateDTO request =
+        new WorkflowDefinitionUpdateDTO(
+            before.name(),
+            before.description(),
+            List.of(),
+            List.of(),
+            before.input(),
+            before.editorMeta(),
+            before.workflowTimeoutSeconds(),
+            before.failureStrategy());
+    when(definitions.get("wf-1")).thenReturn(before);
+    when(definitions.update("wf-1", request)).thenReturn(before);
+
+    WorkflowDefinitionVO result = coordinator.update("wf-1", request);
+
+    assertThat(result).isSameAs(before);
+    assertThat(audit.starts).isZero();
+    verify(definitions).update("wf-1", request);
+  }
+
+  @Test
+  void draftUpdateStoresOnlySafeChangeFlags() {
+    WorkflowDefinitionManager definitions = mock(WorkflowDefinitionManager.class);
+    RecordingAuditService audit = new RecordingAuditService();
+    WorkflowDefinitionAuditCoordinator coordinator =
+        new WorkflowDefinitionAuditCoordinator(definitions, audit);
+    WorkflowDefinitionVO before =
+        workflow(
+            "DRAFT",
+            null,
+            null,
+            false,
+            Map.of("token", "secret-before"),
+            Map.of("layout", "private-before"),
+            List.of());
+    WorkflowDefinitionVO after =
+        workflow(
+            "DRAFT",
+            null,
+            null,
+            false,
+            Map.of("token", "secret-after"),
+            Map.of("layout", "private-after"),
+            List.of());
+    WorkflowDefinitionUpdateDTO request =
+        new WorkflowDefinitionUpdateDTO(
+            before.name(),
+            "updated description",
+            List.of(),
+            List.of(),
+            after.input(),
+            after.editorMeta(),
+            before.workflowTimeoutSeconds(),
+            before.failureStrategy());
+    when(definitions.get("wf-1")).thenReturn(before);
+    when(definitions.update("wf-1", request)).thenReturn(after);
+
+    coordinator.update("wf-1", request);
+
+    assertThat(audit.starts).isEqualTo(1);
+    assertThat(audit.request.operationType()).isEqualTo("WORKFLOW_UPDATE");
+    assertThat(audit.handle.events).hasSize(1);
+    Map<String, ?> payload = audit.handle.events.get(0).payload();
+    assertThat(payload)
+        .containsEntry("descriptionChanged", true)
+        .containsEntry("inputChanged", true)
+        .containsEntry("editorMetaChanged", true);
+    assertThat(payload.toString())
+        .doesNotContain("secret-before", "secret-after", "private-before", "private-after");
+    assertThat(audit.handle.successSummary).isEqualTo("Workflow updated");
+  }
+
+  @Test
+  void publishAndEnableShareOneOperationWithBusinessChangeTypes() {
+    WorkflowDefinitionManager definitions = mock(WorkflowDefinitionManager.class);
+    RecordingAuditService audit = new RecordingAuditService();
+    WorkflowDefinitionAuditCoordinator coordinator =
+        new WorkflowDefinitionAuditCoordinator(definitions, audit);
+    WorkflowDefinitionVO before = workflow("DRAFT", null, null, true, Map.of(), Map.of(), List.of());
+    WorkflowDefinitionVO after = workflow("ONLINE", "wv-1", 1, false, Map.of(), Map.of(), List.of());
+    when(definitions.get("wf-1")).thenReturn(before);
+    when(definitions.online("wf-1")).thenReturn(after);
+
+    coordinator.online("wf-1");
+
+    assertThat(audit.request.operationType()).isEqualTo("WORKFLOW_PUBLISH");
+    assertThat(audit.handle.events).hasSize(2);
+    assertThat(audit.handle.events)
+        .extracting(event -> event.payload().get("changeType"))
+        .containsExactly("VERSION_PUBLISHED", "RESOURCE_ENABLED");
+    assertThat(audit.handle.successSummary).isEqualTo("Workflow published");
+  }
+
+  @Test
+  void taskRevisionNoopDoesNotCreateAuditOperation() {
+    WorkflowDefinitionManager definitions = mock(WorkflowDefinitionManager.class);
+    RecordingAuditService audit = new RecordingAuditService();
+    WorkflowDefinitionAuditCoordinator coordinator =
+        new WorkflowDefinitionAuditCoordinator(definitions, audit);
+    WorkflowDefinitionVO before =
+        workflow("DRAFT", null, null, true, Map.of(), Map.of(), List.of(node(false, 2)));
+    when(definitions.get("wf-1")).thenReturn(before);
+    when(definitions.upgradeTaskRevision("wf-1", "node-1")).thenReturn(before);
+
+    coordinator.upgradeTaskRevision("wf-1", "node-1");
+
+    assertThat(audit.starts).isZero();
+    verify(definitions).upgradeTaskRevision("wf-1", "node-1");
+  }
+
+  @Test
+  void deleteFailureClosesAuditAsFailedWithoutChangingBusinessException() {
+    WorkflowDefinitionManager definitions = mock(WorkflowDefinitionManager.class);
+    RecordingAuditService audit = new RecordingAuditService();
+    WorkflowDefinitionAuditCoordinator coordinator =
+        new WorkflowDefinitionAuditCoordinator(definitions, audit);
+    WorkflowDefinitionVO before = workflow("OFFLINE", "wv-2", 2, false, Map.of(), Map.of(), List.of());
+    when(definitions.get("wf-1")).thenReturn(before);
+    IllegalStateException failure = new IllegalStateException("still referenced");
+    org.mockito.Mockito.doThrow(failure).when(definitions).delete("wf-1");
+
+    assertThatThrownBy(() -> coordinator.delete("wf-1")).isSameAs(failure);
+
+    assertThat(audit.request.operationType()).isEqualTo("WORKFLOW_DELETE");
+    assertThat(audit.handle.failureReason).isEqualTo("WORKFLOW_DELETE_FAILED");
+    assertThat(audit.handle.failureCause).isSameAs(failure);
+  }
+
+  private static WorkflowDefinitionVO workflow(
+      String status,
+      String activeVersionId,
+      Integer activeVersionNo,
+      boolean draftChanged,
+      Map<String, Object> input,
+      Map<String, Object> editorMeta,
+      List<NodeVO> nodes) {
+    Instant now = Instant.parse("2026-09-02T00:00:00Z");
+    return new WorkflowDefinitionVO(
+        "wf-1",
+        "Orders workflow",
+        "description",
+        status,
+        nodes.size(),
+        0,
+        nodes,
+        List.of(),
+        input,
+        editorMeta,
+        300L,
+        "FAIL_FAST",
+        activeVersionId,
+        activeVersionNo,
+        activeVersionNo == null ? 0 : activeVersionNo,
+        draftChanged,
+        null,
+        null,
+        now,
+        now);
+  }
+
+  private static NodeVO node(boolean updateAvailable, int revisionNo) {
+    return new NodeVO(
+        "node-1",
+        "task-asset:10",
+        10L,
+        100L + revisionNo,
+        revisionNo,
+        "Sync task",
+        "OFFLINE_SYNC",
+        "ONLINE",
+        updateAvailable ? 200L : 100L + revisionNo,
+        updateAvailable ? revisionNo + 1 : revisionNo,
+        updateAvailable,
+        0D,
+        0D,
+        1,
+        0L,
+        0L,
+        0L,
+        Map.of(),
+        "ALL_SUCCESS",
+        "FAIL_WORKFLOW");
+  }
+
+  private static final class RecordingAuditService implements BusinessAuditService {
+    int starts;
+    AuditOperationRequest request;
+    RecordingHandle handle;
+
+    @Override
+    public AuditOperationHandle start(AuditOperationRequest request) {
+      starts++;
+      this.request = request;
+      this.handle = new RecordingHandle();
+      return handle;
+    }
+  }
+
+  private static final class RecordingHandle implements AuditOperationHandle {
+    final List<Event> events = new ArrayList<>();
+    String resourceId;
+    String resourceName;
+    String successSummary;
+    String failureReason;
+    Throwable failureCause;
+
+    @Override
+    public String operationId() {
+      return "AUD-test";
+    }
+
+    @Override
+    public void resource(String resourceId, String resourceName) {
+      this.resourceId = resourceId;
+      this.resourceName = resourceName;
+    }
+
+    @Override
+    public void event(AuditEventType type, String message, Map<String, ?> payload) {
+      events.add(new Event(type, message, Map.copyOf(payload)));
+    }
+
+    @Override
+    public void success(String summary) {
+      successSummary = summary;
+    }
+
+    @Override
+    public void failure(String reasonCode, Throwable cause) {
+      failureReason = reasonCode;
+      failureCause = cause;
+    }
+  }
+
+  private record Event(AuditEventType type, String message, Map<String, ?> payload) {}
+}


### PR DESCRIPTION
## Summary

Implements **PR 4.1** for #921: extend the existing end-to-end business Audit platform to the **Workflow Definition lifecycle** without changing Workflow Runtime, Schedule, Backfill, or the Audit persistence model.

This PR deliberately keeps the scope small: synchronous Definition mutations only.

## 1. Workflow Definition audit coverage

Adds business AuditOperations for:

```text
WORKFLOW_CREATE
WORKFLOW_UPDATE
WORKFLOW_TASK_REVISION_UPGRADE
WORKFLOW_PUBLISH
WORKFLOW_ENABLE
WORKFLOW_DISABLE
WORKFLOW_DELETE
```

The existing `WorkflowDefinitionManager` remains the Definition/Version truth owner.

A narrow internal component is added:

```text
WorkflowDefinitionController
    -> WorkflowDefinitionAuditCoordinator
    -> WorkflowDefinitionManager
```

Read paths and Workflow execution/control paths continue to enter the existing Manager/Launcher directly.

## 2. Keep Audit out of Controller, Domain and persistence

`WorkflowDefinitionAuditCoordinator` owns only the cross-cutting command/audit orchestration.

The boundaries are intentionally:

```text
Controller
   -> audited Definition mutation coordinator
   -> existing Definition Manager
   -> existing Repository/DAO

Audit side effect
   -> shared BusinessAuditService
```

No Workflow Domain, Repository or DAO type depends on Audit.

The Workflow module now depends on the shared `yak-ops-business-audit` module in the same direction already used by Datasource.

## 3. No-op saves do not create audit noise

Before an update starts an AuditOperation, the coordinator compares the current normalized Workflow draft with the incoming DTO across:

- name / description;
- nodes / edges;
- input presence/change;
- editor metadata change;
- timeout;
- failure strategy.

An unchanged save delegates to the existing Manager but creates **no AuditOperation**.

Task revision upgrade behaves similarly when the selected TaskAsset is already on the latest revision.

## 4. Safe allowlist payloads only

Audit does **not** copy:

```text
workflow input values
editorMeta contents
full node configuration
TaskVersionSnapshot
runtime output
credentials/secrets
```

Workflow update audit stores only bounded change evidence such as:

```text
name before/after
descriptionChanged
graphChanged
nodeCount before/after
edgeCount before/after
inputChanged
editorMetaChanged
workflowTimeoutSeconds before/after
failureStrategy before/after
```

Task revision upgrade stores only stable identifiers/version numbers needed to explain the mutation.

Publish stores only the published WorkflowVersion identity plus node/edge counts.

## 5. Publish vs enable semantics

The existing `online()` command has two meanings:

```text
Draft changed / no active version
    -> publish a new immutable WorkflowVersion
    -> operation = WORKFLOW_PUBLISH

No draft change, existing version is OFFLINE
    -> re-enable existing version
    -> operation = WORKFLOW_ENABLE
```

When publishing also changes the resource from DRAFT/OFFLINE to ONLINE, one AuditOperation contains both business facts.

## 6. Reuse the small Audit event vocabulary

This PR does **not** add Workflow-specific `AuditEventType` values.

It continues using the stable generic event vocabulary:

```text
RESOURCE_CREATED
RESOURCE_UPDATED
RESOURCE_DELETED
```

`RESOURCE_UPDATED.payload.changeType` carries stable presentation hints:

```text
VERSION_PUBLISHED
RESOURCE_ENABLED
RESOURCE_DISABLED
TASK_REVISION_UPGRADE
```

`AuditTimelineRendererRegistry` renders those as:

```text
版本已发布
资源已启用
资源已停用
任务版本已升级
```

Unknown/ordinary resource updates keep the existing `资源已更新` fallback.

## 7. Failure isolation

Each audited mutation keeps structured terminal reason codes such as:

```text
WORKFLOW_CREATE_FAILED
WORKFLOW_UPDATE_FAILED
WORKFLOW_TASK_REVISION_UPGRADE_FAILED
WORKFLOW_PUBLISH_FAILED
WORKFLOW_ENABLE_FAILED
WORKFLOW_DISABLE_FAILED
WORKFLOW_DELETE_FAILED
```

The shared Audit implementation remains fail-open; Audit availability must not change the Workflow business result.

When `yak.database.enabled=false`, Workflow can still use its existing lightweight mode because the coordinator resolves `BusinessAuditService` optionally and falls back to a no-op Audit implementation.

## 8. Architecture contract

Updates Workflow dependency documentation and role guard coverage so:

- `WorkflowDefinitionManager` stays a stable `@Service` facade;
- `WorkflowDefinitionAuditCoordinator` is an internal `@Component`;
- Audit does not leak into Domain / Repository / DAO;
- Runtime / Schedule / Backfill audit remains explicitly out of scope for 4.1.

## Tests / validation

Added focused tests for:

- unchanged draft save creates no AuditOperation;
- safe update flags without raw input/editor metadata values;
- publish + enable facts remain under one business operation;
- no-op Task revision upgrade creates no AuditOperation;
- failed delete preserves the original exception while closing Audit as failed;
- business Timeline presentation for publish/enable/disable change types.

Repository compare at PR creation:

```text
1 commit ahead
0 commits behind current main
8 changed files
no Flyway/schema change
no Workflow Runtime/Schedule/Backfill production change
```

The available execution container cannot resolve `github.com`, so a full Maven checkout/build was not executable here. GitHub currently reports no commit status checks for the head.

Recommended local verification:

```bash
mvn -pl yak-ops-business/yak-ops-business-audit,yak-ops-business/yak-ops-business-workflow -am test
```

Suggested smoke flow:

1. Create a Workflow and confirm one `WORKFLOW_CREATE` row appears in Audit Center.
2. Save an unchanged draft and confirm no new business-audit row is created.
3. Change name/graph/input and confirm only safe change flags/counts are persisted.
4. Publish the Workflow and confirm Timeline renders `版本已发布` and `资源已启用` under one operation when applicable.
5. Disable and re-enable the same unchanged published version; confirm `WORKFLOW_DISABLE` / `WORKFLOW_ENABLE` rather than a fake publish.
6. Upgrade a TaskAsset node revision and confirm old/new revision numbers are visible without Task snapshots.
7. Delete an OFFLINE Workflow and confirm `WORKFLOW_DELETE`.
8. Force Audit-store failure and confirm the Workflow mutation result is unchanged.

## Non-goals

- Workflow execution / async AuditCarrier propagation (PR 4.2)
- pause/resume/cancel/retry execution auditing
- Schedule / Trigger / Backfill auditing (PR 4.3)
- Node/Attempt/Runtime-log timeline events
- new Audit tables or Flyway changes
- Audit retention/export/SIEM changes
- new Audit RBAC model

Refs #921