### PR TITLE
feat(audit): correlate workflow execution lifecycle

### DIFF
--- a/yak-ops-business/yak-ops-business-audit/src/main/java/io/yak/ops/business/audit/AuditTimelineRendererRegistry.java
+++ b/yak-ops-business/yak-ops-business-audit/src/main/java/io/yak/ops/business/audit/AuditTimelineRendererRegistry.java
@@ -65,6 +65,13 @@ public final class AuditTimelineRendererRegistry {
           case "RESOURCE_ENABLED" -> "资源已启用";
           case "RESOURCE_DISABLED" -> "资源已停用";
           case "TASK_REVISION_UPGRADE" -> "任务版本已升级";
+          case "EXECUTION_STARTED" -> "执行开始";
+          case "EXECUTION_SUCCEEDED" -> "执行成功";
+          case "EXECUTION_FAILED" -> "执行失败";
+          case "EXECUTION_CANCELED" -> "执行已取消";
+          case "EXECUTION_PAUSED" -> "执行已暂停";
+          case "EXECUTION_RESUMED" -> "执行已恢复";
+          case "EXECUTION_CANCEL_REQUESTED" -> "已请求取消执行";
           default -> "资源已更新";
         };
     return new AuditEventPresentation(title, description(context));
@@ -125,6 +132,15 @@ public final class AuditTimelineRendererRegistry {
     labels.put("PROJECT_UNAVAILABLE", "项目空间当前不可用");
     labels.put("PROJECT_OWNER_ACCESS_ALLOWED", "项目所有者权限通过");
     labels.put("PROJECT_MEMBER_ACCESS_ALLOWED", "项目成员权限通过");
+    labels.put("WORKFLOW_EXECUTION_START_FAILED", "工作流启动失败");
+    labels.put("WORKFLOW_EXECUTION_REACTIVATION_FAILED", "工作流恢复执行失败");
+    labels.put("WORKFLOW_EXECUTION_FAILED", "工作流执行失败");
+    labels.put("WORKFLOW_EXECUTION_TIMED_OUT", "工作流执行超时");
+    labels.put("WORKFLOW_EXECUTION_WARNING", "工作流以告警状态结束");
+    labels.put("WORKFLOW_EXECUTION_CANCELED", "工作流执行已取消");
+    labels.put("WORKFLOW_EXECUTION_PAUSE_FAILED", "暂停工作流失败");
+    labels.put("WORKFLOW_EXECUTION_RESUME_FAILED", "恢复工作流失败");
+    labels.put("WORKFLOW_EXECUTION_CANCEL_FAILED", "取消工作流失败");
     return Map.copyOf(labels);
   }
 

--- a/yak-ops-business/yak-ops-business-audit/src/test/java/io/yak/ops/business/audit/AuditTimelineRendererRegistryTest.java
+++ b/yak-ops-business/yak-ops-business-audit/src/test/java/io/yak/ops/business/audit/AuditTimelineRendererRegistryTest.java
@@ -67,6 +67,46 @@ class AuditTimelineRendererRegistryTest {
   }
 
   @Test
