### PR TITLE
feat(audit): cover workflow schedule and backfill lifecycle

### DIFF
--- a/yak-ops-business/yak-ops-business-audit/src/main/java/io/yak/ops/business/audit/AuditTimelineRendererRegistry.java
+++ b/yak-ops-business/yak-ops-business-audit/src/main/java/io/yak/ops/business/audit/AuditTimelineRendererRegistry.java
@@ -21,9 +21,9 @@ public final class AuditTimelineRendererRegistry {
     Map<String, Function<RenderContext, AuditEventPresentation>> values = new LinkedHashMap<>();
     values.put("AUTHORIZATION_DECISION", this::authorization);
     values.put("OPERATION_STARTED", fixed("操作开始"));
-    values.put("RESOURCE_CREATED", fixed("资源已创建"));
+    values.put("RESOURCE_CREATED", this::resourceCreated);
     values.put("RESOURCE_UPDATED", this::resourceUpdated);
-    values.put("RESOURCE_DELETED", fixed("资源已删除"));
+    values.put("RESOURCE_DELETED", this::resourceDeleted);
     values.put("TASK_SUBMITTED", fixed("任务已提交"));
     values.put("TASK_QUEUED", fixed("任务已进入队列"));
     values.put("WORKER_STARTED", fixed("执行器开始处理"));
@@ -57,6 +57,18 @@ public final class AuditTimelineRendererRegistry {
     return context -> new AuditEventPresentation(title, description(context));
   }
 
+  private AuditEventPresentation resourceCreated(RenderContext context) {
+    String changeType = stringValue(context.payload().get("changeType"));
+    String title =
+        switch (changeType == null ? "" : changeType) {
+          case "SCHEDULE_CREATED" -> "调度已创建";
+          case "BACKFILL_CREATED" -> "Backfill 已创建";
+          case "BUSINESS_DATE_RERUN_CREATED" -> "运维补跑已创建";
+          default -> "资源已创建";
+        };
+    return new AuditEventPresentation(title, description(context));
+  }
+
   private AuditEventPresentation resourceUpdated(RenderContext context) {
     String changeType = stringValue(context.payload().get("changeType"));
     String title =
@@ -72,8 +84,19 @@ public final class AuditTimelineRendererRegistry {
           case "EXECUTION_PAUSED" -> "执行已暂停";
           case "EXECUTION_RESUMED" -> "执行已恢复";
           case "EXECUTION_CANCEL_REQUESTED" -> "已请求取消执行";
+          case "SCHEDULE_UPDATED" -> "调度配置已更新";
+          case "SCHEDULE_ENABLED" -> "调度已启用";
+          case "SCHEDULE_DISABLED" -> "调度已停用";
+          case "SCHEDULE_EXPIRED" -> "调度已过期";
+          case "BACKFILL_CANCELED" -> "Backfill 已取消";
           default -> "资源已更新";
         };
+    return new AuditEventPresentation(title, description(context));
+  }
+
+  private AuditEventPresentation resourceDeleted(RenderContext context) {
+    String changeType = stringValue(context.payload().get("changeType"));
+    String title = "SCHEDULE_DELETED".equals(changeType) ? "调度已删除" : "资源已删除";
     return new AuditEventPresentation(title, description(context));
   }
 
@@ -141,6 +164,15 @@ public final class AuditTimelineRendererRegistry {
     labels.put("WORKFLOW_EXECUTION_PAUSE_FAILED", "暂停工作流失败");
     labels.put("WORKFLOW_EXECUTION_RESUME_FAILED", "恢复工作流失败");
     labels.put("WORKFLOW_EXECUTION_CANCEL_FAILED", "取消工作流失败");
+    labels.put("WORKFLOW_SCHEDULE_CREATE_FAILED", "创建工作流调度失败");
+    labels.put("WORKFLOW_SCHEDULE_UPDATE_FAILED", "更新工作流调度失败");
+    labels.put("WORKFLOW_SCHEDULE_ENABLE_FAILED", "启用工作流调度失败");
+    labels.put("WORKFLOW_SCHEDULE_DISABLE_FAILED", "停用工作流调度失败");
+    labels.put("WORKFLOW_SCHEDULE_EXPIRE_FAILED", "工作流调度过期处理失败");
+    labels.put("WORKFLOW_SCHEDULE_DELETE_FAILED", "删除工作流调度失败");
+    labels.put("WORKFLOW_BACKFILL_CREATE_FAILED", "创建 Backfill 失败");
+    labels.put("WORKFLOW_BACKFILL_CANCEL_FAILED", "取消 Backfill 失败");
+    labels.put("WORKFLOW_BUSINESS_DATE_RERUN_FAILED", "创建指定日期补跑失败");
     return Map.copyOf(labels);
   }
 

--- a/yak-ops-business/yak-ops-business-audit/src/test/java/io/yak/ops/business/audit/AuditTimelineRendererRegistryTest.java
+++ b/yak-ops-business/yak-ops-business-audit/src/test/java/io/yak/ops/business/audit/AuditTimelineRendererRegistryTest.java
@@ -107,6 +107,55 @@ class AuditTimelineRendererRegistryTest {
   }
 
   @Test
+  void scheduleAndBackfillChangesUseBusinessCopy() {
+    assertThat(registry
+            .render(
+                "RESOURCE_CREATED",
+                "SUCCESS",
+                null,
+                "created",
+                Map.of("changeType", "SCHEDULE_CREATED"))
+            .title())
+        .isEqualTo("调度已创建");
+    assertThat(registry
+            .render(
+                "RESOURCE_UPDATED",
+                "SUCCESS",
+                null,
+                "enabled",
+                Map.of("changeType", "SCHEDULE_ENABLED"))
+            .title())
+        .isEqualTo("调度已启用");
+    assertThat(registry
+            .render(
+                "RESOURCE_CREATED",
+                "SUCCESS",
+                null,
+                "created",
+                Map.of("changeType", "BACKFILL_CREATED"))
+            .title())
+        .isEqualTo("Backfill 已创建");
+    assertThat(registry
+            .render(
+                "RESOURCE_CREATED",
+                "SUCCESS",
+                null,
+                "created",
+                Map.of("changeType", "BUSINESS_DATE_RERUN_CREATED"))
+            .title())
+        .isEqualTo("运维补跑已创建");
+    assertThat(registry
+            .render(
+                "RESOURCE_UPDATED",
+                "SUCCESS",
+                null,
+                "canceled",
+                Map.of("changeType", "BACKFILL_CANCELED"))
+            .title())
+        .isEqualTo("Backfill 已取消");
+  }
+
+  @Test
   void unknownEventHasSafeFallback() {
     AuditEventPresentation presentation =
         registry.render("CUSTOM_EVENT", "INFO", null, null, Map.of());

--- a/yak-ops-business/yak-ops-business-workflow/ARCHITECTURE.md
+++ b/yak-ops-business/yak-ops-business-workflow/ARCHITECTURE.md
@@ -24,10 +24,10 @@ io.yak.ops.business.workflow
 ├── definition              # draft / version / graph / task binding
 ├── execution               # launcher / operations / reactivation ports
 ├── runtime                 # engine runtime adapter / recovery
-├── schedule                # schedule definition lifecycle / reconcile
+├── schedule                # schedule definition lifecycle / reconcile / audit orchestration
 │   ├── engine              # Yak Schedule bridge
 │   └── trigger             # durable trigger ledger / admission / queue
-├── backfill                # backfill batch / rerun / trigger adapter
+├── backfill                # backfill batch / rerun / trigger adapter / audit orchestration
 ├── observability           # SSE projection
 ├── repository              # durable business/engine persistence adapters
 │   └── support
@@ -50,17 +50,20 @@ WorkflowRuntime
 WorkflowBackfillManager
 ```
 
-它们可以使用 `@Service`，因为它们是稳定 use-case boundary，而不是因为“所有 Bean 都叫 Service”。Planner / Query / Coordinator / Reconciler / Adapter / Guard / EventStream 等内部专业角色使用 `@Component`。
+它们可以使用 `@Service`，因为它们是稳定 use-case boundary，而不是因为“所有 Bean 都叫 Service”。Audit Coordinator / Planner / Query / Coordinator / Reconciler / Adapter / Guard / EventStream 等内部专业角色使用 `@Component`。
+
+Audit Coordinator 只负责围绕已有业务入口记录业务事实，不成为 Definition / Execution / Schedule / Backfill 的第二 truth owner。
 
 ## 4. Definition Subsystem
 
 ```text
 Controller
-    -> WorkflowDefinitionManager
-         -> WorkflowTaskBindingResolver
-         -> WorkflowStartGraphCompiler
-         -> WorkflowDefinitionRepository
-         -> WorkflowRuntime
+    -> WorkflowDefinitionAuditCoordinator
+         -> WorkflowDefinitionManager
+              -> WorkflowTaskBindingResolver
+              -> WorkflowStartGraphCompiler
+              -> WorkflowDefinitionRepository
+              -> WorkflowRuntime
 ```
 
 DefinitionManager 拥有 current draft、publish、active version、Task revision binding 与 definition-level safety。
@@ -83,6 +86,7 @@ Restart / Rerun
         v
   WorkflowLauncher
         |
+        +-> WorkflowExecutionAuditBridge
         +-> resolve active/pinned version
         +-> record TriggerContext
         v
@@ -91,7 +95,7 @@ Restart / Rerun
 
 `WorkflowExecutionReactivator` 处理同一个 Execution 的 retry/continue。它只依赖 execution-owned `WorkflowExecutionReactivationGuard`；Schedule Trigger Coordinator 实现该 Port，从而能施加 Ledger 串行槽位规则而不制造 execution -> schedule package cycle。
 
-`WorkflowExecutionManager` 负责实例运维 read/use-case。businessDate rerun 通过 execution-owned `WorkflowBusinessDateRerunGateway` 进入 Backfill，而不是直接认识 Backfill 实现。
+`WorkflowExecutionManager` 负责实例运维 read/use-case。businessDate rerun 通过 execution-owned `WorkflowBusinessDateRerunGateway` 进入 `WorkflowBackfillAuditCoordinator`，而不是直接认识 Backfill business implementation。
 
 ## 6. Runtime Subsystem
 
@@ -107,22 +111,36 @@ Runtime 负责 engine adapter、NodeDispatch、TaskExecution polling、timeout�
 
 `WorkflowRuntimeRecovery` 只负责应用启动后的 durable recovery orchestration，不成为第二 runtime owner。Runtime 内存中的 dispatch queue、control map、active set 都是可恢复辅助状态。
 
+Business Audit 不进入 Runtime 状态机；Execution 终态通过 durable `WorkflowExecutionTerminalEvent` AFTER_COMMIT 投影到 Audit。
+
 ## 7. Schedule Subsystem
 
 ```text
-WorkflowSchedule create/revision/lifecycle
+HTTP direct schedule mutation
+Yak Schedule automatic expire/disable
+    -> WorkflowScheduleAuditCoordinator
+    -> create / revision / lifecycle
     -> durable schedule DAO
     -> WorkflowScheduleEngineBridge
          -> Yak Schedule
+
+Workflow online/offline linkage
+    -> WorkflowDefinitionScheduleGuard
+    -> WorkflowScheduleAuditCoordinator
+    -> lifecycle only (no second AuditOperation)
 
 Yak Schedule callback
     -> WorkflowScheduleTriggerHandler
     -> WorkflowScheduleTriggerCoordinator
 ```
 
+`WorkflowScheduleAuditCoordinator` 记录直接 Schedule mutation 和无父业务操作的 Scheduler 自动 lifecycle。Cron、timezone、日期区间和策略可作为审计业务事实，Schedule `input` 原值不能复制到 Audit。
+
+Workflow online/offline 的 Schedule 联动属于父 Workflow 操作的派生副作用，不再生成第二条 Schedule AuditOperation；这样既控制 Audit Center 噪音，也保证 Project authorization decision 仍归属父 `WORKFLOW_ENABLE/DISABLE`。
+
 `WorkflowScheduleEngineBridge` 是 framework boundary；Schedule 业务表仍是配置 truth。
 
-`WorkflowScheduleReconciler` 恢复 framework projection；`WorkflowScheduleRuntimeState` 只维护 last/next fire projection；`WorkflowScheduleMisfireRecovery` 生成可审计的恢复 Trigger。
+`WorkflowScheduleReconciler` 恢复 framework projection；`WorkflowScheduleRuntimeState` 只维护 last/next fire projection；`WorkflowScheduleMisfireRecovery` 生成 durable recovery Trigger。
 
 ## 8. Trigger Ledger Subsystem
 
@@ -132,21 +150,27 @@ callback / Backfill occurrence
         -> WorkflowScheduleTriggerAdmission
         -> durable Trigger Ledger
         -> WorkflowLauncher
+        -> WORKFLOW_EXECUTE audit
 ```
 
 Admission 拥有 claim/dedupe、SERIAL_WAIT/SERIAL_DISCARD/PARALLEL、LAUNCHING/REACTIVATING reservation、execution binding 与队首推进。
 
 Coordinator 负责跨步骤编排，不复制 Admission 的事务规则。
 
+Trigger Ledger 不为每个 RECEIVED/WAITING/SKIPPED 状态额外创建 Audit Center 行。真正启动的业务执行由 `WorkflowLauncher` 的 `WORKFLOW_EXECUTE` 记录，并通过 triggerId/scheduleId/backfillId 保留来源血缘。
+
 Backfill-specific trigger 创建/加载/launch 被隔离在 `WorkflowBackfillTriggerGateway` 后面；其实现位于 Backfill 子系统，Schedule 不 import Backfill implementation。
 
 ## 9. Backfill Subsystem
 
 ```text
-WorkflowBackfillManager
-    -> WorkflowBackfillPlanner
-    -> durable Backfill DAO
-    -> WorkflowScheduleTriggerCoordinator
+HTTP create/cancel
+Execution businessDate rerun port
+    -> WorkflowBackfillAuditCoordinator
+    -> WorkflowBackfillManager
+         -> WorkflowBackfillPlanner
+         -> durable Backfill DAO
+         -> WorkflowScheduleTriggerCoordinator
 
 WorkflowBackfillTriggerAdapter
     -> WorkflowBackfillQuery
@@ -154,13 +178,15 @@ WorkflowBackfillTriggerAdapter
     -> WorkflowLauncher
 ```
 
-Manager 拥有批次 create/cancel/businessDate rerun；Planner 只生成 occurrence；Reconciler 只根据 durable batch 补齐 Trigger。
+Manager 拥有批次 create/cancel/businessDate rerun 的业务语义；Planner 只生成 occurrence；Reconciler 只根据 durable batch 补齐 Trigger。
 
-Backfill 实现 execution-owned `WorkflowBusinessDateRerunGateway`，让 Execution use-case 不反向依赖 Backfill package。
+`WorkflowBackfillAuditCoordinator` 是 execution-owned `WorkflowBusinessDateRerunGateway` 的唯一 Backfill 实现，并把 create/cancel/rerun 转成管理 AuditOperation。每个真正启动的子 WorkflowExecution 继续由 Launcher 独立审计。
 
 ## 10. Observability
 
 `WorkflowEventStream` 只维护 SSE client 与 heartbeat，并消费 Runtime 投影。它不读取/修改 Definition、Schedule、Trigger Ledger 或 Engine persistence，SSE 断开也不影响执行。
+
+Business Audit 是独立业务解释投影，不取代 SSE、Runtime log 或 Trigger Ledger。
 
 ## 11. Persistence Boundary
 
@@ -209,6 +235,7 @@ Engine Execution = runtime state truth
 Schedule         = durable timer config
 Trigger Ledger   = dedupe/admission/lineage truth
 Backfill         = pinned-version batch truth
+Business Audit   = historical business-action explanation projection
 SSE/log          = projection only
 ```
 

--- a/yak-ops-business/yak-ops-business-workflow/DEPENDENCIES.md
+++ b/yak-ops-business/yak-ops-business-workflow/DEPENDENCIES.md
@@ -33,8 +33,8 @@ definition -> WorkflowDefinitionManager (read/control)
 execution  -> WorkflowLauncher / WorkflowExecutionManager / WorkflowExecutionReactivator
            -> WorkflowExecutionControlAuditCoordinator (pause/resume/cancel)
 runtime    -> WorkflowRuntime
-schedule   -> create/revision/lifecycle/query + trigger query
-backfill   -> WorkflowBackfillManager / WorkflowBackfillQuery
+schedule   -> WorkflowScheduleAuditCoordinator / WorkflowScheduleQuery + trigger query
+backfill   -> WorkflowBackfillAuditCoordinator / WorkflowBackfillManager (preview) / WorkflowBackfillQuery
 ```
 
 Controller 不直接依赖 DAO、Repository、Schedule Engine Bridge 或 Trigger Admission/Coordinator。
@@ -87,6 +87,43 @@ WorkflowExecutionRepositoryAdapter
 人工 `retry/continue` 会复用同一个 WorkflowExecution，因此必须在重新激活前创建新的 `WORKFLOW_EXECUTE` operation 并替换 carrier；失败时恢复旧 carrier。`pause/resume/cancel` 是独立短操作，不替换 execution carrier。
 
 Audit correlation 更新只能修改 `audit_carrier_json`，不能顺手更新 Runtime status、runtime metadata 或 `updated_at`。
+
+### Schedule Audit Corridor
+
+直接 Schedule 配置/生命周期操作与无父业务操作的 Scheduler 自动动作进入：
+
+```text
+HTTP create/update/online/offline/delete
+Yak Schedule automatic expire/disable
+        -> WorkflowScheduleAuditCoordinator
+        -> existing CreateCommand / Revision / Lifecycle
+        -> shared BusinessAuditService
+```
+
+约束：
+
+- Schedule AuditOperation 的 resource 固定为 `WORKFLOW_SCHEDULE`；
+- Cron、timezone、日期区间和策略可以作为业务事实记录；
+- `input` 原值不能复制到 Audit，只允许 `inputConfigured/inputChanged`；
+- Scheduler 自动过期/停用使用 `source=SCHEDULE`；
+- Workflow online/offline 引起的 Schedule 联动**不创建第二条 AuditOperation**，父 `WORKFLOW_ENABLE/DISABLE` 已经表达用户意图，这也避免抢占父操作的 deferred authorization decision；
+- Trigger Ledger 本身不为每个触发额外创建 AuditOperation，成功启动后的业务历史由 `WORKFLOW_EXECUTE` 承担。
+
+### Backfill Audit Corridor
+
+Backfill 管理动作固定为：
+
+```text
+create/cancel
+businessDate rerun gateway
+        -> WorkflowBackfillAuditCoordinator
+        -> WorkflowBackfillManager
+        -> shared BusinessAuditService
+```
+
+Backfill 管理 Operation 只描述批次创建/取消事实。每个真正启动的子 WorkflowExecution 继续由 `WorkflowLauncher -> WorkflowExecutionAuditBridge` 单独记录，避免把运行期事件复制进 Backfill 管理日志。
+
+Backfill Audit payload 不允许复制 `input`、继承的 source input 或 Trigger runtime message，只保留 schedule/workflow/version、日期范围、执行策略和数量等稳定事实。
 
 ## 3. Definition -> Runtime
 
@@ -143,7 +180,7 @@ WorkflowBusinessDateRerunGateway
 WorkflowLauncher
 ```
 
-`WorkflowBackfillTriggerAdapter` 实现 Schedule-owned `WorkflowBackfillTriggerGateway`；Schedule 不 import `workflow.backfill.*`。
+`WorkflowBackfillAuditCoordinator` 是 execution-owned `WorkflowBusinessDateRerunGateway` 的唯一 Backfill 实现；`WorkflowBackfillManager` 保持纯 Backfill 业务 facade。`WorkflowBackfillTriggerAdapter` 实现 Schedule-owned `WorkflowBackfillTriggerGateway`；Schedule 不 import `workflow.backfill.*`。
 
 ## 7. Runtime -> Observability
 
@@ -215,7 +252,7 @@ execution.WorkflowExecutionReactivationGuard
     <- schedule.trigger.WorkflowScheduleTriggerCoordinator
 
 execution.WorkflowBusinessDateRerunGateway
-    <- backfill.WorkflowBackfillManager
+    <- backfill.WorkflowBackfillAuditCoordinator
 
 schedule.trigger.WorkflowBackfillTriggerGateway
     <- backfill.WorkflowBackfillTriggerAdapter

--- a/yak-ops-business/yak-ops-business-workflow/src/main/java/io/yak/ops/business/workflow/backfill/WorkflowBackfillAuditCoordinator.java
+++ b/yak-ops-business/yak-ops-business-workflow/src/main/java/io/yak/ops/business/workflow/backfill/WorkflowBackfillAuditCoordinator.java
@@ -1,0 +1,215 @@
+package io.yak.ops.business.workflow.backfill;
+
+import io.yak.ops.business.audit.AuditEventType;
+import io.yak.ops.business.audit.AuditOperationHandle;
+import io.yak.ops.business.audit.AuditOperationRequest;
+import io.yak.ops.business.audit.BusinessAuditService;
+import io.yak.ops.business.workflow.execution.WorkflowBusinessDateRerunGateway;
+import io.yak.ops.common.bean.dto.workflow.WorkflowBackfillCreateDTO;
+import io.yak.ops.common.bean.dto.workflow.WorkflowBusinessDateRerunDTO;
+import io.yak.ops.common.bean.po.workflow.WorkflowBackfillPO;
+import io.yak.ops.common.bean.vo.workflow.WorkflowBackfillVO;
+import io.yak.ops.common.bean.vo.workflow.WorkflowInstanceVO;
+import java.util.LinkedHashMap;
+import java.util.Map;
+import org.springframework.beans.factory.ObjectProvider;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.stereotype.Component;
+
+/** Audits Backfill batch management while child WorkflowExecution audit remains owned by Launcher. */
+@Component
+@ConditionalOnProperty(
+    prefix = "yak.database",
+    name = "enabled",
+    havingValue = "true",
+    matchIfMissing = true)
+public class WorkflowBackfillAuditCoordinator implements WorkflowBusinessDateRerunGateway {
+
+  private static final String RESOURCE_TYPE = "WORKFLOW_BACKFILL";
+  private static final BusinessAuditService NOOP_AUDIT =
+      request -> AuditOperationHandle.noop(null);
+
+  private final WorkflowBackfillManager manager;
+  private final WorkflowBackfillQuery query;
+  private final BusinessAuditService auditService;
+
+  @Autowired
+  public WorkflowBackfillAuditCoordinator(
+      WorkflowBackfillManager manager,
+      WorkflowBackfillQuery query,
+      ObjectProvider<BusinessAuditService> auditServiceProvider) {
+    this(manager, query, auditServiceProvider.getIfAvailable(() -> NOOP_AUDIT));
+  }
+
+  WorkflowBackfillAuditCoordinator(
+      WorkflowBackfillManager manager,
+      WorkflowBackfillQuery query,
+      BusinessAuditService auditService) {
+    this.manager = manager;
+    this.query = query;
+    this.auditService = auditService == null ? NOOP_AUDIT : auditService;
+  }
+
+  public WorkflowBackfillVO create(WorkflowBackfillCreateDTO request) {
+    AuditOperationHandle audit =
+        start(
+            "WORKFLOW_BACKFILL_CREATE",
+            "Create workflow Backfill",
+            null,
+            request == null ? null : trimToNull(request.name()),
+            createMetadata(request));
+    try {
+      WorkflowBackfillVO created = manager.create(request);
+      audit.resource(created.id(), created.name());
+      audit.event(
+          AuditEventType.RESOURCE_CREATED,
+          "Workflow Backfill created",
+          snapshot("BACKFILL_CREATED", created));
+      audit.success("Workflow Backfill created");
+      return created;
+    } catch (RuntimeException exception) {
+      audit.failure("WORKFLOW_BACKFILL_CREATE_FAILED", exception);
+      throw exception;
+    }
+  }
+
+  @Override
+  public WorkflowBackfillVO createBusinessDateRerun(
+      String sourceExecutionId,
+      WorkflowInstanceVO source,
+      WorkflowBusinessDateRerunDTO request) {
+    Map<String, Object> metadata = new LinkedHashMap<>();
+    putIfNotNull(metadata, "sourceExecutionId", trimToNull(sourceExecutionId));
+    if (request != null) {
+      putIfNotNull(metadata, "businessDate", request.businessDate());
+      putIfNotNull(metadata, "executionStrategy", trimToNull(request.executionStrategy()));
+      metadata.put("inputConfigured", request.input() != null && !request.input().isEmpty());
+    }
+    AuditOperationHandle audit =
+        start(
+            "WORKFLOW_BUSINESS_DATE_RERUN",
+            "Create workflow business-date rerun",
+            null,
+            null,
+            Map.copyOf(metadata));
+    try {
+      WorkflowBackfillVO created =
+          manager.createBusinessDateRerun(sourceExecutionId, source, request);
+      audit.resource(created.id(), created.name());
+      audit.event(
+          AuditEventType.RESOURCE_CREATED,
+          "Workflow business-date rerun created",
+          snapshot("BUSINESS_DATE_RERUN_CREATED", created));
+      audit.success("Workflow business-date rerun created");
+      return created;
+    } catch (RuntimeException exception) {
+      audit.failure("WORKFLOW_BUSINESS_DATE_RERUN_FAILED", exception);
+      throw exception;
+    }
+  }
+
+  public WorkflowBackfillVO cancel(String id) {
+    WorkflowBackfillPO durable = query.require(id);
+    if ("CANCELED".equals(durable.getStatus())) {
+      return manager.cancel(id);
+    }
+    WorkflowBackfillVO before = query.view(durable);
+
+    AuditOperationHandle audit =
+        start(
+            "WORKFLOW_BACKFILL_CANCEL",
+            "Cancel workflow Backfill",
+            before.id(),
+            before.name(),
+            operationMetadata(before));
+    try {
+      WorkflowBackfillVO canceled = manager.cancel(id);
+      audit.resource(canceled.id(), canceled.name());
+      Map<String, Object> payload = new LinkedHashMap<>(snapshot("BACKFILL_CANCELED", canceled));
+      payload.put("waitingBefore", before.waitingCount());
+      payload.put("runningBefore", before.runningCount());
+      audit.event(
+          AuditEventType.RESOURCE_UPDATED,
+          "Workflow Backfill canceled",
+          Map.copyOf(payload));
+      audit.success("Workflow Backfill canceled");
+      return canceled;
+    } catch (RuntimeException exception) {
+      audit.failure("WORKFLOW_BACKFILL_CANCEL_FAILED", exception);
+      throw exception;
+    }
+  }
+
+  private AuditOperationHandle start(
+      String operationType,
+      String operationName,
+      String resourceId,
+      String resourceName,
+      Map<String, ?> metadata) {
+    return auditService.start(
+        new AuditOperationRequest(
+            operationType,
+            operationName,
+            RESOURCE_TYPE,
+            resourceId,
+            resourceName,
+            "WEB",
+            metadata));
+  }
+
+  private Map<String, Object> createMetadata(WorkflowBackfillCreateDTO request) {
+    if (request == null) return Map.of();
+    Map<String, Object> metadata = new LinkedHashMap<>();
+    putIfNotNull(metadata, "scheduleId", trimToNull(request.scheduleId()));
+    putIfNotNull(metadata, "startBusinessDate", request.startBusinessDate());
+    putIfNotNull(metadata, "endBusinessDate", request.endBusinessDate());
+    putIfNotNull(metadata, "executionStrategy", trimToNull(request.executionStrategy()));
+    metadata.put("inputConfigured", request.input() != null && !request.input().isEmpty());
+    return Map.copyOf(metadata);
+  }
+
+  private Map<String, Object> operationMetadata(WorkflowBackfillVO backfill) {
+    Map<String, Object> metadata = new LinkedHashMap<>();
+    putIfNotNull(metadata, "workflowId", backfill.workflowId());
+    putIfNotNull(metadata, "scheduleId", backfill.scheduleId());
+    putIfNotNull(metadata, "operationType", backfill.operationType());
+    putIfNotNull(metadata, "previousStatus", backfill.status());
+    return Map.copyOf(metadata);
+  }
+
+  private Map<String, Object> snapshot(String changeType, WorkflowBackfillVO backfill) {
+    Map<String, Object> payload = new LinkedHashMap<>();
+    payload.put("changeType", changeType);
+    putIfNotNull(payload, "workflowId", backfill.workflowId());
+    putIfNotNull(payload, "workflowVersionId", backfill.workflowVersionId());
+    putIfNotNull(payload, "workflowVersionNo", backfill.workflowVersionNo());
+    putIfNotNull(payload, "scheduleId", backfill.scheduleId());
+    putIfNotNull(payload, "operationType", backfill.operationType());
+    putIfNotNull(payload, "sourceExecutionId", backfill.sourceExecutionId());
+    putIfNotNull(payload, "startBusinessDate", backfill.startBusinessDate());
+    putIfNotNull(payload, "endBusinessDate", backfill.endBusinessDate());
+    putIfNotNull(payload, "timezone", backfill.timezone());
+    putIfNotNull(payload, "executionStrategy", backfill.executionStrategy());
+    putIfNotNull(payload, "status", backfill.status());
+    payload.put("totalCount", backfill.totalCount());
+    payload.put("waitingCount", backfill.waitingCount());
+    payload.put("runningCount", backfill.runningCount());
+    payload.put("succeededCount", backfill.succeededCount());
+    payload.put("failedCount", backfill.failedCount());
+    payload.put("canceledCount", backfill.canceledCount());
+    payload.put("skippedCount", backfill.skippedCount());
+    payload.put("inputConfigured", backfill.input() != null && !backfill.input().isEmpty());
+    return Map.copyOf(payload);
+  }
+
+  private static void putIfNotNull(Map<String, Object> values, String key, Object value) {
+    if (value != null) values.put(key, value);
+  }
+
+  private static String trimToNull(String value) {
+    if (value == null) return null;
+    String normalized = value.trim();
+    return normalized.isEmpty() ? null : normalized;
+  }
+}

--- a/yak-ops-business/yak-ops-business-workflow/src/main/java/io/yak/ops/business/workflow/backfill/WorkflowBackfillManager.java
+++ b/yak-ops-business/yak-ops-business-workflow/src/main/java/io/yak/ops/business/workflow/backfill/WorkflowBackfillManager.java
@@ -1,7 +1,6 @@
 package io.yak.ops.business.workflow.backfill;
 
 import io.yak.ops.business.workflow.definition.WorkflowDefinitionManager;
-import io.yak.ops.business.workflow.execution.WorkflowBusinessDateRerunGateway;
 import io.yak.ops.business.workflow.schedule.WorkflowScheduleParameterResolver;
 import io.yak.ops.business.workflow.schedule.WorkflowScheduleQuery;
 import io.yak.ops.business.workflow.schedule.trigger.WorkflowScheduleTriggerAdmission;
@@ -35,7 +34,7 @@ import org.springframework.stereotype.Service;
 /** Backfill 批次创建、运维补跑、预览、取消与 Trigger Ledger 分发。 */
 @Service
 @ConditionalOnProperty(prefix = "yak.database", name = "enabled", havingValue = "true", matchIfMissing = true)
-public class WorkflowBackfillManager implements WorkflowBusinessDateRerunGateway {
+public class WorkflowBackfillManager {
   private static final Logger log = LoggerFactory.getLogger(WorkflowBackfillManager.class);
   private static final Set<String> STRATEGIES = Set.of("SERIAL_WAIT", "PARALLEL");
   private static final Set<String> TERMINAL = Set.of(
@@ -149,7 +148,6 @@ public class WorkflowBackfillManager implements WorkflowBusinessDateRerunGateway
    * 按来源实例的不可变发布版本与调度语义，对指定 businessDate 创建运维补跑。
    * 旧实例的系统调度参数和旧运维血缘会被剥离，再根据新的逻辑计划时间重新注入。
    */
-  @Override
   public WorkflowBackfillVO createBusinessDateRerun(
       String sourceExecutionId,
       WorkflowInstanceVO source,

--- a/yak-ops-business/yak-ops-business-workflow/src/main/java/io/yak/ops/business/workflow/controller/v1/WorkflowBackfillController.java
+++ b/yak-ops-business/yak-ops-business-workflow/src/main/java/io/yak/ops/business/workflow/controller/v1/WorkflowBackfillController.java
@@ -3,6 +3,7 @@ package io.yak.ops.business.workflow.controller.v1;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import io.yak.framework.common.Result;
+import io.yak.ops.business.workflow.backfill.WorkflowBackfillAuditCoordinator;
 import io.yak.ops.business.workflow.backfill.WorkflowBackfillManager;
 import io.yak.ops.business.workflow.backfill.WorkflowBackfillQuery;
 import io.yak.ops.common.bean.dto.workflow.WorkflowBackfillCreateDTO;
@@ -11,6 +12,7 @@ import io.yak.ops.common.bean.vo.workflow.WorkflowBackfillVO;
 import io.yak.ops.core.project.ProjectScope;
 import jakarta.validation.Valid;
 import java.util.List;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
@@ -28,12 +30,25 @@ import org.springframework.web.bind.annotation.RestController;
 @ProjectScope
 public class WorkflowBackfillController {
   private final WorkflowBackfillManager service;
+  private final WorkflowBackfillAuditCoordinator audit;
   private final WorkflowBackfillQuery query;
 
+  @Autowired
+  public WorkflowBackfillController(
+      WorkflowBackfillManager service,
+      WorkflowBackfillAuditCoordinator audit,
+      WorkflowBackfillQuery query) {
+    this.service = service;
+    this.audit = audit;
+    this.query = query;
+  }
+
+  /** Focused compatibility constructor for tests without Audit wiring. */
   public WorkflowBackfillController(
       WorkflowBackfillManager service,
       WorkflowBackfillQuery query) {
     this.service = service;
+    this.audit = null;
     this.query = query;
   }
 
@@ -48,7 +63,7 @@ public class WorkflowBackfillController {
   @PostMapping
   public Result<WorkflowBackfillVO> create(
       @Valid @RequestBody WorkflowBackfillCreateDTO request) {
-    return Result.success(service.create(request));
+    return Result.success(audit == null ? service.create(request) : audit.create(request));
   }
 
   @Operation(summary = "查询 Backfill 批次")
@@ -69,6 +84,6 @@ public class WorkflowBackfillController {
   @Operation(summary = "取消 Backfill 中尚未启动的计划")
   @PostMapping("/{id}/cancel")
   public Result<WorkflowBackfillVO> cancel(@PathVariable("id") String id) {
-    return Result.success(service.cancel(id));
+    return Result.success(audit == null ? service.cancel(id) : audit.cancel(id));
   }
 }

--- a/yak-ops-business/yak-ops-business-workflow/src/main/java/io/yak/ops/business/workflow/controller/v1/WorkflowScheduleCommandController.java
+++ b/yak-ops-business/yak-ops-business-workflow/src/main/java/io/yak/ops/business/workflow/controller/v1/WorkflowScheduleCommandController.java
@@ -3,6 +3,7 @@ package io.yak.ops.business.workflow.controller.v1;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import io.yak.framework.common.Result;
+import io.yak.ops.business.workflow.schedule.WorkflowScheduleAuditCoordinator;
 import io.yak.ops.business.workflow.schedule.WorkflowScheduleCreateCommand;
 import io.yak.ops.business.workflow.schedule.WorkflowScheduleLifecycle;
 import io.yak.ops.business.workflow.schedule.WorkflowScheduleRevision;
@@ -11,6 +12,7 @@ import io.yak.ops.common.bean.dto.workflow.WorkflowScheduleUpdateDTO;
 import io.yak.ops.common.bean.vo.workflow.WorkflowScheduleVO;
 import io.yak.ops.core.project.ProjectScope;
 import jakarta.validation.Valid;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.PathVariable;
@@ -30,7 +32,21 @@ public class WorkflowScheduleCommandController {
   private final WorkflowScheduleCreateCommand creator;
   private final WorkflowScheduleRevision revision;
   private final WorkflowScheduleLifecycle lifecycle;
+  private final WorkflowScheduleAuditCoordinator audit;
 
+  @Autowired
+  public WorkflowScheduleCommandController(
+      WorkflowScheduleCreateCommand creator,
+      WorkflowScheduleRevision revision,
+      WorkflowScheduleLifecycle lifecycle,
+      WorkflowScheduleAuditCoordinator audit) {
+    this.creator = creator;
+    this.revision = revision;
+    this.lifecycle = lifecycle;
+    this.audit = audit;
+  }
+
+  /** Focused compatibility constructor for tests without Audit wiring. */
   public WorkflowScheduleCommandController(
       WorkflowScheduleCreateCommand creator,
       WorkflowScheduleRevision revision,
@@ -38,12 +54,13 @@ public class WorkflowScheduleCommandController {
     this.creator = creator;
     this.revision = revision;
     this.lifecycle = lifecycle;
+    this.audit = null;
   }
 
   @Operation(summary = "创建工作流调度定义")
   @PostMapping
   public Result<WorkflowScheduleVO> create(@Valid @RequestBody WorkflowScheduleCreateDTO request) {
-    return Result.success(creator.create(request));
+    return Result.success(audit == null ? creator.create(request) : audit.create(request));
   }
 
   @Operation(summary = "保存工作流调度配置")
@@ -51,25 +68,26 @@ public class WorkflowScheduleCommandController {
   public Result<WorkflowScheduleVO> update(
       @PathVariable("id") String id,
       @Valid @RequestBody WorkflowScheduleUpdateDTO request) {
-    return Result.success(revision.save(id, request));
+    return Result.success(audit == null ? revision.save(id, request) : audit.update(id, request));
   }
 
   @Operation(summary = "启用工作流调度定义")
   @PostMapping("/{id}/online")
   public Result<WorkflowScheduleVO> online(@PathVariable("id") String id) {
-    return Result.success(lifecycle.online(id));
+    return Result.success(audit == null ? lifecycle.online(id) : audit.online(id));
   }
 
   @Operation(summary = "停用工作流调度定义")
   @PostMapping("/{id}/offline")
   public Result<WorkflowScheduleVO> offline(@PathVariable("id") String id) {
-    return Result.success(lifecycle.offline(id));
+    return Result.success(audit == null ? lifecycle.offline(id) : audit.offline(id));
   }
 
   @Operation(summary = "删除工作流调度定义")
   @DeleteMapping("/{id}")
   public Result<Boolean> delete(@PathVariable("id") String id) {
-    lifecycle.remove(id);
+    if (audit == null) lifecycle.remove(id);
+    else audit.remove(id);
     return Result.success(Boolean.TRUE);
   }
 }

--- a/yak-ops-business/yak-ops-business-workflow/src/main/java/io/yak/ops/business/workflow/schedule/WorkflowDefinitionScheduleGuard.java
+++ b/yak-ops-business/yak-ops-business-workflow/src/main/java/io/yak/ops/business/workflow/schedule/WorkflowDefinitionScheduleGuard.java
@@ -9,13 +9,13 @@ import org.springframework.stereotype.Component;
 @Component
 public class WorkflowDefinitionScheduleGuard {
   private final ObjectProvider<WorkflowScheduleDao> scheduleDaoProvider;
-  private final ObjectProvider<WorkflowScheduleLifecycle> scheduleLifecycleProvider;
+  private final ObjectProvider<WorkflowScheduleAuditCoordinator> scheduleAuditProvider;
 
   public WorkflowDefinitionScheduleGuard(
       ObjectProvider<WorkflowScheduleDao> scheduleDaoProvider,
-      ObjectProvider<WorkflowScheduleLifecycle> scheduleLifecycleProvider) {
+      ObjectProvider<WorkflowScheduleAuditCoordinator> scheduleAuditProvider) {
     this.scheduleDaoProvider = scheduleDaoProvider;
-    this.scheduleLifecycleProvider = scheduleLifecycleProvider;
+    this.scheduleAuditProvider = scheduleAuditProvider;
   }
 
   /**
@@ -25,24 +25,24 @@ public class WorkflowDefinitionScheduleGuard {
   public void activateConfiguredSchedules(String workflowId) {
     String id = requireWorkflowId(workflowId);
     WorkflowScheduleDao scheduleDao = scheduleDaoProvider.getIfAvailable();
-    WorkflowScheduleLifecycle lifecycle = scheduleLifecycleProvider.getIfAvailable();
-    if (scheduleDao == null || lifecycle == null) return;
+    WorkflowScheduleAuditCoordinator audit = scheduleAuditProvider.getIfAvailable();
+    if (scheduleDao == null || audit == null) return;
 
     Instant now = Instant.now();
     scheduleDao.selectSchedules(id, "OFFLINE").stream()
         .filter(schedule -> schedule.getEndTime() == null || schedule.getEndTime().isAfter(now))
-        .forEach(schedule -> lifecycle.online(schedule.getId()));
+        .forEach(schedule -> audit.onlineFromWorkflow(schedule.getId(), id));
   }
 
   /** 工作流下线前自动停用所有在线调度，避免继续产生新的计划实例。 */
   public void deactivateConfiguredSchedules(String workflowId) {
     String id = requireWorkflowId(workflowId);
     WorkflowScheduleDao scheduleDao = scheduleDaoProvider.getIfAvailable();
-    WorkflowScheduleLifecycle lifecycle = scheduleLifecycleProvider.getIfAvailable();
-    if (scheduleDao == null || lifecycle == null) return;
+    WorkflowScheduleAuditCoordinator audit = scheduleAuditProvider.getIfAvailable();
+    if (scheduleDao == null || audit == null) return;
 
     scheduleDao.selectSchedules(id, "ONLINE")
-        .forEach(schedule -> lifecycle.offline(schedule.getId()));
+        .forEach(schedule -> audit.offlineFromWorkflow(schedule.getId(), id));
   }
 
   private String requireWorkflowId(String workflowId) {

--- a/yak-ops-business/yak-ops-business-workflow/src/main/java/io/yak/ops/business/workflow/schedule/WorkflowScheduleAuditCoordinator.java
+++ b/yak-ops-business/yak-ops-business-workflow/src/main/java/io/yak/ops/business/workflow/schedule/WorkflowScheduleAuditCoordinator.java
@@ -1,0 +1,345 @@
+package io.yak.ops.business.workflow.schedule;
+
+import io.yak.ops.business.audit.AuditEventType;
+import io.yak.ops.business.audit.AuditOperationHandle;
+import io.yak.ops.business.audit.AuditOperationRequest;
+import io.yak.ops.business.audit.BusinessAuditService;
+import io.yak.ops.common.bean.dto.workflow.WorkflowScheduleCreateDTO;
+import io.yak.ops.common.bean.dto.workflow.WorkflowScheduleUpdateDTO;
+import io.yak.ops.common.bean.vo.workflow.WorkflowScheduleVO;
+import java.time.Instant;
+import java.util.Collections;
+import java.util.LinkedHashMap;
+import java.util.Map;
+import java.util.Objects;
+import org.springframework.beans.factory.ObjectProvider;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.stereotype.Component;
+
+/** Adds business-audit semantics around Workflow Schedule management without owning schedule truth. */
+@Component
+@ConditionalOnProperty(
+    prefix = "yak.database",
+    name = "enabled",
+    havingValue = "true",
+    matchIfMissing = true)
+public class WorkflowScheduleAuditCoordinator {
+
+  private static final String RESOURCE_TYPE = "WORKFLOW_SCHEDULE";
+  private static final BusinessAuditService NOOP_AUDIT =
+      request -> AuditOperationHandle.noop(null);
+
+  private final WorkflowScheduleCreateCommand creator;
+  private final WorkflowScheduleRevision revision;
+  private final WorkflowScheduleLifecycle lifecycle;
+  private final WorkflowScheduleQuery query;
+  private final BusinessAuditService auditService;
+
+  @Autowired
+  public WorkflowScheduleAuditCoordinator(
+      WorkflowScheduleCreateCommand creator,
+      WorkflowScheduleRevision revision,
+      WorkflowScheduleLifecycle lifecycle,
+      WorkflowScheduleQuery query,
+      ObjectProvider<BusinessAuditService> auditServiceProvider) {
+    this(
+        creator,
+        revision,
+        lifecycle,
+        query,
+        auditServiceProvider.getIfAvailable(() -> NOOP_AUDIT));
+  }
+
+  WorkflowScheduleAuditCoordinator(
+      WorkflowScheduleCreateCommand creator,
+      WorkflowScheduleRevision revision,
+      WorkflowScheduleLifecycle lifecycle,
+      WorkflowScheduleQuery query,
+      BusinessAuditService auditService) {
+    this.creator = creator;
+    this.revision = revision;
+    this.lifecycle = lifecycle;
+    this.query = query;
+    this.auditService = auditService == null ? NOOP_AUDIT : auditService;
+  }
+
+  public WorkflowScheduleVO create(WorkflowScheduleCreateDTO request) {
+    AuditOperationHandle audit =
+        start(
+            "WORKFLOW_SCHEDULE_CREATE",
+            "Create workflow schedule",
+            null,
+            request == null ? null : trimToNull(request.name()),
+            "WEB",
+            createMetadata(request));
+    try {
+      WorkflowScheduleVO created = creator.create(request);
+      audit.resource(created.id(), created.name());
+      audit.event(
+          AuditEventType.RESOURCE_CREATED,
+          "Workflow schedule created",
+          scheduleSnapshot("SCHEDULE_CREATED", created, null));
+      audit.success("Workflow schedule created");
+      return created;
+    } catch (RuntimeException exception) {
+      audit.failure("WORKFLOW_SCHEDULE_CREATE_FAILED", exception);
+      throw exception;
+    }
+  }
+
+  public WorkflowScheduleVO update(String id, WorkflowScheduleUpdateDTO request) {
+    WorkflowScheduleVO before = query.get(id);
+    UpdateChanges changes = updateChanges(before, request);
+    if (!changes.changed()) {
+      return revision.save(id, request);
+    }
+
+    AuditOperationHandle audit =
+        start(
+            "WORKFLOW_SCHEDULE_UPDATE",
+            "Update workflow schedule",
+            before.id(),
+            before.name(),
+            "WEB",
+            scheduleMetadata(before, "MANUAL"));
+    try {
+      WorkflowScheduleVO updated = revision.save(id, request);
+      audit.resource(updated.id(), updated.name());
+      Map<String, Object> payload = new LinkedHashMap<>(changes.payload());
+      payload.put("changeType", "SCHEDULE_UPDATED");
+      audit.event(
+          AuditEventType.RESOURCE_UPDATED,
+          "Workflow schedule updated",
+          Map.copyOf(payload));
+      audit.success("Workflow schedule updated");
+      return updated;
+    } catch (RuntimeException exception) {
+      audit.failure("WORKFLOW_SCHEDULE_UPDATE_FAILED", exception);
+      throw exception;
+    }
+  }
+
+  public WorkflowScheduleVO online(String id) {
+    return transition(id, true, "WEB", "MANUAL");
+  }
+
+  public WorkflowScheduleVO offline(String id) {
+    return transition(id, false, "WEB", "MANUAL");
+  }
+
+  /**
+   * Parent WORKFLOW_ENABLE already owns the user's business intent and authorization decision.
+   * Do not create a second Schedule AuditOperation for this derived side effect.
+   */
+  public WorkflowScheduleVO onlineFromWorkflow(String id, String workflowId) {
+    return lifecycle.online(id);
+  }
+
+  /**
+   * Parent WORKFLOW_DISABLE is intentionally started after schedules are safely paused. Keeping
+   * this side effect audit-silent also prevents it from claiming the deferred authorization event.
+   */
+  public WorkflowScheduleVO offlineFromWorkflow(String id, String workflowId) {
+    return lifecycle.offline(id);
+  }
+
+  /** Scheduler-side safety action when the owning Workflow can no longer produce executions. */
+  public WorkflowScheduleVO offlineFromScheduler(String id, String cause) {
+    return transition(id, false, "SCHEDULE", normalizeCause(cause, "SCHEDULER_AUTO_DISABLE"));
+  }
+
+  public WorkflowScheduleVO expire(String id, Instant fireTime) {
+    WorkflowScheduleVO before = query.get(id);
+    AuditOperationHandle audit =
+        start(
+            "WORKFLOW_SCHEDULE_EXPIRE",
+            "Expire workflow schedule",
+            before.id(),
+            before.name(),
+            "SCHEDULE",
+            scheduleMetadata(before, "END_TIME_EXPIRED"));
+    try {
+      WorkflowScheduleVO expired = lifecycle.expire(id, fireTime);
+      audit.resource(expired.id(), expired.name());
+      Map<String, Object> payload =
+          new LinkedHashMap<>(scheduleSnapshot("SCHEDULE_EXPIRED", expired, "END_TIME_EXPIRED"));
+      putIfNotNull(payload, "fireTime", fireTime);
+      audit.event(
+          AuditEventType.RESOURCE_UPDATED,
+          "Workflow schedule expired",
+          Map.copyOf(payload));
+      audit.success("Workflow schedule expired");
+      return expired;
+    } catch (RuntimeException exception) {
+      audit.failure("WORKFLOW_SCHEDULE_EXPIRE_FAILED", exception);
+      throw exception;
+    }
+  }
+
+  public void remove(String id) {
+    WorkflowScheduleVO before = query.get(id);
+    AuditOperationHandle audit =
+        start(
+            "WORKFLOW_SCHEDULE_DELETE",
+            "Delete workflow schedule",
+            before.id(),
+            before.name(),
+            "WEB",
+            scheduleMetadata(before, "MANUAL"));
+    try {
+      lifecycle.remove(id);
+      audit.event(
+          AuditEventType.RESOURCE_DELETED,
+          "Workflow schedule deleted",
+          scheduleSnapshot("SCHEDULE_DELETED", before, "MANUAL"));
+      audit.success("Workflow schedule deleted");
+    } catch (RuntimeException exception) {
+      audit.failure("WORKFLOW_SCHEDULE_DELETE_FAILED", exception);
+      throw exception;
+    }
+  }
+
+  private WorkflowScheduleVO transition(
+      String id, boolean online, String source, String cause) {
+    WorkflowScheduleVO before = query.get(id);
+    String targetStatus = online ? "ONLINE" : "OFFLINE";
+    if (targetStatus.equals(before.status())) {
+      return online ? lifecycle.online(id) : lifecycle.offline(id);
+    }
+
+    String operationType = online ? "WORKFLOW_SCHEDULE_ENABLE" : "WORKFLOW_SCHEDULE_DISABLE";
+    String operationName = online ? "Enable workflow schedule" : "Disable workflow schedule";
+    String reasonCode = online
+        ? "WORKFLOW_SCHEDULE_ENABLE_FAILED"
+        : "WORKFLOW_SCHEDULE_DISABLE_FAILED";
+    String changeType = online ? "SCHEDULE_ENABLED" : "SCHEDULE_DISABLED";
+    String message = online ? "Workflow schedule enabled" : "Workflow schedule disabled";
+    AuditOperationHandle audit =
+        start(
+            operationType,
+            operationName,
+            before.id(),
+            before.name(),
+            source,
+            scheduleMetadata(before, cause));
+    try {
+      WorkflowScheduleVO updated = online ? lifecycle.online(id) : lifecycle.offline(id);
+      audit.resource(updated.id(), updated.name());
+      audit.event(
+          AuditEventType.RESOURCE_UPDATED,
+          message,
+          scheduleSnapshot(changeType, updated, cause));
+      audit.success(message);
+      return updated;
+    } catch (RuntimeException exception) {
+      audit.failure(reasonCode, exception);
+      throw exception;
+    }
+  }
+
+  private AuditOperationHandle start(
+      String operationType,
+      String operationName,
+      String resourceId,
+      String resourceName,
+      String source,
+      Map<String, ?> metadata) {
+    return auditService.start(
+        new AuditOperationRequest(
+            operationType,
+            operationName,
+            RESOURCE_TYPE,
+            resourceId,
+            resourceName,
+            source,
+            metadata));
+  }
+
+  private Map<String, Object> createMetadata(WorkflowScheduleCreateDTO request) {
+    Map<String, Object> metadata = new LinkedHashMap<>();
+    if (request == null) return Map.of();
+    putIfNotNull(metadata, "workflowId", trimToNull(request.workflowId()));
+    putIfNotNull(metadata, "cronExpression", trimToNull(request.cronExpression()));
+    putIfNotNull(metadata, "timezone", trimToNull(request.timezone()));
+    putIfNotNull(metadata, "executionStrategy", trimToNull(request.executionStrategy()));
+    putIfNotNull(metadata, "misfireStrategy", trimToNull(request.misfireStrategy()));
+    metadata.put("inputConfigured", request.input() != null && !request.input().isEmpty());
+    return Map.copyOf(metadata);
+  }
+
+  private Map<String, Object> scheduleMetadata(WorkflowScheduleVO schedule, String cause) {
+    Map<String, Object> metadata = new LinkedHashMap<>();
+    putIfNotNull(metadata, "workflowId", schedule.workflowId());
+    putIfNotNull(metadata, "previousStatus", schedule.status());
+    putIfNotNull(metadata, "cause", trimToNull(cause));
+    return Map.copyOf(metadata);
+  }
+
+  private Map<String, Object> scheduleSnapshot(
+      String changeType, WorkflowScheduleVO schedule, String cause) {
+    Map<String, Object> payload = new LinkedHashMap<>();
+    payload.put("changeType", changeType);
+    putIfNotNull(payload, "workflowId", schedule.workflowId());
+    putIfNotNull(payload, "triggerType", schedule.triggerType());
+    putIfNotNull(payload, "cronExpression", schedule.cronExpression());
+    putIfNotNull(payload, "timezone", schedule.timezone());
+    putIfNotNull(payload, "status", schedule.status());
+    putIfNotNull(payload, "executionStrategy", schedule.executionStrategy());
+    putIfNotNull(payload, "misfireStrategy", schedule.misfireStrategy());
+    putIfNotNull(payload, "startTime", schedule.startTime());
+    putIfNotNull(payload, "endTime", schedule.endTime());
+    putIfNotNull(payload, "cause", trimToNull(cause));
+    payload.put("inputConfigured", schedule.input() != null && !schedule.input().isEmpty());
+    return Map.copyOf(payload);
+  }
+
+  private UpdateChanges updateChanges(
+      WorkflowScheduleVO before, WorkflowScheduleUpdateDTO request) {
+    if (request == null) return new UpdateChanges(true, Map.of());
+    String name = trimToNull(request.name());
+    String cron = trimToNull(request.cronExpression());
+    String timezone = trimToNull(request.timezone());
+    String executionStrategy = trimToNull(request.executionStrategy());
+    String misfireStrategy = trimToNull(request.misfireStrategy());
+
+    Map<String, Object> payload = new LinkedHashMap<>();
+    addValueChange(payload, "name", before.name(), name);
+    addValueChange(payload, "cronExpression", before.cronExpression(), cron);
+    addValueChange(payload, "timezone", before.timezone(), timezone);
+    addValueChange(payload, "startTime", before.startTime(), request.startTime());
+    addValueChange(payload, "endTime", before.endTime(), request.endTime());
+    addValueChange(payload, "executionStrategy", before.executionStrategy(), executionStrategy);
+    addValueChange(payload, "misfireStrategy", before.misfireStrategy(), misfireStrategy);
+    if (!Objects.equals(before.input(), request.input())) {
+      payload.put("inputChanged", true);
+    }
+    return new UpdateChanges(!payload.isEmpty(), Map.copyOf(payload));
+  }
+
+  private static void addValueChange(
+      Map<String, Object> payload, String field, Object before, Object after) {
+    if (Objects.equals(before, after)) return;
+    Map<String, Object> change = new LinkedHashMap<>();
+    change.put("before", before);
+    change.put("after", after);
+    payload.put(field, Collections.unmodifiableMap(change));
+  }
+
+  private static void putIfNotNull(Map<String, Object> values, String key, Object value) {
+    if (value != null) values.put(key, value);
+  }
+
+  private static String normalizeCause(String value, String fallback) {
+    String normalized = trimToNull(value);
+    return normalized == null ? fallback : normalized;
+  }
+
+  private static String trimToNull(String value) {
+    if (value == null) return null;
+    String normalized = value.trim();
+    return normalized.isEmpty() ? null : normalized;
+  }
+
+  private record UpdateChanges(boolean changed, Map<String, Object> payload) {}
+}

--- a/yak-ops-business/yak-ops-business-workflow/src/main/java/io/yak/ops/business/workflow/schedule/trigger/WorkflowScheduleTriggerHandler.java
+++ b/yak-ops-business/yak-ops-business-workflow/src/main/java/io/yak/ops/business/workflow/schedule/trigger/WorkflowScheduleTriggerHandler.java
@@ -4,6 +4,7 @@ import io.yak.framework.schedule.api.ScheduleExecutionContext;
 import io.yak.framework.schedule.api.ScheduleExecutionResult;
 import io.yak.framework.schedule.api.ScheduleHandler;
 import io.yak.ops.business.workflow.definition.WorkflowDefinitionManager;
+import io.yak.ops.business.workflow.schedule.WorkflowScheduleAuditCoordinator;
 import io.yak.ops.business.workflow.schedule.WorkflowScheduleLifecycle;
 import io.yak.ops.business.workflow.schedule.WorkflowScheduleQuery;
 import io.yak.ops.business.workflow.schedule.WorkflowScheduleRuntimeState;
@@ -14,6 +15,7 @@ import io.yak.ops.core.project.ProjectContext;
 import io.yak.ops.core.project.ProjectContextScope;
 import java.time.Instant;
 import java.util.Objects;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.stereotype.Component;
 
@@ -24,11 +26,32 @@ public class WorkflowScheduleTriggerHandler implements ScheduleHandler {
   private final WorkflowScheduleQuery schedules;
   private final WorkflowDefinitionManager definitions;
   private final WorkflowScheduleTriggerCoordinator coordinator;
-  private final WorkflowScheduleLifecycle lifecycle;
+  private final WorkflowScheduleAuditCoordinator scheduleAudit;
+  private final WorkflowScheduleLifecycle lifecycleFallback;
   private final WorkflowScheduleEngineBridge engine;
   private final WorkflowScheduleRuntimeState runtimeState;
   private final ProjectContextScope projectScope;
 
+  @Autowired
+  public WorkflowScheduleTriggerHandler(
+      WorkflowScheduleQuery schedules,
+      WorkflowDefinitionManager definitions,
+      WorkflowScheduleTriggerCoordinator coordinator,
+      WorkflowScheduleAuditCoordinator scheduleAudit,
+      WorkflowScheduleEngineBridge engine,
+      WorkflowScheduleRuntimeState runtimeState,
+      ProjectContextScope projectScope) {
+    this.schedules = schedules;
+    this.definitions = definitions;
+    this.coordinator = coordinator;
+    this.scheduleAudit = scheduleAudit;
+    this.lifecycleFallback = null;
+    this.engine = engine;
+    this.runtimeState = runtimeState;
+    this.projectScope = projectScope;
+  }
+
+  /** Focused compatibility constructor for tests that do not wire business Audit. */
   public WorkflowScheduleTriggerHandler(
       WorkflowScheduleQuery schedules,
       WorkflowDefinitionManager definitions,
@@ -40,7 +63,8 @@ public class WorkflowScheduleTriggerHandler implements ScheduleHandler {
     this.schedules = schedules;
     this.definitions = definitions;
     this.coordinator = coordinator;
-    this.lifecycle = lifecycle;
+    this.scheduleAudit = null;
+    this.lifecycleFallback = lifecycle;
     this.engine = engine;
     this.runtimeState = runtimeState;
     this.projectScope = projectScope;
@@ -85,7 +109,7 @@ public class WorkflowScheduleTriggerHandler implements ScheduleHandler {
     }
 
     if (schedule.getEndTime() != null && plannedFireTime.isAfter(schedule.getEndTime())) {
-      lifecycle.expire(scheduleId, actualFireTime);
+      expire(scheduleId, actualFireTime);
       return ScheduleExecutionResult.accepted(null, "调度已超过生效时间并自动停用");
     }
 
@@ -93,11 +117,11 @@ public class WorkflowScheduleTriggerHandler implements ScheduleHandler {
     try {
       workflow = definitions.get(schedule.getWorkflowId());
     } catch (IllegalArgumentException missing) {
-      lifecycle.offline(scheduleId);
+      offline(scheduleId, "WORKFLOW_DEFINITION_MISSING");
       return ScheduleExecutionResult.accepted(null, "工作流定义已删除，调度自动停用");
     }
     if (!"ONLINE".equals(workflow.status()) || workflow.activeVersionId() == null) {
-      lifecycle.offline(scheduleId);
+      offline(scheduleId, "WORKFLOW_NOT_ONLINE");
       return ScheduleExecutionResult.accepted(null, "工作流已下线，调度自动停用");
     }
 
@@ -110,6 +134,22 @@ public class WorkflowScheduleTriggerHandler implements ScheduleHandler {
           context.manual() ? "MANUAL" : "CRON");
     } finally {
       refreshFireState(schedule, actualFireTime);
+    }
+  }
+
+  private void expire(String scheduleId, Instant actualFireTime) {
+    if (scheduleAudit != null) {
+      scheduleAudit.expire(scheduleId, actualFireTime);
+    } else {
+      lifecycleFallback.expire(scheduleId, actualFireTime);
+    }
+  }
+
+  private void offline(String scheduleId, String cause) {
+    if (scheduleAudit != null) {
+      scheduleAudit.offlineFromScheduler(scheduleId, cause);
+    } else {
+      lifecycleFallback.offline(scheduleId);
     }
   }
 

--- a/yak-ops-business/yak-ops-business-workflow/src/test/java/io/yak/ops/business/workflow/architecture/WorkflowRoleConventionTest.java
+++ b/yak-ops-business/yak-ops-business-workflow/src/test/java/io/yak/ops/business/workflow/architecture/WorkflowRoleConventionTest.java
@@ -2,6 +2,7 @@ package io.yak.ops.business.workflow.architecture;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+import io.yak.ops.business.workflow.backfill.WorkflowBackfillAuditCoordinator;
 import io.yak.ops.business.workflow.backfill.WorkflowBackfillManager;
 import io.yak.ops.business.workflow.backfill.WorkflowBackfillPlanner;
 import io.yak.ops.business.workflow.backfill.WorkflowBackfillQuery;
@@ -20,6 +21,7 @@ import io.yak.ops.business.workflow.observability.WorkflowEventStream;
 import io.yak.ops.business.workflow.runtime.WorkflowRuntime;
 import io.yak.ops.business.workflow.runtime.WorkflowRuntimeRecovery;
 import io.yak.ops.business.workflow.schedule.WorkflowDefinitionScheduleGuard;
+import io.yak.ops.business.workflow.schedule.WorkflowScheduleAuditCoordinator;
 import io.yak.ops.business.workflow.schedule.WorkflowScheduleLifecycle;
 import io.yak.ops.business.workflow.schedule.WorkflowScheduleQuery;
 import io.yak.ops.business.workflow.schedule.WorkflowScheduleReconciler;
@@ -56,6 +58,8 @@ class WorkflowRoleConventionTest {
         WorkflowExecutionAuditBridge.class,
         WorkflowExecutionAuditTerminalListener.class,
         WorkflowExecutionControlAuditCoordinator.class,
+        WorkflowScheduleAuditCoordinator.class,
+        WorkflowBackfillAuditCoordinator.class,
         WorkflowPublishedVersionRunner.class,
         WorkflowRuntimeRecovery.class,
         WorkflowEventStream.class,

--- a/yak-ops-business/yak-ops-business-workflow/src/test/java/io/yak/ops/business/workflow/architecture/WorkflowScheduleBackfillAuditContractTest.java
+++ b/yak-ops-business/yak-ops-business-workflow/src/test/java/io/yak/ops/business/workflow/architecture/WorkflowScheduleBackfillAuditContractTest.java
@@ -1,0 +1,68 @@
+package io.yak.ops.business.workflow.architecture;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import org.junit.jupiter.api.Test;
+
+/** Locks the PR 4.3 audit ownership without turning Trigger Ledger into a second audit stream. */
+class WorkflowScheduleBackfillAuditContractTest {
+
+  @Test
+  void businessDateRerunGatewayIsOwnedByAuditCoordinator() throws IOException {
+    String manager = source("backfill/WorkflowBackfillManager.java");
+    String coordinator = source("backfill/WorkflowBackfillAuditCoordinator.java");
+
+    assertThat(manager).doesNotContain("implements WorkflowBusinessDateRerunGateway");
+    assertThat(coordinator).contains("implements WorkflowBusinessDateRerunGateway");
+  }
+
+  @Test
+  void schedulerAutomaticLifecycleUsesAuditedScheduleBoundary() throws IOException {
+    String handler = source("schedule/trigger/WorkflowScheduleTriggerHandler.java");
+    String guard = source("schedule/WorkflowDefinitionScheduleGuard.java");
+
+    assertThat(handler)
+        .contains("WorkflowScheduleAuditCoordinator")
+        .contains("offlineFromScheduler")
+        .contains("scheduleAudit.expire");
+    assertThat(guard)
+        .contains("WorkflowScheduleAuditCoordinator")
+        .contains("onlineFromWorkflow")
+        .contains("offlineFromWorkflow");
+  }
+
+  @Test
+  void triggerLedgerDoesNotCreateItsOwnBusinessAuditOperations() throws IOException {
+    String coordinator = source("schedule/trigger/WorkflowScheduleTriggerCoordinator.java");
+    String admission = source("schedule/trigger/WorkflowScheduleTriggerAdmission.java");
+
+    assertThat(coordinator)
+        .doesNotContain("BusinessAuditService")
+        .doesNotContain("AuditOperationRequest");
+    assertThat(admission)
+        .doesNotContain("BusinessAuditService")
+        .doesNotContain("AuditOperationRequest");
+  }
+
+  private String source(String relative) throws IOException {
+    Path root = Path.of("src/main/java/io/yak/ops/business/workflow");
+    if (!Files.isDirectory(root)) {
+      root = Path.of(
+          "yak-ops-business",
+          "yak-ops-business-workflow",
+          "src",
+          "main",
+          "java",
+          "io",
+          "yak",
+          "ops",
+          "business",
+          "workflow");
+    }
+    return Files.readString(root.resolve(relative), StandardCharsets.UTF_8);
+  }
+}

--- a/yak-ops-business/yak-ops-business-workflow/src/test/java/io/yak/ops/business/workflow/backfill/WorkflowBackfillAuditCoordinatorTest.java
+++ b/yak-ops-business/yak-ops-business-workflow/src/test/java/io/yak/ops/business/workflow/backfill/WorkflowBackfillAuditCoordinatorTest.java
@@ -1,0 +1,194 @@
+package io.yak.ops.business.workflow.backfill;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import io.yak.ops.business.audit.AuditEventType;
+import io.yak.ops.business.audit.AuditOperationHandle;
+import io.yak.ops.business.audit.AuditOperationRequest;
+import io.yak.ops.business.audit.BusinessAuditService;
+import io.yak.ops.common.bean.dto.workflow.WorkflowBackfillCreateDTO;
+import io.yak.ops.common.bean.dto.workflow.WorkflowBusinessDateRerunDTO;
+import io.yak.ops.common.bean.po.workflow.WorkflowBackfillPO;
+import io.yak.ops.common.bean.vo.workflow.WorkflowBackfillVO;
+import io.yak.ops.common.bean.vo.workflow.WorkflowInstanceVO;
+import java.time.Instant;
+import java.time.LocalDate;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import org.junit.jupiter.api.Test;
+
+class WorkflowBackfillAuditCoordinatorTest {
+
+  @Test
+  void createStoresBoundedBatchFactsWithoutRawInput() {
+    WorkflowBackfillManager manager = mock(WorkflowBackfillManager.class);
+    WorkflowBackfillQuery query = mock(WorkflowBackfillQuery.class);
+    RecordingAuditService audit = new RecordingAuditService();
+    WorkflowBackfillAuditCoordinator coordinator =
+        new WorkflowBackfillAuditCoordinator(manager, query, audit);
+    WorkflowBackfillCreateDTO request = new WorkflowBackfillCreateDTO(
+        "schedule-1",
+        "August refill",
+        LocalDate.parse("2026-08-01"),
+        LocalDate.parse("2026-08-03"),
+        "SERIAL_WAIT",
+        Map.of("token", "backfill-secret"));
+    WorkflowBackfillVO created = backfill("RUNNING", "BACKFILL", Map.of("token", "backfill-secret"));
+    when(manager.create(request)).thenReturn(created);
+
+    coordinator.create(request);
+
+    assertThat(audit.request.operationType()).isEqualTo("WORKFLOW_BACKFILL_CREATE");
+    assertThat(audit.request.resourceType()).isEqualTo("WORKFLOW_BACKFILL");
+    assertThat(audit.request.metadata().toString()).doesNotContain("backfill-secret");
+    Map<String, ?> payload = audit.handle.events.get(0).payload();
+    assertThat(payload)
+        .containsEntry("changeType", "BACKFILL_CREATED")
+        .containsEntry("totalCount", 3)
+        .containsEntry("inputConfigured", true);
+    assertThat(payload.toString()).doesNotContain("backfill-secret");
+  }
+
+  @Test
+  void businessDateRerunIsTheGatewayAuditOwner() {
+    WorkflowBackfillManager manager = mock(WorkflowBackfillManager.class);
+    WorkflowBackfillQuery query = mock(WorkflowBackfillQuery.class);
+    RecordingAuditService audit = new RecordingAuditService();
+    WorkflowBackfillAuditCoordinator coordinator =
+        new WorkflowBackfillAuditCoordinator(manager, query, audit);
+    WorkflowBusinessDateRerunDTO request = new WorkflowBusinessDateRerunDTO(
+        LocalDate.parse("2026-08-02"),
+        "SERIAL_WAIT",
+        Map.of("password", "rerun-secret"));
+    WorkflowInstanceVO source = instance("execution-source");
+    WorkflowBackfillVO created =
+        backfill("RUNNING", "BUSINESS_DATE_RERUN", Map.of("password", "rerun-secret"));
+    when(manager.createBusinessDateRerun("execution-source", source, request)).thenReturn(created);
+
+    coordinator.createBusinessDateRerun("execution-source", source, request);
+
+    assertThat(audit.request.operationType()).isEqualTo("WORKFLOW_BUSINESS_DATE_RERUN");
+    assertThat(audit.request.metadata()).containsEntry("sourceExecutionId", "execution-source");
+    assertThat(audit.request.metadata().toString()).doesNotContain("rerun-secret");
+    assertThat(audit.handle.events.get(0).payload())
+        .containsEntry("changeType", "BUSINESS_DATE_RERUN_CREATED");
+    assertThat(audit.handle.events.get(0).payload().toString()).doesNotContain("rerun-secret");
+  }
+
+  @Test
+  void repeatedCancelDoesNotCreateAuditNoiseWhenDurableBatchIsAlreadyCanceled() {
+    WorkflowBackfillManager manager = mock(WorkflowBackfillManager.class);
+    WorkflowBackfillQuery query = mock(WorkflowBackfillQuery.class);
+    RecordingAuditService audit = new RecordingAuditService();
+    WorkflowBackfillAuditCoordinator coordinator =
+        new WorkflowBackfillAuditCoordinator(manager, query, audit);
+    WorkflowBackfillPO durable = new WorkflowBackfillPO();
+    durable.setId("backfill-1");
+    durable.setStatus("CANCELED");
+    WorkflowBackfillVO canceled = backfill("CANCELED", "BACKFILL", Map.of());
+    when(query.require("backfill-1")).thenReturn(durable);
+    when(manager.cancel("backfill-1")).thenReturn(canceled);
+
+    WorkflowBackfillVO result = coordinator.cancel("backfill-1");
+
+    assertThat(result).isSameAs(canceled);
+    assertThat(audit.starts).isZero();
+    verify(manager).cancel("backfill-1");
+  }
+
+  private static WorkflowBackfillVO backfill(
+      String status, String operationType, Map<String, Object> input) {
+    Instant now = Instant.parse("2026-09-02T00:00:00Z");
+    return new WorkflowBackfillVO(
+        "backfill-1",
+        "workflow-1",
+        "workflow-version-2",
+        2,
+        "schedule-1",
+        "Daily sync",
+        "August refill",
+        status,
+        operationType,
+        "BUSINESS_DATE_RERUN".equals(operationType) ? "execution-source" : null,
+        LocalDate.parse("2026-08-01"),
+        LocalDate.parse("2026-08-03"),
+        "0 0 2 * * ?",
+        "Asia/Shanghai",
+        "SERIAL_WAIT",
+        input,
+        3,
+        2,
+        1,
+        0,
+        0,
+        0,
+        0,
+        now,
+        now);
+  }
+
+  private static WorkflowInstanceVO instance(String id) {
+    Instant now = Instant.parse("2026-09-02T00:00:00Z");
+    return new WorkflowInstanceVO(
+        id,
+        "workflow-version-2",
+        null,
+        "Daily sync",
+        "FAILED",
+        "FAIL_FAST",
+        now,
+        now,
+        now,
+        300L,
+        Map.of(),
+        0,
+        0,
+        List.of(),
+        "workflow-version-2",
+        2,
+        false);
+  }
+
+  private static final class RecordingAuditService implements BusinessAuditService {
+    int starts;
+    AuditOperationRequest request;
+    RecordingHandle handle;
+
+    @Override
+    public AuditOperationHandle start(AuditOperationRequest request) {
+      starts++;
+      this.request = request;
+      this.handle = new RecordingHandle();
+      return handle;
+    }
+  }
+
+  private static final class RecordingHandle implements AuditOperationHandle {
+    final List<Event> events = new ArrayList<>();
+
+    @Override
+    public String operationId() {
+      return "AUD-backfill";
+    }
+
+    @Override
+    public void resource(String resourceId, String resourceName) {}
+
+    @Override
+    public void event(AuditEventType type, String message, Map<String, ?> payload) {
+      events.add(new Event(type, message, Map.copyOf(payload)));
+    }
+
+    @Override
+    public void success(String summary) {}
+
+    @Override
+    public void failure(String reasonCode, Throwable cause) {}
+  }
+
+  private record Event(AuditEventType type, String message, Map<String, ?> payload) {}
+}

--- a/yak-ops-business/yak-ops-business-workflow/src/test/java/io/yak/ops/business/workflow/schedule/WorkflowDefinitionScheduleGuardTest.java
+++ b/yak-ops-business/yak-ops-business-workflow/src/test/java/io/yak/ops/business/workflow/schedule/WorkflowDefinitionScheduleGuardTest.java
@@ -21,15 +21,15 @@ import org.springframework.beans.factory.ObjectProvider;
 class WorkflowDefinitionScheduleGuardTest {
 
   @Mock private ObjectProvider<WorkflowScheduleDao> scheduleDaoProvider;
-  @Mock private ObjectProvider<WorkflowScheduleLifecycle> scheduleLifecycleProvider;
+  @Mock private ObjectProvider<WorkflowScheduleAuditCoordinator> scheduleAuditProvider;
   @Mock private WorkflowScheduleDao scheduleDao;
-  @Mock private WorkflowScheduleLifecycle scheduleLifecycle;
+  @Mock private WorkflowScheduleAuditCoordinator scheduleAudit;
 
   private WorkflowDefinitionScheduleGuard guard;
 
   @BeforeEach
   void setUp() {
-    guard = new WorkflowDefinitionScheduleGuard(scheduleDaoProvider, scheduleLifecycleProvider);
+    guard = new WorkflowDefinitionScheduleGuard(scheduleDaoProvider, scheduleAuditProvider);
   }
 
   @Test
@@ -46,12 +46,12 @@ class WorkflowDefinitionScheduleGuardTest {
   void shouldActivateSavedSchedulesWhenWorkflowGoesOnline() {
     WorkflowSchedulePO schedule = schedule("schedule-1", "OFFLINE");
     when(scheduleDaoProvider.getIfAvailable()).thenReturn(scheduleDao);
-    when(scheduleLifecycleProvider.getIfAvailable()).thenReturn(scheduleLifecycle);
+    when(scheduleAuditProvider.getIfAvailable()).thenReturn(scheduleAudit);
     when(scheduleDao.selectSchedules("workflow-1", "OFFLINE")).thenReturn(List.of(schedule));
 
     guard.activateConfiguredSchedules("workflow-1");
 
-    verify(scheduleLifecycle).online("schedule-1");
+    verify(scheduleAudit).onlineFromWorkflow("schedule-1", "workflow-1");
   }
 
   @Test
@@ -59,24 +59,24 @@ class WorkflowDefinitionScheduleGuardTest {
     WorkflowSchedulePO schedule = schedule("schedule-expired", "OFFLINE");
     schedule.setEndTime(Instant.now().minus(1, ChronoUnit.DAYS));
     when(scheduleDaoProvider.getIfAvailable()).thenReturn(scheduleDao);
-    when(scheduleLifecycleProvider.getIfAvailable()).thenReturn(scheduleLifecycle);
+    when(scheduleAuditProvider.getIfAvailable()).thenReturn(scheduleAudit);
     when(scheduleDao.selectSchedules("workflow-1", "OFFLINE")).thenReturn(List.of(schedule));
 
     guard.activateConfiguredSchedules("workflow-1");
 
-    verifyNoInteractions(scheduleLifecycle);
+    verifyNoInteractions(scheduleAudit);
   }
 
   @Test
   void shouldDeactivateOnlineSchedulesBeforeWorkflowGoesOffline() {
     WorkflowSchedulePO schedule = schedule("schedule-1", "ONLINE");
     when(scheduleDaoProvider.getIfAvailable()).thenReturn(scheduleDao);
-    when(scheduleLifecycleProvider.getIfAvailable()).thenReturn(scheduleLifecycle);
+    when(scheduleAuditProvider.getIfAvailable()).thenReturn(scheduleAudit);
     when(scheduleDao.selectSchedules("workflow-1", "ONLINE")).thenReturn(List.of(schedule));
 
     guard.deactivateConfiguredSchedules("workflow-1");
 
-    verify(scheduleLifecycle).offline("schedule-1");
+    verify(scheduleAudit).offlineFromWorkflow("schedule-1", "workflow-1");
   }
 
   private WorkflowSchedulePO schedule(String id, String status) {

--- a/yak-ops-business/yak-ops-business-workflow/src/test/java/io/yak/ops/business/workflow/schedule/WorkflowScheduleAuditCoordinatorTest.java
+++ b/yak-ops-business/yak-ops-business-workflow/src/test/java/io/yak/ops/business/workflow/schedule/WorkflowScheduleAuditCoordinatorTest.java
@@ -1,0 +1,194 @@
+package io.yak.ops.business.workflow.schedule;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import io.yak.ops.business.audit.AuditEventType;
+import io.yak.ops.business.audit.AuditOperationHandle;
+import io.yak.ops.business.audit.AuditOperationRequest;
+import io.yak.ops.business.audit.BusinessAuditService;
+import io.yak.ops.common.bean.dto.workflow.WorkflowScheduleCreateDTO;
+import io.yak.ops.common.bean.dto.workflow.WorkflowScheduleUpdateDTO;
+import io.yak.ops.common.bean.vo.workflow.WorkflowScheduleVO;
+import java.time.Instant;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import org.junit.jupiter.api.Test;
+
+class WorkflowScheduleAuditCoordinatorTest {
+
+  @Test
+  void createKeepsScheduleInputOutOfAuditPayload() {
+    WorkflowScheduleCreateCommand creator = mock(WorkflowScheduleCreateCommand.class);
+    WorkflowScheduleRevision revision = mock(WorkflowScheduleRevision.class);
+    WorkflowScheduleLifecycle lifecycle = mock(WorkflowScheduleLifecycle.class);
+    WorkflowScheduleQuery query = mock(WorkflowScheduleQuery.class);
+    RecordingAuditService audit = new RecordingAuditService();
+    WorkflowScheduleAuditCoordinator coordinator =
+        new WorkflowScheduleAuditCoordinator(creator, revision, lifecycle, query, audit);
+    WorkflowScheduleCreateDTO request = new WorkflowScheduleCreateDTO(
+        "workflow-1",
+        "Daily sync",
+        "0 0 2 * * ?",
+        "Asia/Shanghai",
+        null,
+        null,
+        "SERIAL_WAIT",
+        "FIRE_ONCE",
+        Map.of("password", "schedule-secret"));
+    WorkflowScheduleVO created = schedule("OFFLINE", Map.of("password", "schedule-secret"));
+    when(creator.create(request)).thenReturn(created);
+
+    coordinator.create(request);
+
+    assertThat(audit.request.operationType()).isEqualTo("WORKFLOW_SCHEDULE_CREATE");
+    assertThat(audit.request.resourceType()).isEqualTo("WORKFLOW_SCHEDULE");
+    assertThat(audit.request.metadata().toString()).doesNotContain("schedule-secret");
+    assertThat(audit.handle.events).hasSize(1);
+    Map<String, ?> payload = audit.handle.events.get(0).payload();
+    assertThat(payload)
+        .containsEntry("changeType", "SCHEDULE_CREATED")
+        .containsEntry("inputConfigured", true);
+    assertThat(payload.toString()).doesNotContain("schedule-secret");
+  }
+
+  @Test
+  void unchangedUpdateDoesNotCreateAuditNoise() {
+    WorkflowScheduleCreateCommand creator = mock(WorkflowScheduleCreateCommand.class);
+    WorkflowScheduleRevision revision = mock(WorkflowScheduleRevision.class);
+    WorkflowScheduleLifecycle lifecycle = mock(WorkflowScheduleLifecycle.class);
+    WorkflowScheduleQuery query = mock(WorkflowScheduleQuery.class);
+    RecordingAuditService audit = new RecordingAuditService();
+    WorkflowScheduleAuditCoordinator coordinator =
+        new WorkflowScheduleAuditCoordinator(creator, revision, lifecycle, query, audit);
+    WorkflowScheduleVO before = schedule("OFFLINE", Map.of());
+    WorkflowScheduleUpdateDTO request = new WorkflowScheduleUpdateDTO(
+        before.name(),
+        before.cronExpression(),
+        before.timezone(),
+        before.startTime(),
+        before.endTime(),
+        before.executionStrategy(),
+        before.misfireStrategy(),
+        before.input());
+    when(query.get("schedule-1")).thenReturn(before);
+    when(revision.save("schedule-1", request)).thenReturn(before);
+
+    WorkflowScheduleVO result = coordinator.update("schedule-1", request);
+
+    assertThat(result).isSameAs(before);
+    assertThat(audit.starts).isZero();
+    verify(revision).save("schedule-1", request);
+  }
+
+  @Test
+  void schedulerDisableUsesSystemSourceAndStableCause() {
+    WorkflowScheduleCreateCommand creator = mock(WorkflowScheduleCreateCommand.class);
+    WorkflowScheduleRevision revision = mock(WorkflowScheduleRevision.class);
+    WorkflowScheduleLifecycle lifecycle = mock(WorkflowScheduleLifecycle.class);
+    WorkflowScheduleQuery query = mock(WorkflowScheduleQuery.class);
+    RecordingAuditService audit = new RecordingAuditService();
+    WorkflowScheduleAuditCoordinator coordinator =
+        new WorkflowScheduleAuditCoordinator(creator, revision, lifecycle, query, audit);
+    WorkflowScheduleVO before = schedule("ONLINE", Map.of());
+    WorkflowScheduleVO after = schedule("OFFLINE", Map.of());
+    when(query.get("schedule-1")).thenReturn(before);
+    when(lifecycle.offline("schedule-1")).thenReturn(after);
+
+    coordinator.offlineFromScheduler("schedule-1", "WORKFLOW_NOT_ONLINE");
+
+    assertThat(audit.request.operationType()).isEqualTo("WORKFLOW_SCHEDULE_DISABLE");
+    assertThat(audit.request.source()).isEqualTo("SCHEDULE");
+    assertThat(audit.request.metadata()).containsEntry("cause", "WORKFLOW_NOT_ONLINE");
+    assertThat(audit.handle.events.get(0).payload())
+        .containsEntry("changeType", "SCHEDULE_DISABLED")
+        .containsEntry("cause", "WORKFLOW_NOT_ONLINE");
+  }
+
+  @Test
+  void expiryIsAStandaloneSystemAuditOperation() {
+    WorkflowScheduleCreateCommand creator = mock(WorkflowScheduleCreateCommand.class);
+    WorkflowScheduleRevision revision = mock(WorkflowScheduleRevision.class);
+    WorkflowScheduleLifecycle lifecycle = mock(WorkflowScheduleLifecycle.class);
+    WorkflowScheduleQuery query = mock(WorkflowScheduleQuery.class);
+    RecordingAuditService audit = new RecordingAuditService();
+    WorkflowScheduleAuditCoordinator coordinator =
+        new WorkflowScheduleAuditCoordinator(creator, revision, lifecycle, query, audit);
+    WorkflowScheduleVO before = schedule("ONLINE", Map.of());
+    WorkflowScheduleVO after = schedule("OFFLINE", Map.of());
+    Instant fireTime = Instant.parse("2026-09-02T02:00:00Z");
+    when(query.get("schedule-1")).thenReturn(before);
+    when(lifecycle.expire("schedule-1", fireTime)).thenReturn(after);
+
+    coordinator.expire("schedule-1", fireTime);
+
+    assertThat(audit.request.operationType()).isEqualTo("WORKFLOW_SCHEDULE_EXPIRE");
+    assertThat(audit.request.source()).isEqualTo("SCHEDULE");
+    assertThat(audit.handle.events.get(0).payload())
+        .containsEntry("changeType", "SCHEDULE_EXPIRED")
+        .containsEntry("fireTime", fireTime);
+  }
+
+  private static WorkflowScheduleVO schedule(String status, Map<String, Object> input) {
+    Instant now = Instant.parse("2026-09-02T00:00:00Z");
+    return new WorkflowScheduleVO(
+        "schedule-1",
+        "workflow-1",
+        "Daily sync",
+        "CRON",
+        "0 0 2 * * ?",
+        "Asia/Shanghai",
+        null,
+        null,
+        status,
+        "SERIAL_WAIT",
+        "FIRE_ONCE",
+        input,
+        null,
+        null,
+        now,
+        now);
+  }
+
+  private static final class RecordingAuditService implements BusinessAuditService {
+    int starts;
+    AuditOperationRequest request;
+    RecordingHandle handle;
+
+    @Override
+    public AuditOperationHandle start(AuditOperationRequest request) {
+      starts++;
+      this.request = request;
+      this.handle = new RecordingHandle();
+      return handle;
+    }
+  }
+
+  private static final class RecordingHandle implements AuditOperationHandle {
+    final List<Event> events = new ArrayList<>();
+
+    @Override
+    public String operationId() {
+      return "AUD-schedule";
+    }
+
+    @Override
+    public void resource(String resourceId, String resourceName) {}
+
+    @Override
+    public void event(AuditEventType type, String message, Map<String, ?> payload) {
+      events.add(new Event(type, message, Map.copyOf(payload)));
+    }
+
+    @Override
+    public void success(String summary) {}
+
+    @Override
+    public void failure(String reasonCode, Throwable cause) {}
+  }
+
+  private record Event(AuditEventType type, String message, Map<String, ?> payload) {}
+}


### PR DESCRIPTION
## Summary

Implements **PR 4.3** for #921: complete the Workflow audit vertical slice with **Schedule management, scheduler-owned lifecycle actions, Backfill batches, and business-date reruns**.

PR 4.1 / #968 and PR 4.2 / #970 are already merged. This branch is directly based on current `main` and contains one focused commit.

The boundary remains deliberate:

```text
Schedule / Backfill management action
    -> management AuditOperation

Trigger Ledger admission/state
    -> remains runtime coordination truth

Trigger actually launches WorkflowExecution
    -> existing WORKFLOW_EXECUTE audit from PR 4.2
```

This avoids turning one Cron/Backfill occurrence into duplicate Audit Center rows.

## 1. Schedule management audit

Adds `WorkflowScheduleAuditCoordinator` around the existing Schedule business roles rather than moving Audit into DAO or Yak Schedule integration.

Direct Schedule operations now create:

```text
WORKFLOW_SCHEDULE_CREATE
WORKFLOW_SCHEDULE_UPDATE
WORKFLOW_SCHEDULE_ENABLE
WORKFLOW_SCHEDULE_DISABLE
WORKFLOW_SCHEDULE_DELETE
```

with:

```text
resource_type = WORKFLOW_SCHEDULE
resource_id   = scheduleId
```

The existing `WorkflowScheduleCreateCommand`, `WorkflowScheduleRevision`, and `WorkflowScheduleLifecycle` remain the business truth owners.

No-op Schedule updates do not create audit noise.

## 2. Scheduler automatic lifecycle is also explainable

The Yak Schedule callback can independently change Schedule state when:

- the configured end time has passed;
- the owning Workflow no longer exists;
- the owning Workflow is no longer ONLINE.

Those background actions now use the same Schedule audit boundary:

```text
WORKFLOW_SCHEDULE_EXPIRE
source = SCHEDULE
cause  = END_TIME_EXPIRED

WORKFLOW_SCHEDULE_DISABLE
source = SCHEDULE
cause  = WORKFLOW_DEFINITION_MISSING | WORKFLOW_NOT_ONLINE
```

Because `WorkflowScheduleTriggerHandler` already restores the durable Project before business IO, these AuditOperations retain the correct Project snapshot while naturally resolving a SYSTEM actor when no interactive user exists.

## 3. Workflow online/offline linkage does not create duplicate Schedule rows

Workflow Definition online/offline automatically enables/disables configured schedules.

Those Schedule mutations are **derived side effects of the parent Workflow action**, so PR 4.3 intentionally keeps them audit-silent:

```text
WORKFLOW_ENABLE / WORKFLOW_DISABLE
    -> WorkflowDefinitionScheduleGuard
    -> Schedule lifecycle side effect
    -> no second Schedule AuditOperation
```

This serves two purposes:

1. Audit Center stays focused on the user's actual business intent rather than emitting N child rows for N schedules.
2. Project authorization remains attached to the parent Workflow operation. In the offline path, schedules are safely paused before `WORKFLOW_DISABLE` starts; creating a child AuditOperation there would otherwise consume the deferred authorization decision before the parent operation could claim it.

Direct user Schedule actions and independent Scheduler actions still create their own Schedule AuditOperations.

## 4. Schedule payload is allowlist-only

Schedule audit may keep stable business facts such as:

```text
workflowId
cronExpression
timezone
startTime / endTime
executionStrategy
misfireStrategy
status
```

Schedule input values are never copied into Audit.

Only bounded facts are stored:

```text
inputConfigured
inputChanged
```

For updates, safe before/after values are emitted only for the allowed configuration fields.

## 5. Backfill management audit

Adds `WorkflowBackfillAuditCoordinator` for:

```text
WORKFLOW_BACKFILL_CREATE
WORKFLOW_BACKFILL_CANCEL
WORKFLOW_BUSINESS_DATE_RERUN
```

with:

```text
resource_type = WORKFLOW_BACKFILL
resource_id   = backfillId
```

The existing `WorkflowBackfillManager` continues to own Backfill business behavior; the new coordinator only wraps those commands with Audit semantics.

Preview/list/detail remain read-only and do not create audit rows.

## 6. businessDate rerun has one audited Gateway

`WorkflowExecutionManager` reaches Backfill through the existing execution-owned port:

```text
WorkflowBusinessDateRerunGateway
```

Before this PR, `WorkflowBackfillManager` implemented that port directly.

PR 4.3 moves the port implementation to:

```text
WorkflowBackfillAuditCoordinator
    -> WorkflowBackfillManager
```

so the operations-page `rerun-business-date` route cannot bypass Audit while Execution still has no dependency on the Backfill implementation package.

The Manager method remains the Backfill business implementation, but it is no longer the cross-subsystem Gateway bean.

## 7. Backfill payload is bounded

Audit records stable batch facts such as:

```text
workflowId
workflowVersionId / workflowVersionNo
scheduleId
operationType
sourceExecutionId
startBusinessDate / endBusinessDate
timezone
executionStrategy
total/waiting/running/succeeded/failed/canceled/skipped counts
```

It deliberately excludes:

```text
Backfill input values
inherited source execution input
schedule input values
Trigger runtime message/error text
Workflow child execution input/output
```

Only `inputConfigured=true/false` is retained.

Repeated cancel is treated as audit-noise only when the **durable Backfill row itself** is already `CANCELED`. The decision does not rely on the read model's Trigger-derived status, because that projection can report CANCELED while the batch row still requires a real cancel mutation.

## 8. Trigger Ledger stays out of business Audit production

PR 4.3 deliberately does not add `BusinessAuditService` to:

```text
WorkflowScheduleTriggerCoordinator
WorkflowScheduleTriggerAdmission
```

RECEIVED / WAITING / LAUNCHING / SKIPPED etc. remain durable scheduling/admission truth, not standalone business Audit Center rows.

When a Trigger actually launches a WorkflowExecution, PR 4.2 already creates:

```text
WORKFLOW_EXECUTE
source = SCHEDULE / BACKFILL
metadata = triggerId / scheduleId / backfillId / plannedFireTime / ...
```

so execution history remains end-to-end without duplicating the Trigger Ledger.

## 9. Keep the Audit event vocabulary small

No new `AuditEventType` is introduced.

PR 4.3 continues using generic resource events plus stable `changeType` hints:

```text
SCHEDULE_CREATED
SCHEDULE_UPDATED
SCHEDULE_ENABLED
SCHEDULE_DISABLED
SCHEDULE_EXPIRED
SCHEDULE_DELETED
BACKFILL_CREATED
BACKFILL_CANCELED
BUSINESS_DATE_RERUN_CREATED
```

`AuditTimelineRendererRegistry` renders these as business-facing copy such as:

```text
调度已创建
调度配置已更新
调度已启用
调度已停用
调度已过期
调度已删除
Backfill 已创建
Backfill 已取消
运维补跑已创建
```

Stable Schedule/Backfill failure reason codes also receive Chinese Audit Center labels without storing arbitrary exception messages.

## 10. Architecture contract

Updates Workflow architecture/dependency documentation and executable guards to lock:

```text
HTTP/Scheduler -> WorkflowScheduleAuditCoordinator -> existing Schedule roles
Execution rerun port -> WorkflowBackfillAuditCoordinator -> WorkflowBackfillManager
Trigger Ledger -> no direct BusinessAuditService
child execution -> WorkflowLauncher -> WorkflowExecutionAuditBridge
```

Both new audit coordinators remain internal `@Component` roles rather than new generic Services.

## Schema

**No Flyway or database schema change.**

PR 4.3 reuses the Audit model and Workflow persistence introduced by the previous PRs.

## Tests / validation

Added/updated focused coverage for:

- Schedule create with raw input excluded from Audit;
- no-op Schedule update creates no AuditOperation;
- Scheduler auto-disable uses `source=SCHEDULE` and a stable cause;
- Schedule expiry is a standalone system business operation;
- Workflow online/offline linkage routes through the Schedule boundary but stays audit-silent;
- Backfill create stores bounded batch facts without raw input;
- businessDate rerun is owned by the audited Gateway;
- repeated Backfill cancel checks durable batch state rather than derived read status;
- Schedule/Backfill Timeline business rendering;
- Trigger Coordinator/Admission remain free of direct Audit production;
- Workflow role/architecture contract updates.

Repository compare at PR creation:

```text
1 commit ahead
0 commits behind current main
16 changed files
no Flyway/schema change
```

GitHub currently reports no workflow runs or commit status checks for the head, so this PR remains Draft.

Recommended local verification:

```bash
mvn -pl yak-ops-business/yak-ops-business-audit,yak-ops-business/yak-ops-business-workflow -am test
```

Suggested smoke flow:

1. Create a Schedule with non-empty input and confirm `WORKFLOW_SCHEDULE_CREATE` contains schedule configuration but not input values.
2. Save the exact same Schedule and confirm no new AuditOperation.
3. Update Cron/timezone/strategy and confirm only safe before/after fields plus `inputChanged` are persisted.
4. Manually enable/disable/delete a Schedule and verify the corresponding management rows.
5. Let an ONLINE Schedule pass its end time and confirm SYSTEM/SCHEDULE creates `WORKFLOW_SCHEDULE_EXPIRE`.
6. Let the Scheduler encounter a missing/offline Workflow and confirm an automatic Schedule disable with the stable cause.
7. Online/offline a Workflow that owns multiple Schedules and verify the parent Workflow audit remains the user-facing operation instead of creating N derived Schedule rows.
8. Create a Backfill with input values and confirm `WORKFLOW_BACKFILL_CREATE` does not contain those values.
9. Use `rerun-business-date` and confirm one `WORKFLOW_BUSINESS_DATE_RERUN` management row plus child `WORKFLOW_EXECUTE` rows when occurrences launch.
10. Cancel a Backfill and confirm the batch AuditOperation is separate from already-running child executions.
11. Verify Trigger Ledger RECEIVED/WAITING/SKIPPED transitions do not appear as standalone Audit Center rows.

## Non-goals

- Node/Attempt/step-level Workflow audit events
- flattening Trigger Ledger into Audit Center
- Backfill child execution aggregation/tree UI
- parent_operation_id / operation trees
- Schedule/Backfill input snapshots
- Audit retention/export/SIEM/lossless delivery
- expanding audit producer coverage to Dataset/Realtime/Data Service

Refs #921