### PR TITLE
fix(workflow): restore control audit startup wiring

### DIFF
--- a/yak-ops-business/yak-ops-business-workflow/src/main/java/io/yak/ops/business/workflow/execution/WorkflowExecutionControlAuditCoordinator.java
+++ b/yak-ops-business/yak-ops-business-workflow/src/main/java/io/yak/ops/business/workflow/execution/WorkflowExecutionControlAuditCoordinator.java
@@ -13,6 +13,7 @@ import java.util.Locale;
 import java.util.Map;
 import java.util.function.Supplier;
 import org.springframework.beans.factory.ObjectProvider;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 
 /** Audits short actor-owned pause/resume/cancel commands without replacing execution correlation. */
@@ -25,6 +26,7 @@ public class WorkflowExecutionControlAuditCoordinator {
   private final WorkflowRuntime runtime;
   private final BusinessAuditService auditService;
 
+  @Autowired
   public WorkflowExecutionControlAuditCoordinator(
       WorkflowRuntime runtime,
       ObjectProvider<BusinessAuditService> auditServiceProvider) {

--- a/yak-ops-business/yak-ops-business-workflow/src/test/java/io/yak/ops/business/workflow/execution/WorkflowExecutionAuditBridgeSpringTest.java
+++ b/yak-ops-business/yak-ops-business-workflow/src/test/java/io/yak/ops/business/workflow/execution/WorkflowExecutionAuditBridgeSpringTest.java
@@ -1,8 +1,10 @@
 package io.yak.ops.business.workflow.execution;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import io.yak.ops.business.workflow.runtime.WorkflowRuntime;
 import org.junit.jupiter.api.Test;
 import org.springframework.context.annotation.AnnotationConfigApplicationContext;
 import org.springframework.context.annotation.Bean;
@@ -13,10 +15,11 @@ import org.springframework.context.annotation.FilterType;
 class WorkflowExecutionAuditBridgeSpringTest {
 
   @Test
-  void componentScanSelectsAutowiredProviderConstructor() {
+  void componentScanSelectsAutowiredConstructorsForAuditComponents() {
     try (AnnotationConfigApplicationContext context =
         new AnnotationConfigApplicationContext(TestConfiguration.class)) {
       assertThat(context.getBean(WorkflowExecutionAuditBridge.class)).isNotNull();
+      assertThat(context.getBean(WorkflowExecutionControlAuditCoordinator.class)).isNotNull();
     }
   }
 
@@ -27,12 +30,20 @@ class WorkflowExecutionAuditBridgeSpringTest {
       includeFilters =
           @ComponentScan.Filter(
               type = FilterType.ASSIGNABLE_TYPE,
-              classes = WorkflowExecutionAuditBridge.class))
+              classes = {
+                WorkflowExecutionAuditBridge.class,
+                WorkflowExecutionControlAuditCoordinator.class
+              }))
   static class TestConfiguration {
 
     @Bean
     ObjectMapper objectMapper() {
       return new ObjectMapper();
+    }
+
+    @Bean
+    WorkflowRuntime workflowRuntime() {
+      return mock(WorkflowRuntime.class);
     }
   }
 }


### PR DESCRIPTION
## Summary

Fix the next startup failure after #972 by explicitly selecting the Spring injection constructor for `WorkflowExecutionControlAuditCoordinator`.

The coordinator follows the same compatibility pattern as `WorkflowExecutionAuditBridge`: a Spring-facing constructor using `ObjectProvider<BusinessAuditService>` plus a package-private constructor used by focused tests. Without `@Autowired`, Spring falls back to default instantiation and fails because no no-arg constructor exists.

## Changes

- mark the Spring-facing `WorkflowExecutionControlAuditCoordinator` constructor with `@Autowired`
- expand the existing Spring wiring regression test to instantiate both workflow execution audit components
- provide a minimal mocked `WorkflowRuntime` in the focused test context

## Root cause

Startup now reaches the control audit component and fails with:

```text
Failed to instantiate [io.yak.ops.business.workflow.execution.WorkflowExecutionControlAuditCoordinator]: No default constructor found
Caused by: java.lang.NoSuchMethodException: io.yak.ops.business.workflow.execution.WorkflowExecutionControlAuditCoordinator.<init>()
```

This is the same constructor-selection omission fixed for `WorkflowExecutionAuditBridge` in #972.

## Scope check

Reviewed the other workflow audit wiring touched by #970: `WorkflowLauncher`, `WorkflowExecutionReactivator`, workflow controllers and definition audit wiring already select their injection constructors; terminal listener and correlation repository only expose one constructor.

## Risk

Low. Runtime behavior is unchanged; this only makes Spring constructor selection explicit and strengthens wiring regression coverage.