+  void workflowExecutionStateChangesUseBusinessCopyWithoutGrowingEventVocabulary() {
+    assertThat(registry
+            .render(
+                "RESOURCE_UPDATED",
+                "INFO",
+                null,
+                "Workflow execution started",
+                Map.of("changeType", "EXECUTION_STARTED"))
+            .title())
+        .isEqualTo("执行开始");
+    assertThat(registry
+            .render(
+                "RESOURCE_UPDATED",
+                "SUCCESS",
+                null,
+                "Workflow execution succeeded",
+                Map.of("changeType", "EXECUTION_SUCCEEDED"))
+            .title())
+        .isEqualTo("执行成功");
+    assertThat(registry
+            .render(
+                "RESOURCE_UPDATED",
+                "FAILURE",
+                "WORKFLOW_EXECUTION_FAILED",
+                "Workflow execution failed",
+                Map.of("changeType", "EXECUTION_FAILED"))
+            .title())
+        .isEqualTo("执行失败");
+    assertThat(registry
+            .render(
+                "RESOURCE_UPDATED",
+                "FAILURE",
+                "WORKFLOW_EXECUTION_CANCELED",
+                "Workflow execution canceled",
+                Map.of("changeType", "EXECUTION_CANCELED"))
+            .title())
+        .isEqualTo("执行已取消");
+  }
+
+  @Test
   void unknownEventHasSafeFallback() {
     AuditEventPresentation presentation =
         registry.render("CUSTOM_EVENT", "INFO", null, null, Map.of());

--- a/yak-ops-business/yak-ops-business-workflow/DEPENDENCIES.md
+++ b/yak-ops-business/yak-ops-business-workflow/DEPENDENCIES.md
@@ -29,8 +29,9 @@ Controller 只能进入稳定业务/运行入口：
 
 ```text
 definition -> WorkflowDefinitionManager (read/control)
-           -> WorkflowDefinitionAuditCoordinator (audited definition mutations)
+           -> WorkflowDefinitionAuditCoordinator (audited definition mutations + editor pause/resume)
 execution  -> WorkflowLauncher / WorkflowExecutionManager / WorkflowExecutionReactivator
+           -> WorkflowExecutionControlAuditCoordinator (pause/resume/cancel)
 runtime    -> WorkflowRuntime
 schedule   -> create/revision/lifecycle/query + trigger query
 backfill   -> WorkflowBackfillManager / WorkflowBackfillQuery
@@ -57,7 +58,35 @@ WorkflowDefinitionAuditCoordinator
 - Domain / Repository / DAO 不依赖 Audit；
 - Audit payload 只保存显式 allowlist 的业务差异，不复制 `input`、`editorMeta`、节点完整配置或 TaskVersionSnapshot；
 - 无实际 Definition 变化的保存不创建 AuditOperation；
-- Runtime / Schedule / Backfill 审计不属于这一 corridor，分别由后续 execution/schedule owner 接入。
+- Runtime / Schedule / Backfill 审计不属于 Definition lifecycle corridor。
+
+编辑器现有 `/definitions/{id}/pause|resume` 路由虽然挂在 Definition HTTP surface 下，实际控制的是 `latestExecutionId`。因此这两个入口仍由 Definition facade 委托 Runtime，但 AuditOperation 的 `resource_type` 必须是 `WORKFLOW_EXECUTION`，并且不得替换该 Execution 的长期 carrier。
+
+### Execution Audit Corridor
+
+Workflow Execution 的启动相关性固定为：
+
+```text
+WorkflowLauncher
+    -> WorkflowExecutionAuditBridge
+    -> shared BusinessAuditService
+    -> WorkflowAuditCorrelationRepository
+    -> WorkflowExecutionDao
+    -> yak_workflow_execution.audit_carrier_json
+```
+
+Runtime 不直接依赖 Audit。终态继续由既有 durable truth 发布：
+
+```text
+WorkflowExecutionRepositoryAdapter
+    -> WorkflowExecutionTerminalEvent
+    -> AFTER_COMMIT WorkflowExecutionAuditTerminalListener
+    -> WorkflowExecutionAuditBridge
+```
+
+人工 `retry/continue` 会复用同一个 WorkflowExecution，因此必须在重新激活前创建新的 `WORKFLOW_EXECUTE` operation 并替换 carrier；失败时恢复旧 carrier。`pause/resume/cancel` 是独立短操作，不替换 execution carrier。
+
+Audit correlation 更新只能修改 `audit_carrier_json`，不能顺手更新 Runtime status、runtime metadata 或 `updated_at`。
 
 ## 3. Definition -> Runtime
 
@@ -74,10 +103,11 @@ Graph compiler、Task binding resolver 不直接调用 Runtime。Schedule activa
 Execution 创建/控制实例只允许进入 `WorkflowRuntime`。
 
 ```text
-WorkflowLauncher               -> WorkflowRuntime
-WorkflowExecutionManager       -> WorkflowRuntime
-WorkflowExecutionReactivator   -> WorkflowRuntime
-WorkflowPublishedVersionRunner -> WorkflowRuntime
+WorkflowLauncher                         -> WorkflowRuntime
+WorkflowExecutionManager                 -> WorkflowRuntime
+WorkflowExecutionReactivator             -> WorkflowRuntime
+WorkflowExecutionControlAuditCoordinator -> WorkflowRuntime
+WorkflowPublishedVersionRunner           -> WorkflowRuntime
 ```
 
 Execution 不直接依赖 Schedule/Backfill 实现。需要反向策略时使用 execution-owned Port。
@@ -133,6 +163,8 @@ Definition/Runtime 的 durable business contract：
 role -> WorkflowDefinitionRepository / WorkflowRuntimeRepository
      -> adapter -> DAO / engine SPI
 ```
+
+Audit correlation 使用独立的窄 Repository，只读写 execution 的相关性列，不进入 Workflow Runtime aggregate contract。
 
 Schedule/Trigger/Backfill 当前允许直接使用自己明确的 DAO/ledger primitive，但：
 

--- a/yak-ops-business/yak-ops-business-workflow/src/main/java/io/yak/ops/business/workflow/controller/v1/WorkflowController.java
+++ b/yak-ops-business/yak-ops-business-workflow/src/main/java/io/yak/ops/business/workflow/controller/v1/WorkflowController.java
@@ -4,6 +4,7 @@ import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import io.yak.framework.common.Result;
 import io.yak.ops.business.workflow.domain.WorkflowTriggerContext;
+import io.yak.ops.business.workflow.execution.WorkflowExecutionControlAuditCoordinator;
 import io.yak.ops.business.workflow.execution.WorkflowExecutionReactivator;
 import io.yak.ops.business.workflow.execution.WorkflowLauncher;
 import io.yak.ops.business.workflow.runtime.WorkflowRuntime;
@@ -12,6 +13,7 @@ import io.yak.ops.common.bean.vo.workflow.WorkflowInstanceVO;
 import io.yak.ops.core.project.ProjectScope;
 import jakarta.validation.Valid;
 import java.util.List;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.MediaType;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
@@ -31,7 +33,21 @@ public class WorkflowController {
   private final WorkflowRuntime workflowRuntimeService;
   private final WorkflowLauncher workflowLaunchService;
   private final WorkflowExecutionReactivator workflowReactivationService;
+  private final WorkflowExecutionControlAuditCoordinator executionControlAudit;
 
+  @Autowired
+  public WorkflowController(
+      WorkflowRuntime workflowRuntimeService,
+      WorkflowLauncher workflowLaunchService,
+      WorkflowExecutionReactivator workflowReactivationService,
+      WorkflowExecutionControlAuditCoordinator executionControlAudit) {
+    this.workflowRuntimeService = workflowRuntimeService;
+    this.workflowLaunchService = workflowLaunchService;
+    this.workflowReactivationService = workflowReactivationService;
+    this.executionControlAudit = executionControlAudit;
+  }
+
+  /** Focused compatibility constructor without Audit wiring. */
   public WorkflowController(
       WorkflowRuntime workflowRuntimeService,
       WorkflowLauncher workflowLaunchService,
@@ -39,6 +55,7 @@ public class WorkflowController {
     this.workflowRuntimeService = workflowRuntimeService;
     this.workflowLaunchService = workflowLaunchService;
     this.workflowReactivationService = workflowReactivationService;
+    this.executionControlAudit = null;
   }
 
   @Operation(summary = "创建工作流运行实例")
@@ -59,21 +76,30 @@ public class WorkflowController {
   @PostMapping("/instances/{executionId}/pause")
   public Result<WorkflowInstanceVO> pause(
       @PathVariable("executionId") String executionId) {
-    return Result.success(workflowRuntimeService.pause(executionId));
+    return Result.success(
+        executionControlAudit == null
+            ? workflowRuntimeService.pause(executionId)
+            : executionControlAudit.pause(executionId));
   }
 
   @Operation(summary = "恢复工作流实例")
   @PostMapping("/instances/{executionId}/resume")
   public Result<WorkflowInstanceVO> resume(
       @PathVariable("executionId") String executionId) {
-    return Result.success(workflowRuntimeService.resume(executionId));
+    return Result.success(
+        executionControlAudit == null
+            ? workflowRuntimeService.resume(executionId)
+            : executionControlAudit.resume(executionId));
   }
 
   @Operation(summary = "取消工作流实例")
   @PostMapping("/instances/{executionId}/cancel")
   public Result<WorkflowInstanceVO> cancel(
       @PathVariable("executionId") String executionId) {
-    return Result.success(workflowRuntimeService.cancel(executionId));
+    return Result.success(
+        executionControlAudit == null
+            ? workflowRuntimeService.cancel(executionId)
+            : executionControlAudit.cancel(executionId));
   }
 
   @Operation(summary = "人工放行失败节点并继续执行后续节点")

--- a/yak-ops-business/yak-ops-business-workflow/src/main/java/io/yak/ops/business/workflow/controller/v1/WorkflowDefinitionController.java
+++ b/yak-ops-business/yak-ops-business-workflow/src/main/java/io/yak/ops/business/workflow/controller/v1/WorkflowDefinitionController.java
@@ -151,12 +151,18 @@ public class WorkflowDefinitionController {
   @Operation(summary = "暂停工作流最近一次执行")
   @PostMapping("/{id}/pause")
   public Result<WorkflowDefinitionVO> pause(@PathVariable("id") String id) {
-    return Result.success(definitionService.pause(id));
+    return Result.success(
+        definitionAudit == null
+            ? definitionService.pause(id)
+            : definitionAudit.pauseExecution(id));
   }
 
   @Operation(summary = "恢复工作流最近一次执行")
   @PostMapping("/{id}/resume")
   public Result<WorkflowDefinitionVO> resume(@PathVariable("id") String id) {
-    return Result.success(definitionService.resume(id));
+    return Result.success(
+        definitionAudit == null
+            ? definitionService.resume(id)
+            : definitionAudit.resumeExecution(id));
   }
 }

--- a/yak-ops-business/yak-ops-business-workflow/src/main/java/io/yak/ops/business/workflow/dao/WorkflowExecutionDao.java
+++ b/yak-ops-business/yak-ops-business-workflow/src/main/java/io/yak/ops/business/workflow/dao/WorkflowExecutionDao.java
@@ -32,6 +32,12 @@ public interface WorkflowExecutionDao {
 
   String selectEffectiveRuntimeMetadata(String executionId);
 
+  /** Cross-cutting correlation read; still scoped to the trusted CurrentProject. */
+  String selectAuditCarrierJson(String executionId);
+
+  /** Updates only audit_carrier_json and never rewrites Workflow runtime status/timestamps. */
+  int updateAuditCarrier(String executionId, String carrierJson);
+
   WorkflowNodeAttemptPO selectAttempt(String attemptId);
 
   int bindExternalExecution(String attemptId, String externalExecutionId);

--- a/yak-ops-business/yak-ops-business-workflow/src/main/java/io/yak/ops/business/workflow/dao/impl/WorkflowExecutionDaoImpl.java
+++ b/yak-ops-business/yak-ops-business-workflow/src/main/java/io/yak/ops/business/workflow/dao/impl/WorkflowExecutionDaoImpl.java
@@ -179,6 +179,16 @@ public class WorkflowExecutionDaoImpl implements WorkflowExecutionDao {
   }
 
   @Override
+  public String selectAuditCarrierJson(String executionId) {
+    return executionMapper.selectAuditCarrierJson(executionId, currentProjectId());
+  }
+
+  @Override
+  public int updateAuditCarrier(String executionId, String carrierJson) {
+    return executionMapper.updateAuditCarrier(executionId, currentProjectId(), carrierJson);
+  }
+
+  @Override
   public WorkflowNodeAttemptPO selectAttempt(String attemptId) {
     currentProjectId();
     WorkflowNodeAttemptPO attempt = nodeAttemptMapper.selectById(attemptId);

--- a/yak-ops-business/yak-ops-business-workflow/src/main/java/io/yak/ops/business/workflow/dao/mapper/WorkflowExecutionMapper.java
+++ b/yak-ops-business/yak-ops-business-workflow/src/main/java/io/yak/ops/business/workflow/dao/mapper/WorkflowExecutionMapper.java
@@ -23,4 +23,13 @@ public interface WorkflowExecutionMapper extends BaseMapper<WorkflowExecutionPO>
   String selectEffectiveRuntimeMetadata(
       @Param("executionId") String executionId,
       @Param("projectId") long projectId);
+
+  String selectAuditCarrierJson(
+      @Param("executionId") String executionId,
+      @Param("projectId") long projectId);
+
+  int updateAuditCarrier(
+      @Param("executionId") String executionId,
+      @Param("projectId") long projectId,
+      @Param("carrierJson") String carrierJson);
 }

--- a/yak-ops-business/yak-ops-business-workflow/src/main/java/io/yak/ops/business/workflow/definition/WorkflowDefinitionAuditCoordinator.java
+++ b/yak-ops-business/yak-ops-business-workflow/src/main/java/io/yak/ops/business/workflow/definition/WorkflowDefinitionAuditCoordinator.java
@@ -15,6 +15,7 @@ import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
+import java.util.function.Supplier;
 import org.springframework.beans.factory.ObjectProvider;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
@@ -24,6 +25,7 @@ import org.springframework.stereotype.Component;
 public class WorkflowDefinitionAuditCoordinator {
 
   private static final String RESOURCE_TYPE = "WORKFLOW";
+  private static final String EXECUTION_RESOURCE_TYPE = "WORKFLOW_EXECUTION";
   private static final String SOURCE = "WEB";
   private static final BusinessAuditService NOOP_AUDIT =
       request -> AuditOperationHandle.noop(null);
@@ -216,6 +218,28 @@ public class WorkflowDefinitionAuditCoordinator {
     }
   }
 
+  /** The editor-facing pause route controls the latest execution but keeps its original carrier. */
+  public WorkflowDefinitionVO pauseExecution(String workflowId) {
+    return controlExecution(
+        workflowId,
+        "WORKFLOW_EXECUTION_PAUSE",
+        "Pause workflow execution",
+        "EXECUTION_PAUSED",
+        "Workflow execution paused",
+        () -> definitions.pause(workflowId));
+  }
+
+  /** The editor-facing resume route controls the latest execution but keeps its original carrier. */
+  public WorkflowDefinitionVO resumeExecution(String workflowId) {
+    return controlExecution(
+        workflowId,
+        "WORKFLOW_EXECUTION_RESUME",
+        "Resume workflow execution",
+        "EXECUTION_RESUMED",
+        "Workflow execution resumed",
+        () -> definitions.resume(workflowId));
+  }
+
   public void delete(String id) {
     WorkflowDefinitionVO before = definitions.get(id);
     AuditOperationHandle audit =
@@ -242,6 +266,41 @@ public class WorkflowDefinitionAuditCoordinator {
     }
   }
 
+  private WorkflowDefinitionVO controlExecution(
+      String workflowId,
+      String operationType,
+      String operationName,
+      String changeType,
+      String message,
+      Supplier<WorkflowDefinitionVO> action) {
+    WorkflowDefinitionVO before = definitions.get(workflowId);
+    String executionId = trimToNull(before.latestExecutionId());
+    Map<String, Object> metadata = new LinkedHashMap<>();
+    metadata.put("workflowId", before.id());
+    putIfNotNull(metadata, "latestExecutionStatus", before.latestExecutionStatus());
+    AuditOperationHandle audit =
+        startExecution(
+            operationType,
+            operationName,
+            executionId,
+            before.name(),
+            Map.copyOf(metadata));
+    try {
+      WorkflowDefinitionVO updated = action.get();
+      Map<String, Object> payload = new LinkedHashMap<>();
+      payload.put("changeType", changeType);
+      payload.put("workflowId", before.id());
+      putIfNotNull(payload, "executionId", executionId);
+      putIfNotNull(payload, "status", updated.latestExecutionStatus());
+      audit.event(AuditEventType.RESOURCE_UPDATED, message, Map.copyOf(payload));
+      audit.success(message);
+      return updated;
+    } catch (RuntimeException exception) {
+      audit.failure(operationType + "_FAILED", exception);
+      throw exception;
+    }
+  }
+
   private AuditOperationHandle start(
       String operationType,
       String operationName,
@@ -254,6 +313,23 @@ public class WorkflowDefinitionAuditCoordinator {
             operationName,
             RESOURCE_TYPE,
             resourceId,
+            resourceName,
+            SOURCE,
+            metadata));
+  }
+
+  private AuditOperationHandle startExecution(
+      String operationType,
+      String operationName,
+      String executionId,
+      String resourceName,
+      Map<String, ?> metadata) {
+    return auditService.start(
+        new AuditOperationRequest(
+            operationType,
+            operationName,
+            EXECUTION_RESOURCE_TYPE,
+            executionId,
             resourceName,
             SOURCE,
             metadata));

--- a/yak-ops-business/yak-ops-business-workflow/src/main/java/io/yak/ops/business/workflow/execution/WorkflowExecutionAuditBridge.java
+++ b/yak-ops-business/yak-ops-business-workflow/src/main/java/io/yak/ops/business/workflow/execution/WorkflowExecutionAuditBridge.java
@@ -1,0 +1,408 @@
+package io.yak.ops.business.workflow.execution;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.yak.ops.business.audit.AuditCarrier;
+import io.yak.ops.business.audit.AuditContext;
+import io.yak.ops.business.audit.AuditEventCategory;
+import io.yak.ops.business.audit.AuditEventRequest;
+import io.yak.ops.business.audit.AuditEventStatus;
+import io.yak.ops.business.audit.AuditEventType;
+import io.yak.ops.business.audit.AuditOperationHandle;
+import io.yak.ops.business.audit.AuditOperationRequest;
+import io.yak.ops.business.audit.BusinessAuditService;
+import io.yak.ops.business.workflow.domain.WorkflowExecutionTerminalEvent;
+import io.yak.ops.business.workflow.domain.WorkflowTriggerContext;
+import io.yak.ops.business.workflow.domain.WorkflowTriggerType;
+import io.yak.ops.business.workflow.repository.WorkflowAuditCorrelationRepository;
+import java.util.LinkedHashMap;
+import java.util.Locale;
+import java.util.Map;
+import java.util.function.Supplier;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.ObjectProvider;
+import org.springframework.stereotype.Component;
+import org.springframework.util.StringUtils;
+
+/** Correlates one Workflow execution phase with a durable business AuditOperation. */
+@Component
+public class WorkflowExecutionAuditBridge {
+
+  private static final Logger log = LoggerFactory.getLogger(WorkflowExecutionAuditBridge.class);
+  private static final String RESOURCE_TYPE = "WORKFLOW_EXECUTION";
+  private static final BusinessAuditService NOOP_AUDIT =
+      request -> AuditOperationHandle.noop(null);
+
+  private final BusinessAuditService auditService;
+  private final WorkflowAuditCorrelationRepository correlationRepository;
+  private final ObjectMapper objectMapper;
+
+  public WorkflowExecutionAuditBridge(
+      ObjectProvider<BusinessAuditService> auditServiceProvider,
+      ObjectProvider<WorkflowAuditCorrelationRepository> correlationRepositoryProvider,
+      ObjectMapper objectMapper) {
+    this(
+        auditServiceProvider.getIfAvailable(() -> NOOP_AUDIT),
+        correlationRepositoryProvider.getIfAvailable(),
+        objectMapper);
+  }
+
+  WorkflowExecutionAuditBridge(
+      BusinessAuditService auditService,
+      WorkflowAuditCorrelationRepository correlationRepository,
+      ObjectMapper objectMapper) {
+    this.auditService = auditService == null ? NOOP_AUDIT : auditService;
+    this.correlationRepository = correlationRepository;
+    this.objectMapper = objectMapper == null ? new ObjectMapper() : objectMapper;
+  }
+
+  LaunchAudit beginLaunch(
+      String launchMode,
+      String target,
+      WorkflowTriggerContext triggerContext) {
+    String mode = required(launchMode, "launchMode must not be blank");
+    WorkflowTriggerContext trigger = java.util.Objects.requireNonNull(triggerContext, "triggerContext");
+    AuditOperationHandle handle =
+        auditService.start(
+            new AuditOperationRequest(
+                "WORKFLOW_EXECUTE",
+                operationName(mode),
+                RESOURCE_TYPE,
+                null,
+                trimToNull(target),
+                source(trigger.triggerType()),
+                launchMetadata(mode, target, trigger)));
+    return new LaunchAudit(handle, mode, trimToNull(target), trigger);
+  }
+
+  <T> T call(LaunchAudit audit, Supplier<T> action) {
+    java.util.Objects.requireNonNull(action, "action");
+    if (audit == null || audit.handle().carrier() == null) return action.get();
+    return AuditContext.call(audit.handle().carrier(), action);
+  }
+
+  void attachLaunch(LaunchAudit audit, String executionId, String resourceName) {
+    if (audit == null || !StringUtils.hasText(executionId)) return;
+    String id = executionId.trim();
+    String name = StringUtils.hasText(resourceName) ? resourceName.trim() : audit.target();
+    audit.handle().resource(id, name);
+    persistCarrier(id, audit.handle().carrier());
+    emitState(
+        audit.handle(),
+        id,
+        "started",
+        AuditEventStatus.INFO,
+        "EXECUTION_STARTED",
+        "Workflow execution started",
+        null,
+        Map.of(
+            "launchMode", audit.launchMode(),
+            "triggerType", audit.triggerContext().triggerType().name()));
+  }
+
+  void failLaunch(LaunchAudit audit, RuntimeException exception) {
+    if (audit != null) {
+      audit.handle().failure("WORKFLOW_EXECUTION_START_FAILED", exception);
+    }
+  }
+
+  /**
+   * A retry/continue reuses the same durable WorkflowExecution but represents a new actor action.
+   * Replace correlation before reactivation so a fast terminal transition belongs to the new actor.
+   */
+  <T> T reactivate(
+      String executionId,
+      String launchMode,
+      String nodeId,
+      Supplier<T> action) {
+    String id = required(executionId, "executionId must not be blank");
+    String mode = required(launchMode, "launchMode must not be blank");
+    java.util.Objects.requireNonNull(action, "action");
+
+    String previousCarrier = rawCarrier(id);
+    Map<String, Object> metadata = new LinkedHashMap<>();
+    metadata.put("launchMode", mode);
+    putIfNotNull(metadata, "nodeId", trimToNull(nodeId));
+    AuditOperationHandle handle =
+        auditService.start(
+            new AuditOperationRequest(
+                "WORKFLOW_EXECUTE",
+                operationName(mode),
+                RESOURCE_TYPE,
+                id,
+                id,
+                "WEB",
+                Map.copyOf(metadata)));
+    persistCarrier(id, handle.carrier());
+
+    Map<String, Object> started = new LinkedHashMap<>();
+    started.put("launchMode", mode);
+    putIfNotNull(started, "nodeId", trimToNull(nodeId));
+    emitState(
+        handle,
+        id,
+        "started",
+        AuditEventStatus.INFO,
+        "EXECUTION_STARTED",
+        "Workflow execution reactivated",
+        null,
+        Map.copyOf(started));
+
+    try {
+      AuditCarrier carrier = handle.carrier();
+      return carrier == null ? action.get() : AuditContext.call(carrier, action);
+    } catch (RuntimeException exception) {
+      restoreCarrier(id, previousCarrier);
+      handle.failure("WORKFLOW_EXECUTION_REACTIVATION_FAILED", exception);
+      throw exception;
+    }
+  }
+
+  /** AFTER_COMMIT projection from durable WorkflowExecution terminal truth. */
+  public void observeTerminal(WorkflowExecutionTerminalEvent event) {
+    if (event == null || !StringUtils.hasText(event.executionId())) return;
+    try {
+      String executionId = event.executionId().trim();
+      AuditCarrier carrier = storedCarrier(executionId);
+      if (carrier == null) carrier = AuditContext.current().orElse(null);
+      if (carrier == null) return;
+
+      AuditOperationHandle handle = auditService.resume(carrier);
+      String status = normalizeStatus(event.executionStatus());
+      switch (status) {
+        case "SUCCESS" -> {
+          terminalSuccess(handle, executionId, status, "Workflow execution succeeded");
+        }
+        case "SUCCESS_WITH_WARNINGS" -> {
+          terminalSuccess(handle, executionId, status, "Workflow execution succeeded with warnings");
+        }
+        case "CANCELED" -> {
+          terminalFailure(
+              handle,
+              executionId,
+              status,
+              "EXECUTION_CANCELED",
+              "Workflow execution canceled",
+              "WORKFLOW_EXECUTION_CANCELED");
+        }
+        case "TIMED_OUT" -> {
+          terminalFailure(
+              handle,
+              executionId,
+              status,
+              "EXECUTION_FAILED",
+              "Workflow execution timed out",
+              "WORKFLOW_EXECUTION_TIMED_OUT");
+        }
+        case "WARNING" -> {
+          terminalFailure(
+              handle,
+              executionId,
+              status,
+              "EXECUTION_FAILED",
+              "Workflow execution finished with warning state",
+              "WORKFLOW_EXECUTION_WARNING");
+        }
+        case "FAILED" -> {
+          terminalFailure(
+              handle,
+              executionId,
+              status,
+              "EXECUTION_FAILED",
+              "Workflow execution failed",
+              "WORKFLOW_EXECUTION_FAILED");
+        }
+        default -> {
+          // Only terminal vocabulary is projected; unknown future states remain fail-open.
+        }
+      }
+    } catch (RuntimeException exception) {
+      log.warn(
+          "Workflow audit terminal projection failed; runtime result is unchanged, executionId={}",
+          event.executionId(),
+          exception);
+    }
+  }
+
+  private void terminalSuccess(
+      AuditOperationHandle handle,
+      String executionId,
+      String status,
+      String summary) {
+    emitState(
+        handle,
+        executionId,
+        status.toLowerCase(Locale.ROOT),
+        AuditEventStatus.SUCCESS,
+        "EXECUTION_SUCCEEDED",
+        summary,
+        null,
+        Map.of("status", status));
+    handle.success(summary);
+  }
+
+  private void terminalFailure(
+      AuditOperationHandle handle,
+      String executionId,
+      String status,
+      String changeType,
+      String message,
+      String reasonCode) {
+    emitState(
+        handle,
+        executionId,
+        status.toLowerCase(Locale.ROOT),
+        AuditEventStatus.FAILURE,
+        changeType,
+        message,
+        reasonCode,
+        Map.of("status", status));
+    handle.failure(reasonCode, null);
+  }
+
+  private void emitState(
+      AuditOperationHandle handle,
+      String executionId,
+      String suffix,
+      AuditEventStatus status,
+      String changeType,
+      String message,
+      String reasonCode,
+      Map<String, ?> additionalPayload) {
+    Map<String, Object> payload = new LinkedHashMap<>();
+    payload.put("changeType", changeType);
+    payload.put("executionId", executionId);
+    if (additionalPayload != null) payload.putAll(additionalPayload);
+    handle.event(
+        new AuditEventRequest(
+            AuditEventType.RESOURCE_UPDATED,
+            AuditEventCategory.BUSINESS,
+            status,
+            eventKey(executionId, suffix),
+            RESOURCE_TYPE,
+            executionId,
+            message,
+            reasonCode,
+            Map.copyOf(payload)));
+  }
+
+  private void persistCarrier(String executionId, AuditCarrier carrier) {
+    if (carrier == null || correlationRepository == null) return;
+    try {
+      String value = objectMapper.writeValueAsString(carrier);
+      if (!correlationRepository.replaceCarrierJson(executionId, value)) {
+        log.warn("Unable to persist Workflow audit carrier, executionId={}", executionId);
+      }
+    } catch (JsonProcessingException | RuntimeException exception) {
+      log.warn(
+          "Workflow audit carrier persistence failed; execution will continue, executionId={}",
+          executionId,
+          exception);
+    }
+  }
+
+  private void restoreCarrier(String executionId, String previousCarrier) {
+    if (correlationRepository == null) return;
+    try {
+      if (!correlationRepository.replaceCarrierJson(executionId, previousCarrier)) {
+        log.warn("Unable to restore Workflow audit carrier, executionId={}", executionId);
+      }
+    } catch (RuntimeException exception) {
+      log.warn(
+          "Workflow audit carrier restore failed; business result is unchanged, executionId={}",
+          executionId,
+          exception);
+    }
+  }
+
+  private String rawCarrier(String executionId) {
+    if (correlationRepository == null) return null;
+    try {
+      return correlationRepository.findCarrierJson(executionId).orElse(null);
+    } catch (RuntimeException exception) {
+      log.warn("Unable to read Workflow audit carrier, executionId={}", executionId, exception);
+      return null;
+    }
+  }
+
+  private AuditCarrier storedCarrier(String executionId) {
+    String value = rawCarrier(executionId);
+    if (!StringUtils.hasText(value)) return null;
+    try {
+      return objectMapper.readValue(value, AuditCarrier.class);
+    } catch (JsonProcessingException exception) {
+      log.warn("Workflow audit carrier is invalid, executionId={}", executionId, exception);
+      return null;
+    }
+  }
+
+  private Map<String, Object> launchMetadata(
+      String launchMode,
+      String target,
+      WorkflowTriggerContext trigger) {
+    Map<String, Object> metadata = new LinkedHashMap<>();
+    metadata.put("launchMode", launchMode);
+    metadata.put("triggerType", trigger.triggerType().name());
+    putIfNotNull(metadata, "target", trimToNull(target));
+    putIfNotNull(metadata, "triggerId", trimToNull(trigger.triggerId()));
+    putIfNotNull(metadata, "scheduleId", trimToNull(trigger.scheduleId()));
+    putIfNotNull(metadata, "backfillId", trimToNull(trigger.backfillId()));
+    if (trigger.plannedFireTime() != null) {
+      metadata.put("plannedFireTime", trigger.plannedFireTime().toString());
+    }
+    putIfNotNull(metadata, "timezone", trimToNull(trigger.timezone()));
+    return Map.copyOf(metadata);
+  }
+
+  private String source(WorkflowTriggerType triggerType) {
+    return switch (triggerType) {
+      case MANUAL, RERUN -> "WEB";
+      case API -> "API";
+      case SCHEDULE -> "SCHEDULE";
+      case BACKFILL -> "BACKFILL";
+    };
+  }
+
+  private String operationName(String launchMode) {
+    return switch (launchMode) {
+      case "DRAFT_TEST" -> "Test workflow";
+      case "RESTART" -> "Restart workflow execution";
+      case "RERUN_FROM_NODE" -> "Rerun workflow from node";
+      case "CONTINUE_AFTER_FAILURE" -> "Continue workflow after failure";
+      case "RETRY_FAILED_NODE" -> "Retry failed workflow node";
+      case "RETRY_FAILED_NODES" -> "Retry failed workflow nodes";
+      default -> "Execute workflow";
+    };
+  }
+
+  private String eventKey(String executionId, String suffix) {
+    return "workflow:execution:" + executionId + ":" + suffix;
+  }
+
+  private String normalizeStatus(String value) {
+    return value == null ? "" : value.trim().toUpperCase(Locale.ROOT);
+  }
+
+  private String required(String value, String message) {
+    String normalized = trimToNull(value);
+    if (normalized == null) throw new IllegalArgumentException(message);
+    return normalized;
+  }
+
+  private String trimToNull(String value) {
+    if (value == null) return null;
+    String normalized = value.trim();
+    return normalized.isEmpty() ? null : normalized;
+  }
+
+  private void putIfNotNull(Map<String, Object> target, String key, Object value) {
+    if (value != null) target.put(key, value);
+  }
+
+  record LaunchAudit(
+      AuditOperationHandle handle,
+      String launchMode,
+      String target,
+      WorkflowTriggerContext triggerContext) {}
+}

--- a/yak-ops-business/yak-ops-business-workflow/src/main/java/io/yak/ops/business/workflow/execution/WorkflowExecutionAuditTerminalListener.java
+++ b/yak-ops-business/yak-ops-business-workflow/src/main/java/io/yak/ops/business/workflow/execution/WorkflowExecutionAuditTerminalListener.java
@@ -1,0 +1,27 @@
+package io.yak.ops.business.workflow.execution;
+
+import io.yak.ops.business.workflow.domain.WorkflowExecutionTerminalEvent;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.event.TransactionPhase;
+import org.springframework.transaction.event.TransactionalEventListener;
+
+/** Projects committed WorkflowExecution terminal truth into the durable business audit timeline. */
+@Component
+@ConditionalOnProperty(
+    prefix = "yak.database",
+    name = "enabled",
+    havingValue = "true",
+    matchIfMissing = true)
+public class WorkflowExecutionAuditTerminalListener {
+  private final WorkflowExecutionAuditBridge auditBridge;
+
+  public WorkflowExecutionAuditTerminalListener(WorkflowExecutionAuditBridge auditBridge) {
+    this.auditBridge = auditBridge;
+  }
+
+  @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT, fallbackExecution = true)
+  public void onTerminal(WorkflowExecutionTerminalEvent event) {
+    auditBridge.observeTerminal(event);
+  }
+}

--- a/yak-ops-business/yak-ops-business-workflow/src/main/java/io/yak/ops/business/workflow/execution/WorkflowExecutionControlAuditCoordinator.java
+++ b/yak-ops-business/yak-ops-business-workflow/src/main/java/io/yak/ops/business/workflow/execution/WorkflowExecutionControlAuditCoordinator.java
@@ -1,0 +1,121 @@
+package io.yak.ops.business.workflow.execution;
+
+import io.yak.ops.business.audit.AuditEventCategory;
+import io.yak.ops.business.audit.AuditEventRequest;
+import io.yak.ops.business.audit.AuditEventStatus;
+import io.yak.ops.business.audit.AuditEventType;
+import io.yak.ops.business.audit.AuditOperationHandle;
+import io.yak.ops.business.audit.AuditOperationRequest;
+import io.yak.ops.business.audit.BusinessAuditService;
+import io.yak.ops.business.workflow.runtime.WorkflowRuntime;
+import io.yak.ops.common.bean.vo.workflow.WorkflowInstanceVO;
+import java.util.Locale;
+import java.util.Map;
+import java.util.function.Supplier;
+import org.springframework.beans.factory.ObjectProvider;
+import org.springframework.stereotype.Component;
+
+/** Audits short actor-owned pause/resume/cancel commands without replacing execution correlation. */
+@Component
+public class WorkflowExecutionControlAuditCoordinator {
+
+  private static final BusinessAuditService NOOP_AUDIT =
+      request -> AuditOperationHandle.noop(null);
+
+  private final WorkflowRuntime runtime;
+  private final BusinessAuditService auditService;
+
+  public WorkflowExecutionControlAuditCoordinator(
+      WorkflowRuntime runtime,
+      ObjectProvider<BusinessAuditService> auditServiceProvider) {
+    this(runtime, auditServiceProvider.getIfAvailable(() -> NOOP_AUDIT));
+  }
+
+  WorkflowExecutionControlAuditCoordinator(
+      WorkflowRuntime runtime,
+      BusinessAuditService auditService) {
+    this.runtime = runtime;
+    this.auditService = auditService == null ? NOOP_AUDIT : auditService;
+  }
+
+  public WorkflowInstanceVO pause(String executionId) {
+    String id = required(executionId);
+    return control(
+        "WORKFLOW_EXECUTION_PAUSE",
+        "Pause workflow execution",
+        "EXECUTION_PAUSED",
+        "Workflow execution paused",
+        id,
+        () -> runtime.pause(id));
+  }
+
+  public WorkflowInstanceVO resume(String executionId) {
+    String id = required(executionId);
+    return control(
+        "WORKFLOW_EXECUTION_RESUME",
+        "Resume workflow execution",
+        "EXECUTION_RESUMED",
+        "Workflow execution resumed",
+        id,
+        () -> runtime.resume(id));
+  }
+
+  public WorkflowInstanceVO cancel(String executionId) {
+    String id = required(executionId);
+    return control(
+        "WORKFLOW_EXECUTION_CANCEL",
+        "Cancel workflow execution",
+        "EXECUTION_CANCEL_REQUESTED",
+        "Workflow execution cancellation requested",
+        id,
+        () -> runtime.cancel(id));
+  }
+
+  private <T> T control(
+      String operationType,
+      String operationName,
+      String changeType,
+      String message,
+      String executionId,
+      Supplier<T> action) {
+    AuditOperationHandle audit =
+        auditService.start(
+            new AuditOperationRequest(
+                operationType,
+                operationName,
+                "WORKFLOW_EXECUTION",
+                executionId,
+                executionId,
+                "WEB",
+                Map.of("controlType", changeType)));
+    try {
+      T result = action.get();
+      audit.event(
+          new AuditEventRequest(
+              AuditEventType.RESOURCE_UPDATED,
+              AuditEventCategory.BUSINESS,
+              AuditEventStatus.SUCCESS,
+              "workflow:execution:"
+                  + executionId
+                  + ":control:"
+                  + changeType.toLowerCase(Locale.ROOT),
+              "WORKFLOW_EXECUTION",
+              executionId,
+              message,
+              null,
+              Map.of("changeType", changeType, "executionId", executionId)));
+      audit.success(message);
+      return result;
+    } catch (RuntimeException exception) {
+      audit.failure(operationType + "_FAILED", exception);
+      throw exception;
+    }
+  }
+
+  private String required(String executionId) {
+    if (executionId == null || executionId.isBlank()) {
+      throw new IllegalArgumentException("工作流实例 ID 不能为空");
+    }
+    return executionId.trim();
+  }
+}

--- a/yak-ops-business/yak-ops-business-workflow/src/main/java/io/yak/ops/business/workflow/execution/WorkflowExecutionReactivator.java
+++ b/yak-ops-business/yak-ops-business-workflow/src/main/java/io/yak/ops/business/workflow/execution/WorkflowExecutionReactivator.java
@@ -4,6 +4,7 @@ import io.yak.ops.business.workflow.runtime.WorkflowRuntime;
 import io.yak.ops.common.bean.vo.workflow.WorkflowInstanceVO;
 import java.util.function.Supplier;
 import org.springframework.beans.factory.ObjectProvider;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 
 /**
@@ -17,12 +18,25 @@ import org.springframework.stereotype.Service;
 public class WorkflowExecutionReactivator {
   private final WorkflowRuntime runtime;
   private final ObjectProvider<WorkflowExecutionReactivationGuard> guard;
+  private final WorkflowExecutionAuditBridge auditBridge;
 
+  @Autowired
+  public WorkflowExecutionReactivator(
+      WorkflowRuntime runtime,
+      ObjectProvider<WorkflowExecutionReactivationGuard> guard,
+      ObjectProvider<WorkflowExecutionAuditBridge> auditBridgeProvider) {
+    this.runtime = runtime;
+    this.guard = guard;
+    this.auditBridge = auditBridgeProvider.getIfAvailable();
+  }
+
+  /** Focused compatibility constructor without Audit wiring. */
   public WorkflowExecutionReactivator(
       WorkflowRuntime runtime,
       ObjectProvider<WorkflowExecutionReactivationGuard> guard) {
     this.runtime = runtime;
     this.guard = guard;
+    this.auditBridge = null;
   }
 
   public WorkflowInstanceVO continueAfterFailure(String executionId, String nodeId) {
@@ -31,6 +45,7 @@ public class WorkflowExecutionReactivator {
     return reactivate(
         id,
         "CONTINUE_AFTER_FAILURE",
+        node,
         () -> runtime.continueAfterFailure(id, node));
   }
 
@@ -40,6 +55,7 @@ public class WorkflowExecutionReactivator {
     return reactivate(
         id,
         "RETRY_FAILED_NODE",
+        node,
         () -> runtime.retryFailedNode(id, node));
   }
 
@@ -48,16 +64,22 @@ public class WorkflowExecutionReactivator {
     return reactivate(
         id,
         "RETRY_FAILED_NODES",
+        null,
         () -> runtime.retryFailedNodes(id));
   }
 
   private WorkflowInstanceVO reactivate(
       String executionId,
       String operation,
+      String nodeId,
       Supplier<WorkflowInstanceVO> action) {
-    WorkflowExecutionReactivationGuard value = guard.getIfAvailable();
-    if (value == null) return action.get();
-    return value.reactivateExecution(executionId, operation, action);
+    Supplier<WorkflowInstanceVO> guarded = () -> {
+      WorkflowExecutionReactivationGuard value = guard.getIfAvailable();
+      if (value == null) return action.get();
+      return value.reactivateExecution(executionId, operation, action);
+    };
+    if (auditBridge == null) return guarded.get();
+    return auditBridge.reactivate(executionId, operation, nodeId, guarded);
   }
 
   private String required(String value, String message) {

--- a/yak-ops-business/yak-ops-business-workflow/src/main/java/io/yak/ops/business/workflow/execution/WorkflowLauncher.java
+++ b/yak-ops-business/yak-ops-business-workflow/src/main/java/io/yak/ops/business/workflow/execution/WorkflowLauncher.java
@@ -28,17 +28,29 @@ public class WorkflowLauncher {
   private final WorkflowRuntime runtimeService;
   private final WorkflowExecutionTriggerRecorder triggerRecorder;
   private final WorkflowPublishedVersionRunner publishedVersionRunner;
+  private final WorkflowExecutionAuditBridge auditBridge;
 
   @Autowired
   public WorkflowLauncher(
       WorkflowDefinitionManager definitionService,
       WorkflowRuntime runtimeService,
       WorkflowExecutionTriggerRecorder triggerRecorder,
-      WorkflowPublishedVersionRunner publishedVersionRunner) {
+      WorkflowPublishedVersionRunner publishedVersionRunner,
+      WorkflowExecutionAuditBridge auditBridge) {
     this.definitionService = definitionService;
     this.runtimeService = runtimeService;
     this.triggerRecorder = triggerRecorder;
     this.publishedVersionRunner = publishedVersionRunner;
+    this.auditBridge = auditBridge;
+  }
+
+  /** Focused tests retain the previous constructor without Audit wiring. */
+  public WorkflowLauncher(
+      WorkflowDefinitionManager definitionService,
+      WorkflowRuntime runtimeService,
+      WorkflowExecutionTriggerRecorder triggerRecorder,
+      WorkflowPublishedVersionRunner publishedVersionRunner) {
+    this(definitionService, runtimeService, triggerRecorder, publishedVersionRunner, null);
   }
 
   /** Focused tests retain the lightweight constructor without pinned-version wiring. */
@@ -46,7 +58,7 @@ public class WorkflowLauncher {
       WorkflowDefinitionManager definitionService,
       WorkflowRuntime runtimeService,
       WorkflowExecutionTriggerRecorder triggerRecorder) {
-    this(definitionService, runtimeService, triggerRecorder, null);
+    this(definitionService, runtimeService, triggerRecorder, null, null);
   }
 
   /** 正式执行当前启用的已发布版本；手工/API 启动仍保持单实例安全默认。 */
@@ -59,7 +71,8 @@ public class WorkflowLauncher {
         id,
         triggerContext,
         () -> definitionService.run(id),
-        WorkflowDefinitionVO::latestExecutionId);
+        WorkflowDefinitionVO::latestExecutionId,
+        WorkflowDefinitionVO::name);
   }
 
   public WorkflowDefinitionVO runScheduledPublished(
@@ -81,7 +94,8 @@ public class WorkflowLauncher {
           id,
           triggerContext,
           () -> definitionService.runConcurrent(id),
-          WorkflowDefinitionVO::latestExecutionId);
+          WorkflowDefinitionVO::latestExecutionId,
+          WorkflowDefinitionVO::name);
     }
   }
 
@@ -133,7 +147,8 @@ public class WorkflowLauncher {
           workflowId + "@" + workflowVersionId,
           triggerContext,
           () -> publishedVersionRunner.run(workflowId, workflowVersionId),
-          WorkflowInstanceVO::id);
+          WorkflowInstanceVO::id,
+          WorkflowInstanceVO::name);
     }
   }
 
