### PR TITLE
refactor(ui): trim data quality monitor editor copy

### DIFF
--- a/yak-ops-ui/src/pages/data-quality/monitor/editor/BasicConfig.tsx
+++ b/yak-ops-ui/src/pages/data-quality/monitor/editor/BasicConfig.tsx
@@ -67,9 +67,6 @@ export const BasicConfig = ({
                   已固定
                 </span>
               </div>
-              <div className="mt-2 border-t border-[#e8e9ec] pt-2 text-[11px] leading-5 text-[#98a2b3]">
-                监控对象来自数据表监控中的已注册数据表，创建过程中不可切换。
-              </div>
             </div>
           ) : (
             <div></div>

--- a/yak-ops-ui/src/pages/data-quality/monitor/editor/NotificationSettings.tsx
+++ b/yak-ops-ui/src/pages/data-quality/monitor/editor/NotificationSettings.tsx
@@ -21,15 +21,10 @@ export const NotificationSettings = ({
     <EditorSection id="notification-settings" title="通知设置">
       <div className="space-y-5">
         <div className="flex items-center justify-between gap-6 rounded-lg bg-[#f7f8fa] px-4 py-3">
-          <div className="flex min-w-0 items-start gap-2.5">
-            <BellRing size={16} className="mt-0.5 shrink-0 text-[#667085]" />
-            <div>
-              <div className="text-[13px] font-medium text-[#344054]">
-                开启质量通知
-              </div>
-              <div className="mt-0.5 text-[11px] leading-5 text-[#98a2b3]">
-                质量检查未通过或执行异常时记录通知；外部渠道继续由现有投递链路处理。
-              </div>
+          <div className="flex min-w-0 items-center gap-2.5">
+            <BellRing size={16} className="shrink-0 text-[#667085]" />
+            <div className="text-[13px] font-medium text-[#344054]">
+              开启质量通知
             </div>
           </div>
           <Switch
@@ -113,11 +108,7 @@ export const NotificationSettings = ({
               </div>
             ) : null}
           </div>
-        ) : (
-          <div className="text-[11px] leading-5 text-[#98a2b3]">
-            站内消息进入 Yak Ops 统一通知中心；当前监控负责人继续作为兼容接收目标。
-          </div>
-        )}
+        ) : null}
       </div>
     </EditorSection>
   );

--- a/yak-ops-ui/src/pages/data-quality/monitor/editor/ScheduleSettings.tsx
+++ b/yak-ops-ui/src/pages/data-quality/monitor/editor/ScheduleSettings.tsx
@@ -7,11 +7,9 @@ import type { ScheduleSettingsState } from './model';
 
 function Field({
   label,
-  hint,
   children,
 }: {
   label: string;
-  hint?: string;
   children: ReactNode;
 }) {
   return (
@@ -20,11 +18,6 @@ function Field({
         {label}
       </div>
       {children}
-      {hint ? (
-        <div className="mt-1.5 text-[11px] leading-5 text-[#98a2b3]">
-          {hint}
-        </div>
-      ) : null}
     </div>
   );
 }
@@ -54,10 +47,7 @@ export const ScheduleSettings = ({
       }
     >
       <div className="grid grid-cols-[minmax(0,1.8fr)_minmax(150px,.55fr)_minmax(220px,.8fr)] gap-4 max-lg:grid-cols-2 max-sm:grid-cols-1">
-        <Field
-          label="Cron 表达式"
-          hint="采用 Quartz Cron；点击输入框可打开可视化调度配置，也支持直接输入。"
-        >
+        <Field label="Cron 表达式">
           <CronSchedulerInput
             value={value.cronExpression}
             placeholder="0 0 9 * * ?"
@@ -70,10 +60,7 @@ export const ScheduleSettings = ({
           />
         </Field>
 
-        <Field
-          label="启用调度"
-          hint="关闭后保留 Cron，仍可在详情页手动运行"
-        >
+        <Field label="启用调度">
           <div className="flex h-8 items-center">
             <Switch
               size="small"
@@ -83,10 +70,7 @@ export const ScheduleSettings = ({
           </div>
         </Field>
 
-        <Field
-          label="规则失败处理"
-          hint="控制单条规则失败后是否继续本次检查"
-        >
+        <Field label="规则失败处理">
           <Select
             size="small"
             variant="filled"


### PR DESCRIPTION
## What changed
- remove the explanatory helper text below Cron, schedule enablement and rule-failure handling
- simplify the notification switch row by removing the long delivery explanation
- remove the extra station-message compatibility description
- remove the remaining explanatory sentence below the fixed monitor object in basic configuration

## Notes
The latest `main` already no longer contains the owner / data-source / monitor-target helper lines shown in the newer screenshot, so this PR removes the equivalent remaining helper copy that still exists on the current editor implementation without reintroducing older layout code.

## Scope
Frontend-only copy cleanup for the data-quality monitor editor. Form fields, values, validation and save behavior are unchanged.

## Validation
- reviewed the final commit diff
- branch is 1 commit ahead of `main`
- only 3 monitor-editor TSX files changed