### PR TITLE
refactor(ui): polish audit center layout

### DIFF
--- a/yak-ops-ui/src/components/security/SecurityPagination/index.tsx
+++ b/yak-ops-ui/src/components/security/SecurityPagination/index.tsx
@@ -5,6 +5,7 @@ interface SecurityPaginationProps {
   pageSize: number;
   total: number;
   disabled?: boolean;
+  bordered?: boolean;
   onChange: (current: number, pageSize: number) => void;
 }
 
@@ -13,43 +14,35 @@ export default function SecurityPagination({
   pageSize,
   total,
   disabled = false,
+  bordered = true,
   onChange,
 }: SecurityPaginationProps) {
+  if (total <= 0) return null;
+
   return (
     <div
-      className="
-        flex
-        h-16
-        w-full
-        shrink-0
-        items-center
-        justify-end
-        rounded-lg
-        border
-        border-slate-200/70
-        bg-white
-        px-6
-      "
+      className={[
+        'flex w-full shrink-0 items-center justify-end bg-white',
+        bordered
+          ? 'h-16 rounded-lg border border-slate-200/70 px-6'
+          : 'h-12 px-0',
+      ].join(' ')}
     >
-      {total > 0 && (
-        <div className="flex flex-wrap items-center justify-end gap-4">
-          <span className="text-sm text-slate-500">
-            共 {total} 条
-          </span>
+      <div className="flex flex-wrap items-center justify-end gap-4">
+        <span className="text-sm text-slate-500">共 {total} 条</span>
 
-          <Pagination
-            current={current}
-            pageSize={pageSize}
-            total={total}
-            disabled={disabled}
-            showSizeChanger
-            showQuickJumper={false}
-            pageSizeOptions={[10, 20, 50, 100]}
-            showTotal={undefined}
-            onChange={onChange}
-          />
-        </div>
-      )}
+        <Pagination
+          current={current}
+          pageSize={pageSize}
+          total={total}
+          disabled={disabled}
+          showSizeChanger
+          showQuickJumper={false}
+          pageSizeOptions={[10, 20, 50, 100]}
+          showTotal={undefined}
+          onChange={onChange}
+        />
+      </div>
     </div>
   );
 }