@@ -147,7 +162,8 @@ public class WorkflowLauncher {
         id,
         triggerContext,
         () -> definitionService.testRun(id),
-        WorkflowDefinitionVO::latestExecutionId);
+        WorkflowDefinitionVO::latestExecutionId,
+        WorkflowDefinitionVO::name);
   }
 
   /** 兼容直接提交 DAG 的底层运行接口，同时纳入统一 Trigger 入口并真正激活实例。 */
@@ -203,6 +219,7 @@ public class WorkflowLauncher {
         triggerContext,
         prepare,
         WorkflowInstanceVO::id,
+        WorkflowInstanceVO::name,
         prepared -> runtimeService.activate(prepared.id()));
   }
 
@@ -211,8 +228,16 @@ public class WorkflowLauncher {
       String target,
       WorkflowTriggerContext triggerContext,
       Supplier<T> action,
-      Function<T, String> executionIdExtractor) {
-    return launch(mode, target, triggerContext, action, executionIdExtractor, Function.identity());
+      Function<T, String> executionIdExtractor,
+      Function<T, String> resourceNameExtractor) {
+    return launch(
+        mode,
+        target,
+        triggerContext,
+        action,
+        executionIdExtractor,
+        resourceNameExtractor,
+        Function.identity());
   }
 
   private <T> T launch(
@@ -221,8 +246,11 @@ public class WorkflowLauncher {
       WorkflowTriggerContext triggerContext,
       Supplier<T> action,
       Function<T, String> executionIdExtractor,
+      Function<T, String> resourceNameExtractor,
       Function<T, T> afterRecord) {
     Objects.requireNonNull(triggerContext, "workflow trigger context");
+    WorkflowExecutionAuditBridge.LaunchAudit audit =
+        auditBridge == null ? null : auditBridge.beginLaunch(mode, target, triggerContext);
     log.info(
         "[workflow-launch] start mode={}, target={}, triggerType={}, triggerId={}, scheduleId={}, backfillId={}, plannedFireTime={}",
         mode,
@@ -233,8 +261,11 @@ public class WorkflowLauncher {
         triggerContext.backfillId(),
         triggerContext.plannedFireTime());
     try {
-      T prepared = action.get();
+      T prepared =
+          auditBridge == null ? action.get() : auditBridge.call(audit, action);
       String executionId = prepared == null ? null : executionIdExtractor.apply(prepared);
+      String resourceName = prepared == null ? null : resourceNameExtractor.apply(prepared);
+      if (auditBridge != null) auditBridge.attachLaunch(audit, executionId, resourceName);
       triggerRecorder.record(executionId, triggerContext);
       log.info(
           "[workflow-launch] created mode={}, target={}, triggerType={}, triggerId={}, execution={}",
@@ -245,6 +276,7 @@ public class WorkflowLauncher {
           executionId);
       return prepared == null ? null : afterRecord.apply(prepared);
     } catch (RuntimeException exception) {
+      if (auditBridge != null) auditBridge.failLaunch(audit, exception);
       log.warn(
           "[workflow-launch] failed mode={}, target={}, triggerType={}, triggerId={}, message={}",
           mode,

--- a/yak-ops-business/yak-ops-business-workflow/src/main/java/io/yak/ops/business/workflow/repository/WorkflowAuditCorrelationRepository.java
+++ b/yak-ops-business/yak-ops-business-workflow/src/main/java/io/yak/ops/business/workflow/repository/WorkflowAuditCorrelationRepository.java
@@ -1,0 +1,12 @@
+package io.yak.ops.business.workflow.repository;
+
+import java.util.Optional;
+
+/** Narrow persistence port for durable WorkflowExecution -> AuditCarrier correlation. */
+public interface WorkflowAuditCorrelationRepository {
+
+  Optional<String> findCarrierJson(String executionId);
+
+  /** Replaces the frozen carrier. A null value clears correlation after a failed reactivation. */
+  boolean replaceCarrierJson(String executionId, String carrierJson);
+}

--- a/yak-ops-business/yak-ops-business-workflow/src/main/java/io/yak/ops/business/workflow/repository/WorkflowAuditCorrelationRepositoryAdapter.java
+++ b/yak-ops-business/yak-ops-business-workflow/src/main/java/io/yak/ops/business/workflow/repository/WorkflowAuditCorrelationRepositoryAdapter.java
@@ -1,0 +1,38 @@
+package io.yak.ops.business.workflow.repository;
+
+import io.yak.ops.business.workflow.dao.WorkflowExecutionDao;
+import java.util.Optional;
+import lombok.RequiredArgsConstructor;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.context.annotation.DependsOn;
+import org.springframework.stereotype.Repository;
+import org.springframework.util.StringUtils;
+
+/** Stores AuditCarrier correlation without rewriting Workflow runtime truth. */
+@Repository
+@RequiredArgsConstructor
+@DependsOn("workflowFlyway")
+@ConditionalOnProperty(
+    prefix = "yak.database",
+    name = "enabled",
+    havingValue = "true",
+    matchIfMissing = true)
+public class WorkflowAuditCorrelationRepositoryAdapter
+    implements WorkflowAuditCorrelationRepository {
+
+  private final WorkflowExecutionDao executionDao;
+
+  @Override
+  public Optional<String> findCarrierJson(String executionId) {
+    if (!StringUtils.hasText(executionId)) return Optional.empty();
+    String value = executionDao.selectAuditCarrierJson(executionId.trim());
+    return StringUtils.hasText(value) ? Optional.of(value.trim()) : Optional.empty();
+  }
+
+  @Override
+  public boolean replaceCarrierJson(String executionId, String carrierJson) {
+    if (!StringUtils.hasText(executionId)) return false;
+    String normalized = StringUtils.hasText(carrierJson) ? carrierJson.trim() : null;
+    return executionDao.updateAuditCarrier(executionId.trim(), normalized) == 1;
+  }
+}

--- a/yak-ops-business/yak-ops-business-workflow/src/main/resources/db/migration/yak-workflow/V2__add_execution_audit_carrier.sql
+++ b/yak-ops-business/yak-ops-business-workflow/src/main/resources/db/migration/yak-workflow/V2__add_execution_audit_carrier.sql
@@ -1,0 +1,4 @@
+-- Durable cross-thread correlation for Workflow business audit.
+-- Historical executions are intentionally not backfilled with fabricated audit operations.
+ALTER TABLE yak_workflow_execution
+    ADD COLUMN audit_carrier_json LONGTEXT NULL AFTER runtime_metadata_json;

--- a/yak-ops-business/yak-ops-business-workflow/src/main/resources/mapper/workflow/WorkflowExecutionMapper.xml
+++ b/yak-ops-business/yak-ops-business-workflow/src/main/resources/mapper/workflow/WorkflowExecutionMapper.xml
@@ -73,4 +73,18 @@
     WHERE e.id = #{executionId}
       AND e.project_id = #{projectId}
   </select>
+
+  <select id="selectAuditCarrierJson" resultType="java.lang.String">
+    SELECT audit_carrier_json
+    FROM yak_workflow_execution
+    WHERE id = #{executionId}
+      AND project_id = #{projectId}
+  </select>
+
+  <update id="updateAuditCarrier">
+    UPDATE yak_workflow_execution
+    SET audit_carrier_json = #{carrierJson}
+    WHERE id = #{executionId}
+      AND project_id = #{projectId}
+  </update>
 </mapper>

--- a/yak-ops-business/yak-ops-business-workflow/src/test/java/io/yak/ops/business/workflow/architecture/WorkflowAuditCorrelationSchemaContractTest.java
+++ b/yak-ops-business/yak-ops-business-workflow/src/test/java/io/yak/ops/business/workflow/architecture/WorkflowAuditCorrelationSchemaContractTest.java
@@ -1,0 +1,61 @@
+package io.yak.ops.business.workflow.architecture;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.charset.StandardCharsets;
+import java.util.Locale;
+import org.junit.jupiter.api.Test;
+
+class WorkflowAuditCorrelationSchemaContractTest {
+
+  @Test
+  void v2AddsOnlyNullableExecutionAuditCarrierWithoutBackfill() throws IOException {
+    String baseline = resource("db/migration/yak-workflow/V1__baseline_workflow.sql");
+    String migration = resource("db/migration/yak-workflow/V2__add_execution_audit_carrier.sql");
+    String upper = migration.toUpperCase(Locale.ROOT);
+
+    assertThat(baseline).doesNotContain("audit_carrier_json");
+    assertThat(migration)
+        .contains("ALTER TABLE yak_workflow_execution")
+        .contains("ADD COLUMN audit_carrier_json LONGTEXT NULL");
+    assertThat(upper)
+        .doesNotContain("UPDATE YAK_WORKFLOW_EXECUTION")
+        .doesNotContain("INSERT INTO YAK_WORKFLOW_EXECUTION")
+        .doesNotContain("DELETE FROM YAK_WORKFLOW_EXECUTION");
+  }
+
+  @Test
+  void correlationMapperStaysProjectScopedAndDoesNotRewriteRuntimeTruth() throws IOException {
+    String mapper = resource("mapper/workflow/WorkflowExecutionMapper.xml");
+    String update = between(mapper, "<update id=\"updateAuditCarrier\">", "</update>");
+    String select = between(mapper, "<select id=\"selectAuditCarrierJson\"", "</select>");
+
+    assertThat(update)
+        .contains("audit_carrier_json = #{carrierJson}")
+        .contains("id = #{executionId}")
+        .contains("project_id = #{projectId}")
+        .doesNotContain("status =")
+        .doesNotContain("updated_at =")
+        .doesNotContain("runtime_metadata_json =");
+    assertThat(select)
+        .contains("audit_carrier_json")
+        .contains("project_id = #{projectId}");
+  }
+
+  private String resource(String path) throws IOException {
+    try (InputStream input = Thread.currentThread().getContextClassLoader().getResourceAsStream(path)) {
+      if (input == null) throw new IllegalStateException("Missing test resource: " + path);
+      return new String(input.readAllBytes(), StandardCharsets.UTF_8);
+    }
+  }
+
+  private String between(String value, String startMarker, String endMarker) {
+    int start = value.indexOf(startMarker);
+    assertThat(start).as("start marker %s", startMarker).isGreaterThanOrEqualTo(0);
+    int end = value.indexOf(endMarker, start);
+    assertThat(end).as("end marker %s", endMarker).isGreaterThan(start);
+    return value.substring(start, end + endMarker.length());
+  }
+}

--- a/yak-ops-business/yak-ops-business-workflow/src/test/java/io/yak/ops/business/workflow/architecture/WorkflowLayeringConventionTest.java
+++ b/yak-ops-business/yak-ops-business-workflow/src/test/java/io/yak/ops/business/workflow/architecture/WorkflowLayeringConventionTest.java
@@ -8,6 +8,7 @@ import io.yak.ops.business.workflow.dao.WorkflowCatalogDao;
 import io.yak.ops.business.workflow.dao.WorkflowExecutionDao;
 import io.yak.ops.business.workflow.dao.WorkflowScheduleDao;
 import io.yak.ops.business.workflow.dao.WorkflowScheduleTriggerDao;
+import io.yak.ops.business.workflow.repository.WorkflowAuditCorrelationRepository;
 import io.yak.ops.business.workflow.repository.WorkflowDefinitionRepository;
 import io.yak.ops.business.workflow.repository.WorkflowRuntimeRepository;
 import io.yak.ops.common.bean.po.workflow.WorkflowBackfillPO;
@@ -27,7 +28,10 @@ class WorkflowLayeringConventionTest {
   @Test
   void repositoryBoundariesDoNotExposeHttpOrPersistenceContracts() {
     assertCleanRepositoryBoundary(
-        List.of(WorkflowDefinitionRepository.class, WorkflowRuntimeRepository.class));
+        List.of(
+            WorkflowDefinitionRepository.class,
+            WorkflowRuntimeRepository.class,
+            WorkflowAuditCorrelationRepository.class));
   }
 
   @Test

--- a/yak-ops-business/yak-ops-business-workflow/src/test/java/io/yak/ops/business/workflow/architecture/WorkflowRoleConventionTest.java
+++ b/yak-ops-business/yak-ops-business-workflow/src/test/java/io/yak/ops/business/workflow/architecture/WorkflowRoleConventionTest.java
@@ -9,6 +9,9 @@ import io.yak.ops.business.workflow.backfill.WorkflowBackfillReconciler;
 import io.yak.ops.business.workflow.backfill.WorkflowBackfillTriggerAdapter;
 import io.yak.ops.business.workflow.definition.WorkflowDefinitionAuditCoordinator;
 import io.yak.ops.business.workflow.definition.WorkflowDefinitionManager;
+import io.yak.ops.business.workflow.execution.WorkflowExecutionAuditBridge;
+import io.yak.ops.business.workflow.execution.WorkflowExecutionAuditTerminalListener;
+import io.yak.ops.business.workflow.execution.WorkflowExecutionControlAuditCoordinator;
 import io.yak.ops.business.workflow.execution.WorkflowExecutionManager;
 import io.yak.ops.business.workflow.execution.WorkflowExecutionReactivator;
 import io.yak.ops.business.workflow.execution.WorkflowLauncher;
@@ -50,6 +53,9 @@ class WorkflowRoleConventionTest {
   void internalRolesRemainExplicitComponents() {
     for (Class<?> role : List.of(
         WorkflowDefinitionAuditCoordinator.class,
+        WorkflowExecutionAuditBridge.class,
+        WorkflowExecutionAuditTerminalListener.class,
+        WorkflowExecutionControlAuditCoordinator.class,
         WorkflowPublishedVersionRunner.class,
         WorkflowRuntimeRecovery.class,
         WorkflowEventStream.class,

--- a/yak-ops-business/yak-ops-business-workflow/src/test/java/io/yak/ops/business/workflow/definition/WorkflowDefinitionAuditCoordinatorTest.java
+++ b/yak-ops-business/yak-ops-business-workflow/src/test/java/io/yak/ops/business/workflow/definition/WorkflowDefinitionAuditCoordinatorTest.java
@@ -139,6 +139,31 @@ class WorkflowDefinitionAuditCoordinatorTest {
   }
 
   @Test
+  void editorPauseAuditsLatestExecutionInsteadOfOnlyWorkflowDefinition() {
+    WorkflowDefinitionManager definitions = mock(WorkflowDefinitionManager.class);
+    RecordingAuditService audit = new RecordingAuditService();
+    WorkflowDefinitionAuditCoordinator coordinator =
+        new WorkflowDefinitionAuditCoordinator(definitions, audit);
+    WorkflowDefinitionVO before = workflowWithExecution("RUNNING");
+    WorkflowDefinitionVO after = workflowWithExecution("PAUSED");
+    when(definitions.get("wf-1")).thenReturn(before);
+    when(definitions.pause("wf-1")).thenReturn(after);
+
+    WorkflowDefinitionVO result = coordinator.pauseExecution("wf-1");
+
+    assertThat(result).isSameAs(after);
+    assertThat(audit.request.operationType()).isEqualTo("WORKFLOW_EXECUTION_PAUSE");
+    assertThat(audit.request.resourceType()).isEqualTo("WORKFLOW_EXECUTION");
+    assertThat(audit.request.resourceId()).isEqualTo("execution-1");
+    assertThat(audit.handle.events).singleElement().satisfies(event -> {
+      assertThat(event.payload())
+          .containsEntry("changeType", "EXECUTION_PAUSED")
+          .containsEntry("executionId", "execution-1")
+          .containsEntry("status", "PAUSED");
+    });
+  }
+
+  @Test
   void deleteFailureClosesAuditAsFailedWithoutChangingBusinessException() {
     WorkflowDefinitionManager definitions = mock(WorkflowDefinitionManager.class);
     RecordingAuditService audit = new RecordingAuditService();
@@ -164,6 +189,41 @@ class WorkflowDefinitionAuditCoordinatorTest {
       Map<String, Object> input,
       Map<String, Object> editorMeta,
       List<NodeVO> nodes) {
+    return workflow(
+        status,
+        activeVersionId,
+        activeVersionNo,
+        draftChanged,
+        input,
+        editorMeta,
+        nodes,
+        null,
+        null);
+  }
+
+  private static WorkflowDefinitionVO workflowWithExecution(String executionStatus) {
+    return workflow(
+        "ONLINE",
+        "wv-1",
+        1,
+        false,
+        Map.of(),
+        Map.of(),
+        List.of(),
+        "execution-1",
+        executionStatus);
+  }
+
+  private static WorkflowDefinitionVO workflow(
+      String status,
+      String activeVersionId,
+      Integer activeVersionNo,
+      boolean draftChanged,
+      Map<String, Object> input,
+      Map<String, Object> editorMeta,
+      List<NodeVO> nodes,
+      String latestExecutionId,
+      String latestExecutionStatus) {
     Instant now = Instant.parse("2026-09-02T00:00:00Z");
     return new WorkflowDefinitionVO(
         "wf-1",
@@ -182,8 +242,8 @@ class WorkflowDefinitionAuditCoordinatorTest {
         activeVersionNo,
         activeVersionNo == null ? 0 : activeVersionNo,
         draftChanged,
-        null,
-        null,
+        latestExecutionId,
+        latestExecutionStatus,
         now,
         now);
   }

--- a/yak-ops-business/yak-ops-business-workflow/src/test/java/io/yak/ops/business/workflow/execution/WorkflowExecutionAuditBridgeTest.java
+++ b/yak-ops-business/yak-ops-business-workflow/src/test/java/io/yak/ops/business/workflow/execution/WorkflowExecutionAuditBridgeTest.java
@@ -1,0 +1,246 @@
+package io.yak.ops.business.workflow.execution;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.yak.ops.business.audit.AuditCarrier;
+import io.yak.ops.business.audit.AuditContext;
+import io.yak.ops.business.audit.AuditEventRequest;
+import io.yak.ops.business.audit.AuditEventType;
+import io.yak.ops.business.audit.AuditOperationHandle;
+import io.yak.ops.business.audit.AuditOperationRequest;
+import io.yak.ops.business.audit.BusinessAuditService;
+import io.yak.ops.business.workflow.domain.WorkflowExecutionTerminalEvent;
+import io.yak.ops.business.workflow.domain.WorkflowTriggerContext;
+import io.yak.ops.business.workflow.repository.WorkflowAuditCorrelationRepository;
+import java.time.Instant;
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import org.junit.jupiter.api.Test;
+
+class WorkflowExecutionAuditBridgeTest {
+
+  private final ObjectMapper objectMapper = new ObjectMapper();
+  private final RecordingAuditService auditService = new RecordingAuditService();
+  private final InMemoryCorrelationRepository correlation = new InMemoryCorrelationRepository();
+  private final WorkflowExecutionAuditBridge bridge =
+      new WorkflowExecutionAuditBridge(auditService, correlation, objectMapper);
+
+  @Test
+  void launchFreezesCarrierAndCompletesFromDurableTerminalTruth() throws Exception {
+    WorkflowExecutionAuditBridge.LaunchAudit launch =
+        bridge.beginLaunch("PUBLISHED", "workflow-1", WorkflowTriggerContext.manual());
+
+    String activeOperation = bridge.call(
+        launch,
+        () -> AuditContext.current().orElseThrow().operationId());
+    assertThat(activeOperation).isEqualTo("AUD-1");
+
+    bridge.attachLaunch(launch, "execution-1", "订单同步");
+    AuditCarrier stored = objectMapper.readValue(
+        correlation.findCarrierJson("execution-1").orElseThrow(), AuditCarrier.class);
+    assertThat(stored.operationId()).isEqualTo("AUD-1");
+    assertThat(stored.resourceId()).isEqualTo("execution-1");
+    assertThat(stored.actorName()).isEqualTo("alice");
+
+    bridge.observeTerminal(new WorkflowExecutionTerminalEvent(
+        "execution-1", "SUCCESS", Instant.parse("2026-09-02T07:30:00Z")));
+
+    RecordingHandle handle = auditService.handle("AUD-1");
+    assertThat(handle.successSummary).isEqualTo("Workflow execution succeeded");
+    assertThat(changeTypes(handle.events))
+        .containsExactly("EXECUTION_STARTED", "EXECUTION_SUCCEEDED");
+    assertThat(handle.events)
+        .allSatisfy(event -> assertThat(event.payload()).doesNotContainKeys("input", "output", "errorMessage"));
+  }
+
+  @Test
+  void reactivationReplacesOldActorCorrelationBeforeActionRuns() throws Exception {
+    AuditCarrier previous = new AuditCarrier(
+        "AUD-OLD",
+        "user-old",
+        "alice-old",
+        "USER",
+        7L,
+        "Project A",
+        "WORKFLOW_EXECUTION",
+        "execution-2",
+        "订单同步",
+        "WEB");
+    correlation.replaceCarrierJson("execution-2", objectMapper.writeValueAsString(previous));
+
+    String activeOperation = bridge.reactivate(
+        "execution-2",
+        "RETRY_FAILED_NODE",
+        "node-1",
+        () -> AuditContext.current().orElseThrow().operationId());
+
+    assertThat(activeOperation).isEqualTo("AUD-1");
+    AuditCarrier stored = objectMapper.readValue(
+        correlation.findCarrierJson("execution-2").orElseThrow(), AuditCarrier.class);
+    assertThat(stored.operationId()).isEqualTo("AUD-1");
+    assertThat(stored.actorName()).isEqualTo("alice");
+    assertThat(auditService.requests.getFirst().metadata())
+        .containsEntry("launchMode", "RETRY_FAILED_NODE")
+        .containsEntry("nodeId", "node-1");
+
+    bridge.observeTerminal(new WorkflowExecutionTerminalEvent(
+        "execution-2", "SUCCESS", Instant.parse("2026-09-02T07:31:00Z")));
+    assertThat(auditService.handle("AUD-1").successSummary)
+        .isEqualTo("Workflow execution succeeded");
+  }
+
+  @Test
+  void failedReactivationRestoresPreviousCarrierAndKeepsBusinessException() throws Exception {
+    AuditCarrier previous = new AuditCarrier(
+        "AUD-OLD",
+        "user-old",
+        "alice-old",
+        "USER",
+        7L,
+        "Project A",
+        "WORKFLOW_EXECUTION",
+        "execution-3",
+        "订单同步",
+        "WEB");
+    String previousJson = objectMapper.writeValueAsString(previous);
+    correlation.replaceCarrierJson("execution-3", previousJson);
+    IllegalStateException failure = new IllegalStateException("runtime rejected reactivation");
+
+    assertThatThrownBy(() -> bridge.reactivate(
+            "execution-3",
+            "CONTINUE_AFTER_FAILURE",
+            "node-2",
+            () -> {
+              throw failure;
+            }))
+        .isSameAs(failure);
+
+    assertThat(correlation.findCarrierJson("execution-3")).contains(previousJson);
+    assertThat(auditService.handle("AUD-1").failureReason)
+        .isEqualTo("WORKFLOW_EXECUTION_REACTIVATION_FAILED");
+  }
+
+  @Test
+  void canceledTerminalUsesStableReasonWithoutRuntimeErrorText() {
+    WorkflowExecutionAuditBridge.LaunchAudit launch =
+        bridge.beginLaunch("DRAFT_TEST", "workflow-4", WorkflowTriggerContext.manual());
+    bridge.attachLaunch(launch, "execution-4", "测试工作流");
+
+    bridge.observeTerminal(new WorkflowExecutionTerminalEvent(
+        "execution-4", "CANCELED", Instant.parse("2026-09-02T07:32:00Z")));
+
+    RecordingHandle handle = auditService.handle("AUD-1");
+    assertThat(handle.failureReason).isEqualTo("WORKFLOW_EXECUTION_CANCELED");
+    AuditEventRequest terminal = handle.events.getLast();
+    assertThat(terminal.reasonCode()).isEqualTo("WORKFLOW_EXECUTION_CANCELED");
+    assertThat(terminal.payload()).containsOnlyKeys("changeType", "executionId", "status");
+  }
+
+  private List<String> changeTypes(List<AuditEventRequest> events) {
+    return events.stream()
+        .map(event -> String.valueOf(event.payload().get("changeType")))
+        .toList();
+  }
+
+  private static final class InMemoryCorrelationRepository
+      implements WorkflowAuditCorrelationRepository {
+    private final Map<String, String> values = new LinkedHashMap<>();
+
+    @Override
+    public Optional<String> findCarrierJson(String executionId) {
+      return Optional.ofNullable(values.get(executionId));
+    }
+
+    @Override
+    public boolean replaceCarrierJson(String executionId, String carrierJson) {
+      if (carrierJson == null) values.remove(executionId);
+      else values.put(executionId, carrierJson);
+      return true;
+    }
+  }
+
+  private static final class RecordingAuditService implements BusinessAuditService {
+    private int sequence;
+    private final List<AuditOperationRequest> requests = new ArrayList<>();
+    private final Map<String, RecordingHandle> handles = new LinkedHashMap<>();
+
+    @Override
+    public AuditOperationHandle start(AuditOperationRequest request) {
+      requests.add(request);
+      String operationId = "AUD-" + (++sequence);
+      RecordingHandle handle = new RecordingHandle(new AuditCarrier(
+          operationId,
+          "user-1",
+          "alice",
+          "USER",
+          7L,
+          "Project A",
+          request.resourceType(),
+          request.resourceId(),
+          request.resourceName(),
+          request.source()));
+      handles.put(operationId, handle);
+      return handle;
+    }
+
+    @Override
+    public AuditOperationHandle resume(AuditCarrier carrier) {
+      return handles.getOrDefault(carrier.operationId(), AuditOperationHandle.noop(carrier));
+    }
+
+    RecordingHandle handle(String operationId) {
+      return handles.get(operationId);
+    }
+  }
+
+  private static final class RecordingHandle implements AuditOperationHandle {
+    private AuditCarrier carrier;
+    private final List<AuditEventRequest> events = new ArrayList<>();
+    private String successSummary;
+    private String failureReason;
+
+    private RecordingHandle(AuditCarrier carrier) {
+      this.carrier = carrier;
+    }
+
+    @Override
+    public String operationId() {
+      return carrier.operationId();
+    }
+
+    @Override
+    public AuditCarrier carrier() {
+      return carrier;
+    }
+
+    @Override
+    public void resource(String resourceId, String resourceName) {
+      carrier = carrier.withResource(resourceId, resourceName);
+    }
+
+    @Override
+    public void event(AuditEventType type, String message, Map<String, ?> payload) {
+      events.add(new AuditEventRequest(type, null, message, null, payload));
+    }
+
+    @Override
+    public void event(AuditEventRequest request) {
+      events.add(request);
+    }
+
+    @Override
+    public void success(String summary) {
+      successSummary = summary;
+    }
+
+    @Override
+    public void failure(String reasonCode, Throwable cause) {
+      failureReason = reasonCode;
+    }
+  }
+}


### PR DESCRIPTION
## Summary

Implements **PR 4.2** for #921: extend the shared business Audit model from Workflow Definition mutations into the **durable Workflow Execution lifecycle**.

PR 4.1 / #968 is already merged. This branch is rebased directly on that latest `main` and contains one focused commit.

The key contract is:

```text
one execution phase
    -> one WORKFLOW_EXECUTE AuditOperation
    -> one durable AuditCarrier frozen on WorkflowExecution
    -> asynchronous/recovered terminal state resumes the same operation
```

`operation_id` remains independent from trace/span IDs.

## 1. Unified launch audit

`WorkflowLauncher` is the existing common entry for manual, API, scheduled, Backfill, restart and rerun launches. PR 4.2 attaches Audit there instead of scattering Audit calls through Runtime internals.

Covered launch modes include:

```text
PUBLISHED
SCHEDULED_PUBLISHED
BACKFILL_PUBLISHED
OPERATIONAL_RERUN
DRAFT_TEST
AD_HOC
RESTART
RERUN_FROM_NODE
```

All of them create:

```text
operation_type = WORKFLOW_EXECUTE
resource_type  = WORKFLOW_EXECUTION
```

with bounded metadata such as launch mode, trigger type/id, schedule/backfill identity and planned fire time.

The actual workflow input, node input/output and runtime errors are not copied into Audit.

## 2. Durable AuditCarrier on WorkflowExecution

Adds Workflow migration:

```text
V2__add_execution_audit_carrier.sql
```

with one nullable additive column:

```text
yak_workflow_execution.audit_carrier_json LONGTEXT NULL
```

Historical rows are deliberately not backfilled with fabricated operations.

A narrow persistence boundary owns this column:

```text
WorkflowAuditCorrelationRepository
    -> WorkflowExecutionDao
    -> audit_carrier_json
```

The mapper read/write remains Project-scoped.

The correlation update modifies **only** `audit_carrier_json`; it does not rewrite Workflow status, runtime metadata or `updated_at`, so the cross-cutting Audit concern cannot accidentally perturb recovery/scheduling truth.

## 3. Explicit AuditContext during launch

The initial launch runs inside the new operation's `AuditContext`.

After a durable `workflowExecutionId` exists, the bridge:

1. updates the Audit resource snapshot to that execution;
2. freezes the carrier on the execution row;
3. emits an idempotent `EXECUTION_STARTED` business fact.

This handles the small window where a very fast same-thread execution may reach terminal state before the launcher returns: the existing AuditContext remains available during that launch call. Later worker/recovery paths use the persisted carrier.

## 4. Terminal state comes from committed Workflow truth

PR 4.2 intentionally does **not** add Audit calls to the large `WorkflowRuntime` state machine.

The existing execution repository already publishes `WorkflowExecutionTerminalEvent` from durable terminal state. A new listener consumes it with:

```text
@TransactionalEventListener(AFTER_COMMIT)
```

and resumes the frozen AuditCarrier.

Terminal projection is deliberately coarse:

```text
SUCCESS / SUCCESS_WITH_WARNINGS
    -> EXECUTION_SUCCEEDED
    -> AuditOperation SUCCEEDED

FAILED
    -> EXECUTION_FAILED
    -> WORKFLOW_EXECUTION_FAILED

TIMED_OUT
    -> EXECUTION_FAILED
    -> WORKFLOW_EXECUTION_TIMED_OUT

WARNING
    -> EXECUTION_FAILED
    -> WORKFLOW_EXECUTION_WARNING

CANCELED
    -> EXECUTION_CANCELED
    -> WORKFLOW_EXECUTION_CANCELED
```

Repeated terminal observations are safe because event keys are deterministic and terminal operation updates already have RUNNING guards.

## 5. Retry / continue correctly changes the actor

`continueAfterFailure`, `retryFailedNode` and `retryFailedNodes` reuse the **same durable WorkflowExecution**.

That means keeping the original launch carrier would be historically wrong when another user performs the recovery.

PR 4.2 therefore does:

```text
operator B clicks retry/continue
    -> create new WORKFLOW_EXECUTE operation for operator B
    -> replace execution audit_carrier_json before reactivation
    -> run existing reactivation guard/runtime
    -> later terminal state completes operator B's operation
```

If reactivation itself fails, the previous carrier is restored and the new operation is closed with:

```text
WORKFLOW_EXECUTION_REACTIVATION_FAILED
```

This avoids attributing operator B's retry to the original operator A.

## 6. Pause / resume / cancel are separate short operations

Pause, resume and cancel are actor-owned control actions, so they are **not** appended as if the original launcher performed them.

Direct instance routes use:

```text
WORKFLOW_EXECUTION_PAUSE
WORKFLOW_EXECUTION_RESUME
WORKFLOW_EXECUTION_CANCEL
```

They do not replace the long-running execution carrier.

The real editor UI currently calls the Definition-surface aliases:

```text
/definitions/{id}/pause
/definitions/{id}/resume
```

Those paths are also audited. Although the HTTP route is Definition-shaped, their Audit resource is explicitly:

```text
resource_type = WORKFLOW_EXECUTION
resource_id   = latestExecutionId
```

so the historical resource semantics stay correct.

## 7. Keep the Audit event vocabulary small

No new `AuditEventType` is introduced.

Execution facts continue to use generic:

```text
RESOURCE_UPDATED
```

with stable `payload.changeType` values:

```text
EXECUTION_STARTED
EXECUTION_SUCCEEDED
EXECUTION_FAILED
EXECUTION_CANCELED
EXECUTION_PAUSED
EXECUTION_RESUMED
EXECUTION_CANCEL_REQUESTED
```

`AuditTimelineRendererRegistry` renders them as business copy such as:

```text
执行开始
执行成功
执行失败
执行已取消
执行已暂停
执行已恢复
已请求取消执行
```

Stable Workflow failure reason codes also receive Chinese Audit Center labels without storing arbitrary runtime error text.

## 8. Sensitive-data boundary

Workflow Execution audit payloads intentionally exclude:

```text
Workflow input values
Node input/output
predecessor outputs
Task payloads / TaskVersionSnapshot
runtime errorMessage / exception message
credentials / secrets
```

Only bounded execution/trigger/status identifiers are retained.

## 9. Fail-open and historical compatibility

Audit remains a best-effort side effect:

- missing Audit runtime/store cannot change Workflow execution results;
- carrier serialization/persistence failures are logged and execution continues;
- existing historical Workflow executions without a carrier are not retroactively assigned a fabricated operation;
- no Runtime state machine or engine schema ownership changes are introduced.

## Tests / guards

Adds or updates coverage for:

- launch `AuditContext` and durable frozen carrier;
- terminal SUCCESS/CANCELED projection;
- safe payload boundary without input/output/error text;
- retry/continue replacing an old actor carrier before reactivation;
- failed reactivation restoring the old carrier;
- editor-facing pause auditing the actual WorkflowExecution resource;
- execution changeType Timeline rendering;
- V2 nullable/additive migration with no backfill;
- Project-scoped correlation mapper;
- correlation update cannot rewrite status/runtime metadata/`updated_at`;
- Workflow role/layering architecture guards.

Repository compare at PR creation:

```text
1 commit ahead
0 commits behind current main
23 changed files
```

GitHub currently reports no workflow runs or commit status checks for the head, so this PR remains Draft.

Recommended local verification:

```bash
mvn -pl yak-ops-business/yak-ops-business-audit,yak-ops-business/yak-ops-business-workflow -am test
```

Suggested smoke flow:

1. Manually run an ONLINE Workflow and confirm one `WORKFLOW_EXECUTE` row is created.
2. Confirm its Timeline contains `执行开始`, then eventually `执行成功/执行失败` under the same operationId.
3. Start a draft test-run and confirm source/launchMode are distinguishable without storing the draft input.
4. Start an execution, log in as another user and retry a failed node; confirm the new execution phase is attributed to the second user.
5. Force retry/continue rejection and confirm the previous carrier is restored.
6. Pause/resume from the Workflow editor and confirm short `WORKFLOW_EXECUTION_PAUSE/RESUME` rows point to the latest execution.
7. Cancel through the instance API and confirm a short cancel operation plus the original execution's terminal canceled state.
8. Restart the application during a long execution and confirm terminal projection can resume from the persisted carrier after Project context restoration.
9. Verify `audit_carrier_json` changes do not change Workflow `updated_at` or Runtime status.
10. Search Audit payloads and confirm Workflow input/output/error messages are absent.

## Non-goals

- Workflow Node / Attempt / step-level audit timeline
- copying Workflow Runtime logs into business Audit
- Schedule definition lifecycle auditing
- Trigger Ledger auditing
- Backfill batch lifecycle auditing
- Audit retention/export/SIEM/lossless delivery
- redesigning Workflow Runtime state ownership

Schedule / Backfill management coverage remains **PR 4.3**.

Refs #921