### PR TITLE
refactor(ui): streamline audit center filters

### DIFF
--- a/yak-ops-ui/src/pages/system/oplogs/components/BusinessAuditPanel.tsx
+++ b/yak-ops-ui/src/pages/system/oplogs/components/BusinessAuditPanel.tsx
@@ -1,7 +1,6 @@
 import { ReloadOutlined, SearchOutlined } from '@ant-design/icons';
 import { history } from '@umijs/max';
 import {
-  Button,
   DatePicker,
   Input,
   Select,
@@ -18,6 +17,7 @@ import {
   SecurityPagination,
   SecurityQueryTable,
 } from '@/components/security';
+import { YakButton } from '@/components/ui';
 import {
   getAuditFilterOptions,
   queryAuditOperations,
@@ -236,13 +236,13 @@ export default function BusinessAuditPanel() {
         fixed: 'right',
         width: 80,
         render: (_, record) => (
-          <Button
+          <YakButton
             type="link"
             size="small"
             onClick={() => setSelectedOperationId(record.operationId)}
           >
             查看
-          </Button>
+          </YakButton>
         ),
       },
     ],
@@ -266,34 +266,37 @@ export default function BusinessAuditPanel() {
 
   return (
     <div className="flex min-h-0 flex-1 flex-col">
-      <div className="mb-3 rounded-lg border border-slate-200 bg-white p-3">
-        <div className="flex flex-wrap items-center gap-2">
-          <Input
-            allowClear
-            value={filters.keyword}
-            onChange={(event) =>
-              setFilters((current) => ({ ...current, keyword: event.target.value }))
-            }
-            onPressEnter={search}
-            placeholder="操作名 / Operation ID / 资源 / 摘要"
-            className="w-[260px]"
-          />
-          <DatePicker.RangePicker
-            value={filters.timeRange}
-            onChange={(value) =>
-              setFilters((current) => ({
-                ...current,
-                timeRange:
-                  value?.[0] && value?.[1] ? [value[0], value[1]] : undefined,
-              }))
-            }
-            className="w-[260px]"
-          />
+      <div className="mb-3 flex flex-wrap items-center gap-2">
+        <Input
+          allowClear
+          value={filters.keyword}
+          variant="filled"
+          onChange={(event) =>
+            setFilters((current) => ({ ...current, keyword: event.target.value }))
+          }
+          onPressEnter={search}
+          placeholder="操作名 / Operation ID / 资源 / 摘要"
+          className="w-[280px]"
+        />
+        <DatePicker.RangePicker
+          value={filters.timeRange}
+          variant="filled"
+          onChange={(value) =>
+            setFilters((current) => ({
+              ...current,
+              timeRange:
+                value?.[0] && value?.[1] ? [value[0], value[1]] : undefined,
+            }))
+          }
+          className="w-[250px]"
+        />
+        <Space.Compact>
           <Select
             allowClear
             showSearch
             optionFilterProp="label"
             value={filters.projectId}
+            variant="filled"
             options={selectOptions(options.projects)}
             onChange={(value) =>
               setFilters((current) => ({ ...current, projectId: value }))
@@ -306,6 +309,7 @@ export default function BusinessAuditPanel() {
             showSearch
             optionFilterProp="label"
             value={filters.actor}
+            variant="filled"
             options={selectOptions(options.actors)}
             onChange={(value) =>
               setFilters((current) => ({ ...current, actor: value }))
@@ -313,11 +317,14 @@ export default function BusinessAuditPanel() {
             placeholder="操作人"
             className="w-[140px]"
           />
+        </Space.Compact>
+        <Space.Compact>
           <Select
             allowClear
             showSearch
             optionFilterProp="label"
             value={filters.operationType}
+            variant="filled"
             options={selectOptions(options.operationTypes)}
             onChange={(value) =>
               setFilters((current) => ({ ...current, operationType: value }))
@@ -330,6 +337,7 @@ export default function BusinessAuditPanel() {
             showSearch
             optionFilterProp="label"
             value={filters.resourceType}
+            variant="filled"
             options={selectOptions(options.resourceTypes)}
             onChange={(value) =>
               setFilters((current) => ({ ...current, resourceType: value }))
@@ -337,10 +345,16 @@ export default function BusinessAuditPanel() {
             placeholder="资源类型"
             className="w-[150px]"
           />
+        </Space.Compact>
+        <Space.Compact>
           <Select
             allowClear
             value={filters.status}
-            options={selectOptions(options.statuses, (option) => statusMeta(option.value).label)}
+            variant="filled"
+            options={selectOptions(
+              options.statuses,
+              (option) => statusMeta(option.value).label,
+            )}
             onChange={(value) =>
               setFilters((current) => ({ ...current, status: value }))
             }
@@ -350,6 +364,7 @@ export default function BusinessAuditPanel() {
           <Select
             allowClear
             value={filters.source}
+            variant="filled"
             options={selectOptions(options.sources)}
             onChange={(value) =>
               setFilters((current) => ({ ...current, source: value }))
@@ -357,15 +372,15 @@ export default function BusinessAuditPanel() {
             placeholder="来源"
             className="w-[110px]"
           />
-          <Space size={6}>
-            <Button type="primary" icon={<SearchOutlined />} onClick={search}>
-              查询
-            </Button>
-            <Button onClick={reset}>重置</Button>
-            <Button icon={<ReloadOutlined />} onClick={refresh} loading={loading}>
-              刷新
-            </Button>
-          </Space>
+        </Space.Compact>
+        <div className="flex items-center gap-2">
+          <YakButton type="primary" icon={<SearchOutlined />} onClick={search}>
+            查询
+          </YakButton>
+          <YakButton onClick={reset}>重置</YakButton>
+          <YakButton icon={<ReloadOutlined />} onClick={refresh} loading={loading}>
+            刷新
+          </YakButton>
         </div>
       </div>
 

--- a/yak-ops-ui/src/pages/system/oplogs/components/OperationLogFilterBar.tsx
+++ b/yak-ops-ui/src/pages/system/oplogs/components/OperationLogFilterBar.tsx
@@ -8,6 +8,7 @@ import {
   Input,
   Popover,
   Select,
+  Space,
 } from 'antd';
 import type { Dayjs } from 'dayjs';
 import { useMemo, useState } from 'react';
@@ -156,6 +157,7 @@ export default function OperationLogFilterBar({
           allowClear
           showSearch
           value={draftAdvanced.operateType}
+          variant="filled"
           options={selectOptions(options.operateTypes)}
           placeholder="全部操作类型"
           className="w-full"
@@ -174,6 +176,7 @@ export default function OperationLogFilterBar({
           allowClear
           showSearch
           value={draftAdvanced.operatePage}
+          variant="filled"
           options={selectOptions(options.operatePages)}
           placeholder="全部操作页面"
           className="w-full"
@@ -192,6 +195,7 @@ export default function OperationLogFilterBar({
           allowClear
           showSearch
           value={draftAdvanced.targetType}
+          variant="filled"
           options={selectOptions(options.targetTypes)}
           placeholder="全部目标类型"
           className="w-full"
@@ -209,6 +213,7 @@ export default function OperationLogFilterBar({
         <DatePicker.RangePicker
           showTime
           value={draftAdvanced.timeRange}
+          variant="filled"
           className="w-full"
           onChange={(value) =>
             setDraftAdvanced((current) => ({
@@ -242,20 +247,19 @@ export default function OperationLogFilterBar({
       </div>
 
       <div className="flex shrink-0 flex-wrap items-center gap-2">
-        <div className="flex h-8 w-[330px] max-w-full overflow-hidden rounded-md bg-[#f2f2f4]">
+        <Space.Compact className="w-[330px] max-w-full">
           <Select<OperationLogSearchField>
             value={searchField}
             options={OPERATION_LOG_SEARCH_FIELDS}
-            variant="borderless"
+            variant="filled"
             popupMatchSelectWidth={120}
-            className="h-8 w-[104px] shrink-0"
+            className="w-[104px] shrink-0"
             onChange={changeSearchField}
           />
-          <div className="my-2 w-px shrink-0 bg-slate-200" />
           <Input
             allowClear
             value={keyword}
-            variant="borderless"
+            variant="filled"
             placeholder={OPERATION_LOG_SEARCH_PLACEHOLDERS[searchField]}
             suffix={
               <SearchOutlined
@@ -263,7 +267,7 @@ export default function OperationLogFilterBar({
                 onClick={submit}
               />
             }
-            className="min-w-0 flex-1 !h-8 !bg-transparent !shadow-none"
+            className="min-w-0 flex-1"
             onChange={(event) => {
               const value = event.target.value;
               setKeyword(value);
@@ -275,7 +279,7 @@ export default function OperationLogFilterBar({
             }}
             onPressEnter={submit}
           />
-        </div>
+        </Space.Compact>
 
         <Popover
           trigger="click"

--- a/yak-ops-ui/src/pages/system/oplogs/index.tsx
+++ b/yak-ops-ui/src/pages/system/oplogs/index.tsx
@@ -25,7 +25,7 @@ export default function AuditCenterPage() {
       icon={<SafetyCertificateOutlined className="text-slate-500" />}
       className="min-h-[calc(100vh-64px)] overflow-hidden"
     >
-      <div className="flex min-h-0 flex-1 flex-col rounded-lg border border-slate-200 bg-white px-4 pt-1">
+      <div className="flex min-h-0 flex-1 flex-col bg-white px-4 pt-1">
         <YakTab
           activeKey={activeTab}
           onChange={setActiveTab}


### PR DESCRIPTION
## What changed
- use Ant Design `filled` variants for audit-center Input / Select / date filter controls
- replace business-audit actions with `YakButton`
- compact related business filters and merge the Security search-field selector + keyword input with `Space.Compact`
- remove the outer Audit Center border and the business filter-panel border to reduce nested card styling

## Scope
Frontend-only refactor of the Audit Center / operation-log page. Existing query parameters, pagination, detail drawers, and backend API contracts are unchanged.

## Validation
- reviewed the generated commit diff; only 3 audit-center frontend files changed
- ran a TypeScript syntax parse locally; dependency resolution was unavailable in the isolated environment, so repository CI remains the source of truth for full type/lint/build validation