### PR TITLE
fix(workflow): restore startup after execution audit wiring

### DIFF
--- a/yak-ops-business/yak-ops-business-workflow/src/main/java/io/yak/ops/business/workflow/execution/WorkflowExecutionAuditBridge.java
+++ b/yak-ops-business/yak-ops-business-workflow/src/main/java/io/yak/ops/business/workflow/execution/WorkflowExecutionAuditBridge.java
@@ -22,6 +22,7 @@ import java.util.function.Supplier;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.ObjectProvider;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 import org.springframework.util.StringUtils;
 
@@ -38,6 +39,7 @@ public class WorkflowExecutionAuditBridge {
   private final WorkflowAuditCorrelationRepository correlationRepository;
   private final ObjectMapper objectMapper;
 
+  @Autowired
   public WorkflowExecutionAuditBridge(
       ObjectProvider<BusinessAuditService> auditServiceProvider,
       ObjectProvider<WorkflowAuditCorrelationRepository> correlationRepositoryProvider,

--- a/yak-ops-business/yak-ops-business-workflow/src/test/java/io/yak/ops/business/workflow/execution/WorkflowExecutionAuditBridgeSpringTest.java
+++ b/yak-ops-business/yak-ops-business-workflow/src/test/java/io/yak/ops/business/workflow/execution/WorkflowExecutionAuditBridgeSpringTest.java
@@ -1,0 +1,38 @@
+package io.yak.ops.business.workflow.execution;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.Test;
+import org.springframework.context.annotation.AnnotationConfigApplicationContext;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.ComponentScan;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.FilterType;
+
+class WorkflowExecutionAuditBridgeSpringTest {
+
+  @Test
+  void componentScanSelectsAutowiredProviderConstructor() {
+    try (AnnotationConfigApplicationContext context =
+        new AnnotationConfigApplicationContext(TestConfiguration.class)) {
+      assertThat(context.getBean(WorkflowExecutionAuditBridge.class)).isNotNull();
+    }
+  }
+
+  @Configuration(proxyBeanMethods = false)
+  @ComponentScan(
+      basePackageClasses = WorkflowExecutionAuditBridge.class,
+      useDefaultFilters = false,
+      includeFilters =
+          @ComponentScan.Filter(
+              type = FilterType.ASSIGNABLE_TYPE,
+              classes = WorkflowExecutionAuditBridge.class))
+  static class TestConfiguration {
+
+    @Bean
+    ObjectMapper objectMapper() {
+      return new ObjectMapper();
+    }
+  }
+}


### PR DESCRIPTION
## Summary

Fix application startup failure introduced by the workflow execution audit correlation wiring.

`WorkflowExecutionAuditBridge` has two constructors: the Spring-facing `ObjectProvider` constructor and a package-private compatibility constructor used by focused tests. Without an explicit injection constructor, Spring falls back to default instantiation and fails because the component has no no-arg constructor.

## Changes

- mark the `ObjectProvider` constructor with `@Autowired`
- add a focused component-scan regression test proving Spring can instantiate `WorkflowExecutionAuditBridge`
- keep the package-private constructor for existing unit tests and direct wiring

## Root cause

Startup failed with:

```text
Failed to instantiate [io.yak.ops.business.workflow.execution.WorkflowExecutionAuditBridge]: No default constructor found
Caused by: java.lang.NoSuchMethodException: io.yak.ops.business.workflow.execution.WorkflowExecutionAuditBridge.<init>()
```

This was introduced when workflow execution audit correlation added the second constructor without explicitly selecting the Spring constructor.

## Risk

Low. The fix only clarifies constructor selection; runtime audit behavior and workflow execution logic are unchanged.