--- a/yak-ops-ui/src/pages/system/oplogs/components/BusinessAuditPanel.tsx
+++ b/yak-ops-ui/src/pages/system/oplogs/components/BusinessAuditPanel.tsx
@@ -1,8 +1,13 @@
-import { ReloadOutlined, SearchOutlined } from '@ant-design/icons';
+import {
+  FilterOutlined,
+  ReloadOutlined,
+  SearchOutlined,
+} from '@ant-design/icons';
 import { history } from '@umijs/max';
 import {
   DatePicker,
   Input,
+  Popover,
   Select,
   Space,
   Tag,
@@ -39,6 +44,11 @@ interface FilterState {
   source?: string;
   timeRange?: [Dayjs, Dayjs];
 }
+
+type AdvancedFilterState = Pick<
+  FilterState,
+  'operationType' | 'resourceType' | 'status' | 'source'
+>;
 
 const EMPTY_OPTIONS: AuditFilterOptions = {
   actors: [],
@@ -96,12 +106,21 @@ const buildQuery = (
     .format('YYYY-MM-DDTHH:mm:ss'),
 });
 
+const getAdvancedFilters = (filters: FilterState): AdvancedFilterState => ({
+  operationType: filters.operationType,
+  resourceType: filters.resourceType,
+  status: filters.status,
+  source: filters.source,
+});
+
 export default function BusinessAuditPanel() {
   const [rows, setRows] = useState<AuditOperationSummary[]>([]);
   const [options, setOptions] = useState<AuditFilterOptions>(EMPTY_OPTIONS);
   const [filters, setFilters] = useState<FilterState>({});
   const [loading, setLoading] = useState(false);
   const [selectedOperationId, setSelectedOperationId] = useState<string>();
+  const [advancedOpen, setAdvancedOpen] = useState(false);
+  const [draftAdvanced, setDraftAdvanced] = useState<AdvancedFilterState>({});
   const [pagination, setPagination] = useState({ current: 1, pageSize: 20, total: 0 });
 
   const loadOptions = useCallback(async () => {
@@ -256,6 +275,8 @@ export default function BusinessAuditPanel() {
   const reset = () => {
     const empty: FilterState = {};
     setFilters(empty);
+    setDraftAdvanced({});
+    setAdvancedOpen(false);
     void loadPage(1, pagination.pageSize, empty);
   };
 
@@ -264,9 +285,129 @@ export default function BusinessAuditPanel() {
     void loadPage(pagination.current, pagination.pageSize, filters);
   };
 
+  const applyAdvanced = () => {
+    const nextFilters = { ...filters, ...draftAdvanced };
+    setFilters(nextFilters);
+    setAdvancedOpen(false);
+    void loadPage(1, pagination.pageSize, nextFilters);
+  };
+
+  const resetAdvanced = () => {
+    const nextFilters: FilterState = {
+      ...filters,
+      operationType: undefined,
+      resourceType: undefined,
+      status: undefined,
+      source: undefined,
+    };
+    setFilters(nextFilters);
+    setDraftAdvanced({});
+    setAdvancedOpen(false);
+    void loadPage(1, pagination.pageSize, nextFilters);
+  };
+
+  const advancedCount = [
+    filters.operationType,
+    filters.resourceType,
+    filters.status,
+    filters.source,
+  ].filter(Boolean).length;
+
+  const advancedContent = (
+    <div className="w-[440px] max-w-[calc(100vw-48px)] p-1">
+      <div className="grid grid-cols-1 gap-3 sm:grid-cols-2">
+        <div>
+          <div className="mb-1.5 text-xs font-medium text-slate-500">操作类型</div>
+          <Select
+            allowClear
+            showSearch
+            optionFilterProp="label"
+            value={draftAdvanced.operationType}
+            variant="filled"
+            options={selectOptions(options.operationTypes)}
+            placeholder="全部操作类型"
+            className="w-full"
+            onChange={(value) =>
+              setDraftAdvanced((current) => ({
+                ...current,
+                operationType: value,
+              }))
+            }
+          />
+        </div>
+
+        <div>
+          <div className="mb-1.5 text-xs font-medium text-slate-500">资源类型</div>
+          <Select
+            allowClear
+            showSearch
+            optionFilterProp="label"
+            value={draftAdvanced.resourceType}
+            variant="filled"
+            options={selectOptions(options.resourceTypes)}
+            placeholder="全部资源类型"
+            className="w-full"
+            onChange={(value) =>
+              setDraftAdvanced((current) => ({
+                ...current,
+                resourceType: value,
+              }))
+            }
+          />
+        </div>
+
+        <div>
+          <div className="mb-1.5 text-xs font-medium text-slate-500">状态</div>
+          <Select
+            allowClear
+            value={draftAdvanced.status}
+            variant="filled"
+            options={selectOptions(
+              options.statuses,
+              (option) => statusMeta(option.value).label,
+            )}
+            placeholder="全部状态"
+            className="w-full"
+            onChange={(value) =>
+              setDraftAdvanced((current) => ({
+                ...current,
+                status: value,
+              }))
+            }
+          />
+        </div>
+
+        <div>
+          <div className="mb-1.5 text-xs font-medium text-slate-500">来源</div>
+          <Select
+            allowClear
+            value={draftAdvanced.source}
+            variant="filled"
+            options={selectOptions(options.sources)}
+            placeholder="全部来源"
+            className="w-full"
+            onChange={(value) =>
+              setDraftAdvanced((current) => ({
+                ...current,
+                source: value,
+              }))
+            }
+          />
+        </div>
+      </div>
+
+      <div className="mt-4 flex justify-end gap-2 border-t border-slate-100 pt-3">
+        <YakButton onClick={resetAdvanced}>清空</YakButton>
+        <YakButton type="primary" onClick={applyAdvanced}>
+          应用筛选
+        </YakButton>
+      </div>
+    </div>
+  );
+
   return (
-    <div className="flex min-h-0 flex-1 flex-col">
-      <div className="mb-3 flex flex-wrap items-center gap-2">
+    <div className="flex h-full min-h-0 flex-1 flex-col">
+      <div className="mb-4 flex shrink-0 flex-wrap items-center gap-2">
         <Input
           allowClear
           value={filters.keyword}
@@ -276,8 +417,9 @@ export default function BusinessAuditPanel() {
           }
           onPressEnter={search}
           placeholder="操作名 / Operation ID / 资源 / 摘要"
-          className="w-[280px]"
+          className="w-[280px] max-w-full"
         />
+
         <DatePicker.RangePicker
           value={filters.timeRange}
           variant="filled"
@@ -288,8 +430,9 @@ export default function BusinessAuditPanel() {
                 value?.[0] && value?.[1] ? [value[0], value[1]] : undefined,
             }))
           }
-          className="w-[250px]"
+          className="w-[230px]"
         />
+
         <Space.Compact>
           <Select
             allowClear
@@ -318,62 +461,23 @@ export default function BusinessAuditPanel() {
             className="w-[140px]"
           />
         </Space.Compact>
-        <Space.Compact>
-          <Select
-            allowClear
-            showSearch
-            optionFilterProp="label"
-            value={filters.operationType}
-            variant="filled"
-            options={selectOptions(options.operationTypes)}
-            onChange={(value) =>
-              setFilters((current) => ({ ...current, operationType: value }))
-            }
-            placeholder="操作类型"
-            className="w-[170px]"
-          />
-          <Select
-            allowClear
-            showSearch
-            optionFilterProp="label"
-            value={filters.resourceType}
-            variant="filled"
-            options={selectOptions(options.resourceTypes)}
-            onChange={(value) =>
-              setFilters((current) => ({ ...current, resourceType: value }))
-            }
-            placeholder="资源类型"
-            className="w-[150px]"
-          />
-        </Space.Compact>
-        <Space.Compact>
-          <Select
-            allowClear
-            value={filters.status}
-            variant="filled"
-            options={selectOptions(
-              options.statuses,
-              (option) => statusMeta(option.value).label,
-            )}
-            onChange={(value) =>
-              setFilters((current) => ({ ...current, status: value }))
-            }
-            placeholder="状态"
-            className="w-[110px]"
-          />
-          <Select
-            allowClear
-            value={filters.source}
-            variant="filled"
-            options={selectOptions(options.sources)}
-            onChange={(value) =>
-              setFilters((current) => ({ ...current, source: value }))
-            }
-            placeholder="来源"
-            className="w-[110px]"
-          />
-        </Space.Compact>
-        <div className="flex items-center gap-2">
+
+        <Popover
+          trigger="click"
+          placement="bottomRight"
+          open={advancedOpen}
+          content={advancedContent}
+          onOpenChange={(open) => {
+            setAdvancedOpen(open);
+            if (open) setDraftAdvanced(getAdvancedFilters(filters));
+          }}
+        >
+          <YakButton icon={<FilterOutlined />}>
+            更多筛选{advancedCount > 0 ? ` (${advancedCount})` : ''}
+          </YakButton>
+        </Popover>
+
+        <div className="flex items-center gap-2 xl:ml-auto">
           <YakButton type="primary" icon={<SearchOutlined />} onClick={search}>
             查询
           </YakButton>
@@ -384,7 +488,7 @@ export default function BusinessAuditPanel() {
         </div>
       </div>
 
-      <div className="min-h-0 flex-1 overflow-hidden rounded-lg border border-slate-200 bg-white">
+      <div className="min-h-0 flex-1 overflow-y-auto overflow-x-hidden">
         <SecurityQueryTable<AuditOperationSummary>
           rowKey="operationId"
           columns={columns}
@@ -395,15 +499,20 @@ export default function BusinessAuditPanel() {
         />
       </div>
 
-      <SecurityPagination
-        current={pagination.current}
-        pageSize={pagination.pageSize}
-        total={pagination.total}
-        disabled={loading}
-        onChange={(page, pageSize) => {
-          void loadPage(page, pageSize, filters);
-        }}
-      />
+      {pagination.total > 0 ? (
+        <div className="shrink-0 pt-3">
+          <SecurityPagination
+            current={pagination.current}
+            pageSize={pagination.pageSize}
+            total={pagination.total}
+            disabled={loading}
+            bordered={false}
+            onChange={(page, pageSize) => {
+              void loadPage(page, pageSize, filters);
+            }}
+          />
+        </div>
+      ) : null}
 
       <AuditOperationDetailDrawer
         operationId={selectedOperationId}

--- a/yak-ops-ui/src/pages/system/oplogs/components/SecurityOperationLogsPanel.tsx
+++ b/yak-ops-ui/src/pages/system/oplogs/components/SecurityOperationLogsPanel.tsx
@@ -44,7 +44,7 @@ export default function SecurityOperationLogsPanel() {
   const columns = useOperationLogColumns({ onDetail: showDetail });
 
   return (
-    <div className="flex min-h-0 flex-1 flex-col">
+    <div className="flex h-full min-h-0 flex-1 flex-col">
       <div className="shrink-0">
         <OperationLogFilterBar
           options={options}
@@ -52,7 +52,9 @@ export default function SecurityOperationLogsPanel() {
           onSearch={searchLogs}
           onRefresh={refreshLogs}
         />
+      </div>
 
+      <div className="min-h-0 flex-1 overflow-y-auto overflow-x-hidden">
         <SecurityQueryTable<OperationLog>
           rowKey="id"
           columns={columns}
@@ -64,15 +66,18 @@ export default function SecurityOperationLogsPanel() {
         />
       </div>
 
-      <div className="min-h-6 flex-1" />
-
-      <SecurityPagination
-        current={pagination.current}
-        pageSize={pagination.pageSize}
-        total={pagination.total}
-        disabled={isLoading}
-        onChange={changePage}
-      />
+      {pagination.total > 0 ? (
+        <div className="shrink-0 pt-3">
+          <SecurityPagination
+            current={pagination.current}
+            pageSize={pagination.pageSize}
+            total={pagination.total}
+            disabled={isLoading}
+            bordered={false}
+            onChange={changePage}
+          />
+        </div>
+      ) : null}
 
       <OperationLogDetailDrawer ref={detailRef} />
     </div>

--- a/yak-ops-ui/src/pages/system/oplogs/index.tsx
+++ b/yak-ops-ui/src/pages/system/oplogs/index.tsx
@@ -23,13 +23,13 @@ export default function AuditCenterPage() {
       title="审计中心"
       titleId="system-operation-logs-title"
       icon={<SafetyCertificateOutlined className="text-slate-500" />}
-      className="min-h-[calc(100vh-64px)] overflow-hidden"
+      className="h-[calc(100vh-64px)] min-h-0 overflow-hidden"
     >
       <div className="flex min-h-0 flex-1 flex-col bg-white px-4 pt-1">
         <YakTab
           activeKey={activeTab}
           onChange={setActiveTab}
-          className="flex min-h-0 flex-1 flex-col [&_.ant-tabs-content]:h-full [&_.ant-tabs-content-holder]:min-h-0 [&_.ant-tabs-content-holder]:flex-1 [&_.ant-tabs-tabpane]:h-full"
+          className="flex min-h-0 flex-1 flex-col [&_.ant-tabs-content]:h-full [&_.ant-tabs-content-holder]:min-h-0 [&_.ant-tabs-content-holder]:flex-1 [&_.ant-tabs-content-holder]:pt-4 [&_.ant-tabs-tabpane]:h-full [&_.ant-tabs-tabpane-active]:flex [&_.ant-tabs-tabpane-active]:min-h-0 [&_.ant-tabs-tabpane-active]:flex-col"
           items={[
             {
               key: 'business',


### PR DESCRIPTION
## What changed
- pin Audit Center pagination to the bottom of the available workspace instead of leaving it directly under short tables
- hide pagination completely when there is no data, removing the empty bordered pagination block
- add a borderless compact mode to `SecurityPagination` and use it in both audit tabs
- reduce the Business Audit primary filter row to keyword, date, project and actor
- move operation type, resource type, status and source into a compact `更多筛选` popover with an active-filter count
- add breathing room below `YakTab` and make active tab panes fill the remaining viewport height
- keep audit table scrolling inside the content area so pagination stays fixed at the bottom

## Scope
Frontend-only Audit Center / operation-log layout refactor. Query parameters, audit APIs, pagination semantics and detail drawers are unchanged.

## Validation
- TypeScript `transpileModule` syntax validation passed for all 4 changed TSX files
- reviewed the final commit diff; branch is 1 commit ahead of `main`
- full repository type/lint/build validation is left to CI