### PR TITLE
feat(data-service): add IP access control

### DIFF
--- a/yak-ops-business/yak-ops-business-data-service/ARCHITECTURE.md
+++ b/yak-ops-business/yak-ops-business-data-service/ARCHITECTURE.md
@@ -13,6 +13,7 @@ Data Service 位于“已发布数据资产”与“在线查询调用”之间�
 - 固定 SQL + Datasource Runtime Snapshot；
 - 单条只读 SELECT 编译与调用；
 - API Key 生命周期、鉴权和集群共享限流；
+- Data Service 级 IP/CIDR allowlist / denylist 与可信代理解析；
 - node-local Cache / Circuit Breaker；
 - cluster invocation metric projection；
 - API contract documentation / OpenAPI；
@@ -26,9 +27,9 @@ Data Service 位于“已发布数据资产”与“在线查询调用”之间�
 - Offline/Realtime Sync orchestration；
 - 任意 DML/DDL；
 - shared result cache / distributed circuit state；
-- API Gateway；
+- 通用 API Gateway / WAF；
 - 血缘、质量计算；
-- 用 Yak Project Header 替代 Public Runtime 的 NONE/API_KEY 鉴权。
+- 用 Yak Project Header 替代 Public Runtime 的 IP Policy / NONE/API_KEY 访问控制。
 
 ## 2. 设计原则
 
@@ -40,10 +41,11 @@ Data Service 位于“已发布数据资产”与“在线查询调用”之间�
 6. **SQL Trust Boundary 在服务端。** SQL/dataSourceId 只能来自 Source Provider。
 7. **安全 Secret 最小暴露。** raw API key 只在 create/rotate 返回一次；audit 参数在落库前脱敏。
 8. **读写角色分开。** Manager/Publisher 管 command，Reader 管 query/projection。
-9. **管理面与调用面分离。** Console 使用 Project + RBAC；外部 Invocation 使用全局 path + NONE/API_KEY。
-10. **热路径最小化。** Result Cache/Circuit 留在节点内；历史清理不进入 invocation 热路径。
-11. **依赖图无环。** 不用新增 package edge 掩盖职责混乱。
-12. **结构重构默认不改行为。** REST、HTTP status、SqlExecution contract 的变化先更新 Requirements/Domain。
+9. **管理面与调用面分离。** Console 使用 Project + RBAC；外部 Invocation 使用全局 path + IP Policy + NONE/API_KEY。
+10. **代理 Header 默认不可信。** 只有 TCP 直接对端属于显式 Trusted Proxy CIDR 时才解析 XFF/X-Real-IP。
+11. **热路径最小化。** Result Cache/Circuit 留在节点内；历史清理不进入 invocation 热路径。
+12. **依赖图无环。** 不用新增 package edge 掩盖职责混乱。
+13. **结构重构默认不改行为。** REST、HTTP status、SqlExecution contract 的变化先更新 Requirements/Domain。
 
 ## 3. 总体架构
 
@@ -78,6 +80,8 @@ DataServiceDefinition(projectId, runtimeGeneration)
               Datasource
 
 Invocation
+  +--> trusted client-IP resolution
+  +--> shared IP access policy/rules
   +--> shared API-key minute window
   +--> node-local Cache/Circuit
   +--> sanitized audit -> raw log -> hourly rollup
@@ -95,6 +99,8 @@ Yak Ops User
 
 External Client
    -> /api/v1/data-service/runtime/{servicePath}
+   -> trusted client-IP resolution
+   -> NONE / ALLOWLIST / DENYLIST
    -> NONE / X-API-Key
    -> global findByRuntimePath
    -> resolved DataServiceDefinition(projectId)
@@ -108,7 +114,7 @@ dataservice
 ├── publication/source     # publish / republish / source extension contract
 ├── management             # stable aggregate command lifecycle
 ├── query                  # Data Service read side / projection
-├── access                 # API Key lifecycle / authorize / cluster rate-limit coordinator
+├── access                 # API Key + IP policy lifecycle / authorize / trusted proxy / rate-limit
 ├── execution              # compiler / invoker / physical query / audit sanitizer+recorder
 ├── runtime                # node-local cache/circuit + cluster metric projection facade
 ├── documentation          # docs persistence / merge / OpenAPI rendering
@@ -125,25 +131,26 @@ dataservice
 
 | Role | 本模块职责 | 例子 |
 | --- | --- | --- |
-| `Manager` | Aggregate command / lifecycle | `DataServiceManager`, `DataServiceApiKeyManager` |
+| `Manager` | Aggregate / access command lifecycle | `DataServiceManager`, `DataServiceApiKeyManager`, `DataServiceIpAccessManager` |
 | `Publisher` | Source Revision -> Data Service snapshot | `DataServicePublisher` |
 | `Reader` | read-side 查询/projection | `DataServiceReader`, `DataServiceOverviewReader` |
 | `Registry` | Source extension discovery | `DataServiceSourceRegistry` |
-| `Authorizer` | 每次调用访问判定 | `DataServiceAuthorizer` |
+| `Authorizer` | 每次调用访问判定 | `DataServiceAuthorizer`, `DataServiceIpAccessAuthorizer` |
+| `Resolver` | 请求边界事实解析 | `DataServiceClientIpResolver` |
 | `RateLimiter` | 调用共享 minute-window coordination | `DataServiceRateLimiter` |
 | `Compiler` | SELECT 校验和 named binding | `DataServiceSqlCompiler` |
 | `Invoker` | 一次在线调用编排 | `DataServiceInvoker` |
 | `Executor` | 已编译 SQL 物理执行 | `DataServiceQueryExecutor` |
 | `Runtime` | node-local resilience | `LocalDataServiceRuntime` |
 | `Recorder` | sanitized 调用审计写入 | `DataServiceInvocationRecorder` |
-| `Repository` | Domain / coordination persistence port | `DataServiceRepository`, `DataServiceRateLimitRepository` |
+| `Repository` | Domain / coordination persistence port | `DataServiceRepository`, `DataServiceRateLimitRepository`, `DataServiceIpAccessRepository` |
 | `Adapter` | persistence translation / SQL coordination | `*RepositoryAdapter` |
 | `Renderer` | typed contract -> artifact | `OpenApiRenderer` |
 | `Factory` | read-side projection | `DataServiceViewFactory` |
 
 ## 6. Definition / Publication / Runtime Generation
 
-初次发布绑定 CurrentProject；source-managed ownership 规则延续 Stage 2。
+初次发布绑定 CurrentProject；source-managed ownership 规则保持不变。
 
 `runtimeGeneration` 是 Data Service 持久化在线代际：
 
@@ -155,12 +162,14 @@ settings/auth/policy/enable/republish mutation
 
 Cache namespace 还包含 Source Revision 与影响执行/缓存的 settings/policy shape，因此并发管理请求即便观察到同一旧 generation，也不能让不同最终配置误用同一 Cache entry。
 
+IP Access Policy 不参与结果 Cache identity：它决定请求能否进入调用链，不改变同一 SQL/bindings 的查询结果。规则变更通过共享持久化在后续请求中直接读取，不依赖 node-local cache invalidation。
+
 Republish 保持：
 
 ```text
 same Data Service ID
 same Project ownership
-preserved AuthMode / RuntimePolicy
+preserved AuthMode / IP Access / RuntimePolicy
 new SourceReference / RuntimeSnapshot
 new runtimeGeneration
 ```
@@ -173,7 +182,7 @@ Console 管理入口统一 `PROJECT_REQUIRED`，并按动作使用：
 READ / PUBLISH / MANAGE / DELETE / ACCESS / RUNTIME / OBSERVE
 ```
 
-管理 Repository 的 ID/path/source/list/save/delete 绑定 `CurrentProject`。API Key / Documentation 不重复保存 projectId，但 Console 读写必须先经过父 Data Service ownership。
+管理 Repository 的 ID/path/source/list/save/delete 绑定 `CurrentProject`。API Key / IP Access / Documentation 不重复保存 projectId，但 Console 读写必须先经过父 Data Service ownership。
 
 首页系统 Cockpit 的全局 Data Service count 是一个显式只读 aggregate corridor：只返回数量，不暴露 API identity/path/SQL/source，因此不能被 Console management 复用。
 
@@ -185,10 +194,13 @@ GET /api/v1/data-service/runtime/{servicePath}
        v
 DataServiceInvocationController
        |
+       +-- resolve TCP peer / trusted proxy chain
+       |
        v
 DataServiceInvoker
        |
        +-- global DataServiceReader.requireByPath
+       +-- IP allow/deny admission
        +-- NONE / API_KEY authorization
        +-- cluster shared rate-limit admission
        +-- pagination / SQL compile
@@ -199,9 +211,52 @@ DataServiceInvoker
 
 Public Controller 故意没有 Yak `@ProjectScope` / `@RequiresPermission`。Path 跨 Project 全局唯一。
 
-## 9. Cluster-wide rate-limit corridor
+网络策略与身份认证是两个独立 gate：IP Policy 回答“来源能否进入”，API Key 回答“调用方凭证是否有效”。网络策略必须先执行，避免明确拒绝的来源继续进入 Key hash lookup / shared rate-limit 热路径。
 
-调用限流不再使用 JVM `ConcurrentHashMap`。
+## 9. Trusted Proxy / IP Access corridor
+
+默认行为：
+
+```text
+remoteAddr -> client IP
+X-Forwarded-For -> ignored
+X-Real-IP -> ignored
+```
+
+只有 `remoteAddr` 命中显式配置的：
+
+```text
+yak.data-service.access.trusted-proxies
+```
+
+才允许解析 Forwarded Header。该配置支持逗号分隔 IPv4/IPv6 CIDR。
+
+XFF 解析从右向左：
+
+```text
+client, trusted-proxy-1, trusted-proxy-2
+                           ^ remote peer
+
+right -> left through trusted proxies
+stop at first untrusted hop => client
+```
+
+因此客户端在最左侧预置更多伪造地址不能覆盖真实的第一个非可信 Hop。XFF 存在但格式异常时回退到 TCP 对端，不再继续读取另一个可伪造 Forwarded Header。
+
+IP Access persistence：
+
+```text
+DataServiceIpAccessAuthorizer
+   -> DataServiceIpAccessRepository
+      +-- policy(apiId -> NONE/ALLOWLIST/DENYLIST)
+      +-- rules(apiId, ruleType, normalized CIDR, enabled, expiresAt)
+```
+
+ALLOWLIST 空规则时 fail closed；DENYLIST 空规则时允许。激活策略但客户端 IP 无法可信解析时统一 403。
+
+## 10. Cluster-wide rate-limit corridor
+
+调用限流不使用 JVM `ConcurrentHashMap`。
 
 ```text
 DataServiceAuthorizer
@@ -216,7 +271,7 @@ Key rotate / disable / delete 通过 `rateLimiter.invalidate(keyId)` 清理共�
 
 未来接 Redis 时只替换 Repository Adapter；Authorizer/API Key Domain 不变。
 
-## 10. Node-local Cache / Circuit
+## 11. Node-local Cache / Circuit
 
 `LocalDataServiceRuntime` 继续拥有 Caffeine Cache 与 Circuit state：
 
@@ -233,7 +288,7 @@ LocalDataServiceRuntime per instance
 
 这是**version-safe local cache**，不是 shared cache。
 
-## 11. Cluster Runtime Metrics
+## 12. Cluster Runtime Metrics
 
 Runtime status 的调用规模来自 durable evidence：
 
@@ -252,7 +307,7 @@ P95 使用最近 raw duration 的有界样本；不是全历史精确 histogram�
 
 同一个 Runtime DTO 中 Cache/Circuit 仍来自当前节点，因此返回 `metricsScope=CLUSTER_INVOCATION_LOCAL_RESILIENCE`，明确两层 evidence 的差异。
 
-## 12. Audit Security / Reliability
+## 13. Audit Security / Reliability
 
 `DataServiceInvocationRecorder` 的职责顺序是：
 
@@ -267,9 +322,9 @@ request parameters
 
 Secret/PII 不能先序列化再靠 UI 隐藏。
 
-Stage 1 的可靠性规则保持：audit persistence failure 不能把成功查询变成失败，也不能覆盖原始 SQL/auth/rate-limit 异常。
+可靠性规则保持：audit persistence failure 不能把成功查询变成失败，也不能覆盖原始 IP policy / SQL / auth / rate-limit 异常。
 
-## 13. Observability Lifecycle
+## 14. Observability Lifecycle
 
 Raw call log 默认保留 30 天；hourly rollup 默认保留 365 天。
 
@@ -284,7 +339,7 @@ Commit
 
 任何一步失败整个小时回滚，防止双算或丢数。过期 rate-limit window 也由该维护角色统一清理。
 
-## 14. Persistence Boundary
+## 15. Persistence Boundary
 
 允许：
 
@@ -299,7 +354,7 @@ Business Role
 
 禁止：Controller/Access/Execution/Runtime/Observability 业务角色直接拥有 JdbcTemplate/Mapper/PO。
 
-## 15. Cross-module Boundary
+## 16. Cross-module Boundary
 
 上游模块只依赖：
 
@@ -309,10 +364,11 @@ io.yak.ops.business.dataservice.publication.source.DataServiceSourceProvider
 
 Data Service 不反向依赖 Data Development implementation。物理 SQL 只走 `yak-ops-core` execution contract；Project scope 只依赖 core Project contract。
 
-## 16. Failure Semantics
+## 17. Failure Semantics
 
 - invalid source/settings/SQL -> 参数/业务错误；
 - missing Console Project / permission -> Project/RBAC error；
+- Public IP policy rejected -> 403；
 - invalid Public API key -> 401；
 - shared RPM exceeded -> 429；
 - shared rate-limit storage unavailable -> fail closed；
@@ -321,24 +377,30 @@ Data Service 不反向依赖 Data Development implementation。物理 SQL 只走
 - audit persistence failure -> 不改变已确定调用结果；
 - maintenance failure -> 保留该小时 raw evidence，下一轮可重试。
 
-## 17. Architecture Guards
+## 18. Architecture Guards
 
 ```text
 DataServiceDependencyBoundaryTest
 DataServiceCodeStyleConventionTest
 DataServiceGovernanceContractTest
 DataServiceClusterRuntimeContractTest
+DataServiceFlywayContractTest
+IpNetworkTest
+DataServiceClientIpResolverTest
+DataServiceIpAccessAuthorizerTest
 ```
 
-Stage 3 Guard 锁定：
+Guard 锁定：
 
 - Rate Limit 不得退回 per-JVM Map；
+- Forwarded Header 不得在未验证 Trusted Proxy 时被信任；
+- IP policy 必须先于 API Key admission；
 - Cache 可以 local，但 namespace 必须带 durable generation/runtime shape；
 - Audit 必须先 sanitize；
 - Rollup + raw delete 必须共享 transaction boundary；
 - Cluster invocation metrics 与 local resilience 必须显式区分。
 
-## 18. 修改协议
+## 19. 修改协议
 
 ```text
 Architecture Impact

--- a/yak-ops-business/yak-ops-business-data-service/DOMAIN.md
+++ b/yak-ops-business/yak-ops-business-data-service/DOMAIN.md
@@ -15,7 +15,9 @@ DataServiceDefinition (Aggregate Root)
 └── AuthMode
 
 Access
-└── DataServiceApiKey
+├── DataServiceApiKey
+├── IpAccessMode
+└── DataServiceIpAccessRule
 
 Documentation
 └── DataServiceDocumentation
@@ -63,7 +65,13 @@ immutable source revision
 - `AuthMode`：NONE/API_KEY。
 - `runtimeGeneration`：单调持久化 Runtime 代际；每次会影响在线行为的 Aggregate 变更都推进代际。
 
-运行调用读取这里的持久化快照，不在每次请求时重新解析上游 Source。
+Access 还拥有与 Definition 生命周期绑定、但独立持久化的策略事实：
+
+- API Key 集合；
+- `IpAccessMode`：NONE/ALLOWLIST/DENYLIST；
+- `DataServiceIpAccessRule`：名单类型、规范化 IP/CIDR、enabled、expiresAt、description。
+
+运行调用读取这里的持久化快照和访问策略，不在每次请求时重新解析上游 Source。
 
 `projectId` 是 Console ownership，不进入 Public Runtime URL。外部调用通过全局唯一 path 找到 Definition 后，自然获得该服务的 Project identity；调用方不能通过 Project Header 选择或覆盖服务归属。
 
@@ -73,11 +81,13 @@ immutable source revision
 
 ```text
 API Key minute-window usage
+IP access policy/rules
 Invocation audit evidence
 Hourly invocation rollup
 ```
 
 - API Key minute-window usage 是集群配额事实，不属于单个 JVM。
+- IP access policy/rules 是所有实例共享的持久化访问事实，不属于某个节点的本地状态。
 - Invocation / hourly rollup 是跨实例可聚合的调用 evidence。
 - 它们不能反向成为 Data Service Definition 或 RuntimePolicy 的 owner。
 
@@ -102,7 +112,7 @@ Local circuit-rejected evidence
 4. `PublishedRuntimeSnapshot.dataSourceId` 必须指向有效已发布 Datasource identity。
 5. `PublishedRuntimeSnapshot.sql` 必须存在，并在 Publication / Execution boundary 验证为单条 SELECT。
 6. `SourceReference` 固定到不可变 Revision；republish 更新引用而不是新建服务身份。
-7. republish 不能重置 `AuthMode`、`RuntimePolicy` 或 Project ownership。
+7. republish 不能重置 `AuthMode`、RuntimePolicy、IP Access Policy 或 Project ownership。
 8. 服务侧 settings 更新不能改 SQL/dataSourceId/source revision/projectId。
 9. enable/disable 只改变服务可调用性。
 10. `runtimeGeneration` 必须是正数，在线行为发生变更时推进；旧代际不能继续复用新请求的 cache identity。
@@ -134,7 +144,7 @@ Source Revision owns:
 name / path / maxRows / timeout / pagination / description / contract
 
 Data Service owns:
-projectId / enabled / auth / API keys / runtime policy / runtimeGeneration
+projectId / enabled / auth / API keys / IP access / runtime policy / runtimeGeneration
 ```
 
 客户端不能用 publish/update 请求覆盖 Source-owned 字段。
@@ -162,7 +172,7 @@ raw secret --SHA-256--> keyHash -> persisted
 prefix ----------------------------> persisted for identification/audit
 ```
 
-硬规则：
+API Key 硬规则：
 
 - raw secret 永不写 PO、日志、Domain `toString()` 或普通响应。
 - API_KEY 模式必须至少有一个 enabled 且未过期的 Key。
@@ -173,18 +183,47 @@ prefix ----------------------------> persisted for identification/audit
 - Console Key lifecycle 必须先通过父 Data Service 的 CurrentProject ownership；不能只凭 keyId 修改另一 Project 的 Key。
 - Public Invocation 的 Key 查找属于已解析 Data Service 的访问执行过程，不依赖 Yak Console Project Header。
 
+IP Access 硬规则：
+
+```text
+IpAccessMode = NONE | ALLOWLIST | DENYLIST
+
+DataServiceIpAccessRule
+  -> apiId
+  -> ALLOWLIST | DENYLIST
+  -> normalized IP/CIDR
+  -> enabled
+  -> expiresAt
+  -> description
+```
+
+- `NONE` 不做来源 IP 拦截。
+- `ALLOWLIST` 只允许命中 enabled 且未过期白名单的来源；没有有效规则时拒绝全部外部来源。
+- `DENYLIST` 拒绝命中 enabled 且未过期黑名单的来源，未命中继续执行。
+- ALLOWLIST 与 DENYLIST 规则可以同时持久化；`IpAccessMode` 只决定当前哪一组规则参与判定，切换模式不破坏另一组规则。
+- 相同 API、相同规则类型、相同规范化网络只能存在一条规则。
+- IP Access 判定先于 API Key hash lookup / rate-limit；被网络策略拒绝的请求不能继续消耗 Key/配额查询。
+- 激活名单后无法可信解析来源 IP 时 fail closed。
+- `X-Forwarded-For` / `X-Real-IP` 不是天然可信业务事实。只有 TCP 直接对端属于显式 Trusted Proxy CIDR 时，才进入代理链解析。
+- XFF 从右向左穿过可信代理，遇到第一个不可信 Hop 即得到客户端地址；更左侧客户端可控值不再参与结果。
+- Console IP Policy lifecycle 必须先通过父 Data Service CurrentProject ownership；ruleId 不能跨 Project 越权。
+
 ## 6. SQL Template / Invocation 不变量
 
 ```text
-HTTP parameters
+HTTP request
+   |
+   +--> trusted client-IP resolution
+   |
+   +--> IP allow/deny admission
+   |
+   +--> API Key authentication + cluster quota
    |
    v
 named parameter validation
    |
    v
 CompiledSql(sql + bindings)
-   |
-   +--> cluster API Key admission
    |
    v
 Node-local Runtime protection
@@ -285,6 +324,8 @@ Console request
 
 External request
   -> global runtime path
+  -> trusted client-IP resolution
+  -> IP policy
   -> NONE/API_KEY
   -> global findByRuntimePath only
   -> resolved Definition(projectId)
@@ -306,7 +347,7 @@ Domain / capability port
 
 允许 `dao/model` 使用 Lombok bean/setter 适配 ORM；Domain 不因此恢复为 `@Data` 贫血 Bean。
 
-管理 Repository 的 `findById/findByPath/findBySource/findAll/save/delete` 必须绑定 CurrentProject。Public path lookup 和平台级 count 是显式窄 global corridor；共享 rate-window / rollup 属于 Runtime/Observability coordination corridor，不得被 Controller 直接访问。
+管理 Repository 的 `findById/findByPath/findBySource/findAll/save/delete` 必须绑定 CurrentProject。Public path lookup 和平台级 count 是显式窄 global corridor；共享 rate-window / IP access policy / rollup 属于 Runtime/Access/Observability coordination corridor，不得被 Controller 直接访问。
 
 ## 12. 修改协议
 

--- a/yak-ops-business/yak-ops-business-data-service/MIGRATIONS.md
+++ b/yak-ops-business/yak-ops-business-data-service/MIGRATIONS.md
@@ -1,6 +1,6 @@
 # Data Service Migration Contract
 
-Data Service 和 Datasource 使用完全独立的 Flyway namespace。当前仍处于产品第一期，数据库结构尚未形成正式发布兼容承诺，因此开发期增量 migration 已收敛为各模块自己的一个 V1 baseline。
+Data Service 和 Datasource 使用完全独立的 Flyway namespace。`V1` 是两个模块各自的第一版完整 baseline；从 Data Service IP Access Policy 开始，Data Service schema 通过独立的增量版本继续演进，不再改写已经进入 `main` 的 V1 checksum。
 
 ## 1. Namespace ownership
 
@@ -21,21 +21,18 @@ Data Service
 - Data Service 模块禁止再创建 `db/migration/yak-datasource`；
 - 两个模块拥有独立 version sequence，不共享版本号和 history table。
 
-## 2. First-release baselines
+## 2. Baseline 与当前版本
 
-当前 baseline：
+当前 Data Service migration：
 
 ```text
-yak-ops-business-datasource
-└── db/migration/yak-datasource
-    └── V1__baseline_datasource.sql
-
 yak-ops-business-data-service
 └── db/migration/yak-data-service
-    └── V1__baseline_data_service.sql
+    ├── V1__baseline_data_service.sql
+    └── V2__ip_access_policy.sql
 ```
 
-`V1__baseline_data_service.sql` 直接创建 Data Service 当前最终结构，包括：
+`V1__baseline_data_service.sql` 创建首版完整结构，包括：
 
 - Data Service API definition / source revision / Project ownership；
 - API Key / auth mode / rate-limit policy；
@@ -45,7 +42,12 @@ yak-ops-business-data-service
 - cluster rate-limit minute window；
 - hourly invocation rollup。
 
-不再保留开发期 `V3/V4/V5/V6/V7/V9/V10/V11/V12/V13` 链路。
+`V2__ip_access_policy.sql` 只新增 Data Service 自有的来源访问控制结构：
+
+- `yak_ops_data_service_ip_access_policy`：每个 API 的 `NONE / ALLOWLIST / DENYLIST` 当前模式；
+- `yak_ops_data_service_ip_access_rule`：规范化 IP/CIDR、名单类型、enabled、expiresAt、description。
+
+V2 不回写、不 ALTER V1 业务字段，也不借用 Datasource migration namespace。
 
 ## 3. Flyway ordering
 
@@ -61,17 +63,19 @@ yak-ops-business-data-service
 Datasource V1
     ↓
 Data Service V1
+    ↓
+Data Service V2
 ```
 
 这是初始化顺序，不代表两个模块共享 schema history。
 
-## 4. One-time development database reset
+## 4. Development database reset
 
-本次 baseline squash 明确以“第一期开发数据可丢弃”为前提。不要尝试保留旧 checksum/history。
-
-合并本次调整后，本地旧开发库建议一次性执行：
+如果本地数据库来自 V1 baseline squash 之前的旧开发链路，仍建议一次性清理旧开发 schema history 后重建。当前完整 reset 顺序：
 
 ```sql
+DROP TABLE IF EXISTS yak_ops_data_service_ip_access_rule;
+DROP TABLE IF EXISTS yak_ops_data_service_ip_access_policy;
 DROP TABLE IF EXISTS yak_ops_data_service_call_log_hourly;
 DROP TABLE IF EXISTS yak_ops_data_service_rate_window;
 DROP TABLE IF EXISTS yak_ops_data_service_documentation;
@@ -88,16 +92,14 @@ DROP TABLE IF EXISTS yak_datasource_schema_history;
 DROP TABLE IF EXISTS yak_data_service_schema_history;
 ```
 
-然后重新启动 Yak Ops，让两个 V1 baseline 从零创建当前结构。
+然后重新启动 Yak Ops，让两个 namespace 从各自 V1 开始按版本顺序创建当前结构。
 
-> 该 reset 只适用于当前未正式发布的一期开发数据库。后续一旦进入正式版本，不再允许通过 squash/reset 处理已发布 migration。
+> Reset 只用于历史开发数据库迁移到稳定 baseline。已经运行 V1 的数据库不需要为了 IP Access 重置；Flyway 会直接执行 Data Service V2。
 
-## 5. Rules after first release
+## 5. 后续版本规则
 
-正式发布 baseline 后：
-
-1. Datasource 后续使用 `yak-datasource/V2`, `V3`, ...；
-2. Data Service 后续使用 `yak-data-service/V2`, `V3`, ...；
-3. 已发布 migration 不改名、不改内容、不改 checksum；
+1. Datasource 后续继续使用其自己的 `V2`, `V3`, ...；
+2. Data Service 下一个 schema 变更从 `yak-data-service/V3` 开始；
+3. 已进入 `main` 的 migration 不改名、不改内容、不改 checksum；
 4. 不允许再次跨模块共享 migration location/history table；
 5. schema ownership 变化必须先更新本文件和对应 Flyway contract test。

--- a/yak-ops-business/yak-ops-business-data-service/REQUIREMENTS.md
+++ b/yak-ops-business/yak-ops-business-data-service/REQUIREMENTS.md
@@ -12,6 +12,7 @@ Data Service 将已发布的数据定义转化为稳定、可调用、可保护�
 - SQL / Datasource 来源可信；
 - 调用参数安全绑定；
 - API Key 鉴权、调用方识别和集群共享调用配额；
+- IP/CIDR 来源白名单、黑名单与可信代理边界；
 - Cache / Circuit 等低延迟 Runtime 保护；
 - 多实例调用指标、审计生命周期和敏感参数保护；
 - 文档、OpenAPI、调用日志和运行概览；
@@ -22,7 +23,7 @@ Data Service 将已发布的数据定义转化为稳定、可调用、可保护�
 - Data Service 必须有稳定 ID、所属 Project Space、名称、Path、启用状态、最大返回行数、超时、分页开关和访问模式。
 - Path 在模块内唯一；由于 Public Invocation URL 不包含 Project namespace，Path 必须跨 Project 全局唯一。
 - 启用/停用不能改变已发布 SQL、Datasource 或 Source Revision。
-- 删除服务时必须清理其 API Key，并移除当前节点的 Runtime state。
+- 删除服务时必须清理其 API Key、IP 访问策略/规则，并移除当前节点的 Runtime state。
 - Runtime/Access 配置可以独立调整，不要求重新发布上游 Revision。
 - Data Service 必须维护持久化的单调 Runtime generation，用于区分不同发布/配置代际。
 
@@ -58,9 +59,11 @@ Source Provider
 - Pagination 控制参数 `pageNum/pageSize/returnTotalNum` 不得作为 SQL 命名参数透传。
 - `pageSize` 不能超过服务最大返回行数。
 
-## 5. Access / API Key
+## 5. Access / API Key / IP Policy
 
-- 支持 `NONE` 和 `API_KEY` 两种访问模式。
+API Key：
+
+- 支持 `NONE` 和 `API_KEY` 两种身份认证模式。
 - 切换到 `API_KEY` 前必须至少存在一个有效 Key。
 - Key create / rotate 时产生的 raw secret 只返回一次。
 - raw secret 永不落库；持久化只保存不可逆 hash 和可识别 prefix。
@@ -72,6 +75,21 @@ Source Provider
 - Key rotate / disable / delete 必须使对应共享限流窗口失效；过期窗口清理由维护任务处理，不能把扫描清理放在调用热路径。
 - 成功鉴权后调用日志需要记录 Key ID / Name / Prefix 快照，不记录 raw secret。
 - Console 管理 API Key 时必须先确认父 Data Service 属于 CurrentProject；keyId 不能绕过 Project ownership。
+
+来源 IP 访问策略：
+
+- 每个 Data Service 独立支持 `NONE / ALLOWLIST / DENYLIST` 三种 IP 访问模式；该模式与 `NONE / API_KEY` 身份认证模式正交。
+- 规则只表达 `ALLOWLIST` 或 `DENYLIST`，支持单 IP、IPv4 CIDR、IPv6 CIDR、enabled、可选过期时间和说明。
+- IP/CIDR 保存前必须规范化；相同 Data Service、相同名单类型、相同规范化网络不能重复创建。
+- `ALLOWLIST` 模式只允许命中至少一条 enabled 且未过期白名单规则的来源；空白名单等价于拒绝所有外部来源。
+- `DENYLIST` 模式拒绝命中任一 enabled 且未过期黑名单规则的来源；没有命中则继续调用。
+- IP 访问判定必须发生在 API Key 查询、Hash 校验和共享限流之前；来源被拒绝时返回 403。
+- 启用白名单或黑名单时，如果无法可信解析客户端 IP，必须 fail closed，不能静默绕过来源策略。
+- 默认只信任 TCP 直接对端地址；不能无条件信任客户端提供的 `X-Forwarded-For` 或 `X-Real-IP`。
+- 只有直接上游命中显式配置的 `yak.data-service.access.trusted-proxies` CIDR 时，才能读取 Forwarded Header。
+- `X-Forwarded-For` 必须从右向左按可信代理链解析，在第一个非可信 Hop 停止；客户端预置的伪造地址不能覆盖该结果。
+- Forwarded Header 格式异常时必须回退到直接对端，而不是继续信任另一个可伪造 Forwarded Header。
+- Console 管理 IP 策略/规则时必须先确认父 Data Service 属于 CurrentProject；ruleId 不能绕过 Project ownership。
 
 ## 6. Runtime Resilience
 
@@ -123,7 +141,7 @@ Source Provider
 调用审计是 evidence，不是业务结果 Truth：
 
 - 调用日志持久化失败不能把已经成功的查询变成失败响应；
-- 调用日志持久化失败不能覆盖原始 SQL / 鉴权 / 限流异常；
+- 调用日志持久化失败不能覆盖原始 SQL / IP 策略 / 鉴权 / 限流异常；
 - 审计故障允许降级为内部告警/日志，业务调用语义保持原状；
 - password/token/authorization/API Key/credential 等 Secret 参数必须在 JSON 序列化前完全脱敏；手机号、证件号、邮箱等常见个人标识必须按规则掩码；
 - 单个服务详情的调用记录必须支持按 Data Service ID 有界读取，不能依赖“读取全局最近日志后在浏览器过滤”；
@@ -145,17 +163,17 @@ Data Service 明确区分两个入口平面：
 
 ```text
 Management Plane -> Yak Project membership + Data Service RBAC
-Invocation Plane -> global service path + NONE/API_KEY
+Invocation Plane -> global service path + IP policy + NONE/API_KEY
 ```
 
 要求：
 
 - `/api/v1/data-service` 下的 Console 管理能力为 `PROJECT_REQUIRED`；
-- API 集市、详情、发布、配置、API Key、Runtime 管理、Documentation、Overview、Logs 都不能跨 Project 读取或修改；
+- API 集市、详情、发布、配置、API Key、IP 访问规则、Runtime 管理、Documentation、Overview、Logs 都不能跨 Project 读取或修改；
 - 管理权限至少拆分为 `read / publish / manage / delete / access / runtime / observe`；
 - Project membership 与 RBAC 是两个独立 gate，不能用其中一个替代另一个；
 - `/api/v1/data-service/runtime/{servicePath}` 是 Public Invocation Plane，不要求也不信任 Yak Project Header；
-- Public Invocation 只能通过全局唯一 runtime path 找到服务，再按已发布 `NONE/API_KEY` 契约鉴权；
+- Public Invocation 只能通过全局唯一 runtime path 找到服务，再按已发布 IP 访问策略与 `NONE/API_KEY` 契约鉴权；
 - Repository 只允许明确声明的全局窄 corridor，例如 Public Invocation 的 global-by-path 和首页只读 count；其他 management read/write 必须使用 CurrentProject；
 - Source-managed Data Service 仍必须从 owning authoring context 发起定义变更，Project/RBAC 不能绕过该 owner boundary。
 
@@ -167,6 +185,7 @@ Invocation Plane -> global service path + NONE/API_KEY
 - Source publication / republish；
 - Data Service invocation；
 - API Key / auth / cluster-wide rate limit；
+- Data Service 级 IP/CIDR allowlist / denylist 与可信代理解析；
 - node-local cache / circuit；
 - cluster invocation metric projection；
 - API documentation / OpenAPI；
@@ -181,7 +200,7 @@ Invocation Plane -> global service path + NONE/API_KEY
 - 任意 DML/DDL；
 - shared result-cache Truth；
 - distributed circuit-breaker state machine；
-- API Gateway；
+- 通用 API Gateway / WAF；
 - 数据血缘或质量计算；
 - 用 Project Header 替代 Public Runtime API Key 鉴权。
 
@@ -197,10 +216,10 @@ yak_ops_data_service_* 表的既有业务字段与 Flyway 历史
 yak-ops-core SqlExecutionRuntime contract
 Datasource Plugin / Catalog contract
 Data Development SourceProvider 业务语义
-401 / 429 / 503 HTTP 状态语义
+401 / 403 / 429 / 503 HTTP 状态语义
 ```
 
-Project cutover 可以通过 Expand + Backfill 增加 `project_id`，Stage 3 可以通过新 Flyway 增加 Runtime coordination / rollup 表，但不能改写已有 Flyway 历史。
+Project cutover 可以通过 Expand + Backfill 增加 `project_id`，Runtime coordination / rollup / access-policy schema 通过 Data Service 自有 Flyway namespace 演进，不能改写已发布 Flyway 历史。
 
 ## 12. 需求变更协议
 

--- a/yak-ops-business/yak-ops-business-data-service/src/main/java/io/yak/ops/business/dataservice/access/DataServiceAuthorizer.java
+++ b/yak-ops-business/yak-ops-business-data-service/src/main/java/io/yak/ops/business/dataservice/access/DataServiceAuthorizer.java
@@ -17,8 +17,15 @@ public class DataServiceAuthorizer {
   private final DataServiceApiKeyRepository repository;
   private final ApiKeySecretGenerator secrets;
   private final DataServiceRateLimiter rateLimiter;
+  private final DataServiceIpAccessAuthorizer ipAccessAuthorizer;
 
   public AccessContext authorize(DataServiceDefinition definition, String rawKey) {
+    return authorize(definition, rawKey, null);
+  }
+
+  /** Network policy is evaluated before API Key lookup/rate-limit work. */
+  public AccessContext authorize(DataServiceDefinition definition, String rawKey, String clientIp) {
+    ipAccessAuthorizer.authorize(definition.id(), clientIp);
     if (definition.authMode() == AuthMode.NONE) return AccessContext.publicAccess();
     if (rawKey == null || rawKey.isBlank()) throw new DataServiceUnauthorizedException("缺少 X-API-Key 请求头");
     DataServiceApiKey key = repository.findByHash(definition.id(), secrets.hash(rawKey.trim()))

--- a/yak-ops-business/yak-ops-business-data-service/src/main/java/io/yak/ops/business/dataservice/access/DataServiceClientIpResolver.java
+++ b/yak-ops-business/yak-ops-business-data-service/src/main/java/io/yak/ops/business/dataservice/access/DataServiceClientIpResolver.java
@@ -1,0 +1,74 @@
+package io.yak.ops.business.dataservice.access;
+
+import io.yak.ops.business.datasource.config.ConditionalOnDataSourceEnabled;
+import jakarta.servlet.http.HttpServletRequest;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+import org.springframework.util.StringUtils;
+
+/**
+ * Resolves the external client IP without blindly trusting spoofable forwarding headers.
+ *
+ * <p>Forwarded headers are considered only when the direct peer belongs to the explicitly
+ * configured trusted-proxy CIDRs. The X-Forwarded-For chain is walked from right to left until the
+ * first untrusted hop, which prevents a caller from winning by prepending a forged address.</p>
+ */
+@Component
+@ConditionalOnDataSourceEnabled
+public class DataServiceClientIpResolver {
+  private static final int MAX_FORWARDED_HOPS = 32;
+  private final List<String> trustedProxyNetworks;
+
+  public DataServiceClientIpResolver(
+      @Value("${yak.data-service.access.trusted-proxies:}") String trustedProxies) {
+    this.trustedProxyNetworks = parseTrustedProxies(trustedProxies);
+  }
+
+  public String resolve(HttpServletRequest request) {
+    if (request == null) return null;
+    String remote = IpNetwork.tryNormalizeAddress(request.getRemoteAddr());
+    if (remote == null || !isTrustedProxy(remote)) return remote;
+
+    List<String> forwarded = parseForwardedFor(request.getHeader("X-Forwarded-For"));
+    if (!forwarded.isEmpty()) {
+      String current = remote;
+      for (int index = forwarded.size() - 1; index >= 0 && isTrustedProxy(current); index--) {
+        current = forwarded.get(index);
+      }
+      return current;
+    }
+
+    String realIp = IpNetwork.tryNormalizeAddress(request.getHeader("X-Real-IP"));
+    return realIp == null ? remote : realIp;
+  }
+
+  private boolean isTrustedProxy(String address) {
+    if (address == null) return false;
+    return trustedProxyNetworks.stream().anyMatch(network -> IpNetwork.contains(network, address));
+  }
+
+  private List<String> parseTrustedProxies(String raw) {
+    if (!StringUtils.hasText(raw)) return List.of();
+    return Arrays.stream(raw.split(","))
+        .map(String::trim)
+        .filter(StringUtils::hasText)
+        .map(IpNetwork::normalizeNetwork)
+        .toList();
+  }
+
+  private List<String> parseForwardedFor(String raw) {
+    if (!StringUtils.hasText(raw)) return List.of();
+    String[] values = raw.split(",", -1);
+    if (values.length == 0 || values.length > MAX_FORWARDED_HOPS) return List.of();
+    List<String> result = new ArrayList<>(values.length);
+    for (String value : values) {
+      String normalized = IpNetwork.tryNormalizeAddress(value.trim());
+      if (normalized == null) return List.of();
+      result.add(normalized);
+    }
+    return List.copyOf(result);
+  }
+}

--- a/yak-ops-business/yak-ops-business-data-service/src/main/java/io/yak/ops/business/dataservice/access/DataServiceClientIpResolver.java
+++ b/yak-ops-business/yak-ops-business-data-service/src/main/java/io/yak/ops/business/dataservice/access/DataServiceClientIpResolver.java
@@ -32,8 +32,10 @@ public class DataServiceClientIpResolver {
     String remote = IpNetwork.tryNormalizeAddress(request.getRemoteAddr());
     if (remote == null || !isTrustedProxy(remote)) return remote;
 
-    List<String> forwarded = parseForwardedFor(request.getHeader("X-Forwarded-For"));
-    if (!forwarded.isEmpty()) {
+    String forwardedHeader = request.getHeader("X-Forwarded-For");
+    if (StringUtils.hasText(forwardedHeader)) {
+      List<String> forwarded = parseForwardedFor(forwardedHeader);
+      if (forwarded.isEmpty()) return remote;
       String current = remote;
       for (int index = forwarded.size() - 1; index >= 0 && isTrustedProxy(current); index--) {
         current = forwarded.get(index);

--- a/yak-ops-business/yak-ops-business-data-service/src/main/java/io/yak/ops/business/dataservice/access/DataServiceForbiddenException.java
+++ b/yak-ops-business/yak-ops-business-data-service/src/main/java/io/yak/ops/business/dataservice/access/DataServiceForbiddenException.java
@@ -1,0 +1,11 @@
+package io.yak.ops.business.dataservice.access;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.ResponseStatus;
+
+@ResponseStatus(HttpStatus.FORBIDDEN)
+public class DataServiceForbiddenException extends RuntimeException {
+  public DataServiceForbiddenException(String message) {
+    super(message);
+  }
+}

--- a/yak-ops-business/yak-ops-business-data-service/src/main/java/io/yak/ops/business/dataservice/access/DataServiceIpAccessAuthorizer.java
+++ b/yak-ops-business/yak-ops-business-data-service/src/main/java/io/yak/ops/business/dataservice/access/DataServiceIpAccessAuthorizer.java
@@ -5,27 +5,18 @@ import io.yak.ops.business.dataservice.domain.access.IpAccessMode;
 import io.yak.ops.business.dataservice.domain.access.IpAccessRuleType;
 import io.yak.ops.business.dataservice.repository.DataServiceIpAccessRepository;
 import io.yak.ops.business.datasource.config.ConditionalOnDataSourceEnabled;
-import java.time.Clock;
 import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Objects;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 
 @Component
 @ConditionalOnDataSourceEnabled
 public class DataServiceIpAccessAuthorizer {
   private final DataServiceIpAccessRepository repository;
-  private final Clock clock;
 
-  @Autowired
   public DataServiceIpAccessAuthorizer(DataServiceIpAccessRepository repository) {
-    this(repository, Clock.systemDefaultZone());
-  }
-
-  DataServiceIpAccessAuthorizer(DataServiceIpAccessRepository repository, Clock clock) {
     this.repository = Objects.requireNonNull(repository, "repository");
-    this.clock = Objects.requireNonNull(clock, "clock");
   }
 
   public void authorize(Long apiId, String clientIp) {
@@ -40,7 +31,7 @@ public class DataServiceIpAccessAuthorizer {
     IpAccessRuleType activeType = mode == IpAccessMode.ALLOWLIST
         ? IpAccessRuleType.ALLOWLIST
         : IpAccessRuleType.DENYLIST;
-    LocalDateTime now = LocalDateTime.now(clock);
+    LocalDateTime now = LocalDateTime.now();
     List<DataServiceIpAccessRule> rules = repository.findRules(apiId).stream()
         .filter(rule -> rule.ruleType() == activeType)
         .filter(rule -> rule.active(now))

--- a/yak-ops-business/yak-ops-business-data-service/src/main/java/io/yak/ops/business/dataservice/access/DataServiceIpAccessAuthorizer.java
+++ b/yak-ops-business/yak-ops-business-data-service/src/main/java/io/yak/ops/business/dataservice/access/DataServiceIpAccessAuthorizer.java
@@ -1,0 +1,58 @@
+package io.yak.ops.business.dataservice.access;
+
+import io.yak.ops.business.dataservice.domain.access.DataServiceIpAccessRule;
+import io.yak.ops.business.dataservice.domain.access.IpAccessMode;
+import io.yak.ops.business.dataservice.domain.access.IpAccessRuleType;
+import io.yak.ops.business.dataservice.repository.DataServiceIpAccessRepository;
+import io.yak.ops.business.datasource.config.ConditionalOnDataSourceEnabled;
+import java.time.Clock;
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Objects;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Component;
+
+@Component
+@ConditionalOnDataSourceEnabled
+public class DataServiceIpAccessAuthorizer {
+  private final DataServiceIpAccessRepository repository;
+  private final Clock clock;
+
+  @Autowired
+  public DataServiceIpAccessAuthorizer(DataServiceIpAccessRepository repository) {
+    this(repository, Clock.systemDefaultZone());
+  }
+
+  DataServiceIpAccessAuthorizer(DataServiceIpAccessRepository repository, Clock clock) {
+    this.repository = Objects.requireNonNull(repository, "repository");
+    this.clock = Objects.requireNonNull(clock, "clock");
+  }
+
+  public void authorize(Long apiId, String clientIp) {
+    IpAccessMode mode = repository.findMode(apiId);
+    if (mode == IpAccessMode.NONE) return;
+
+    String normalizedIp = IpNetwork.tryNormalizeAddress(clientIp);
+    if (normalizedIp == null) {
+      throw new DataServiceForbiddenException("无法确认调用来源 IP，访问策略拒绝本次调用");
+    }
+
+    IpAccessRuleType activeType = mode == IpAccessMode.ALLOWLIST
+        ? IpAccessRuleType.ALLOWLIST
+        : IpAccessRuleType.DENYLIST;
+    LocalDateTime now = LocalDateTime.now(clock);
+    List<DataServiceIpAccessRule> rules = repository.findRules(apiId).stream()
+        .filter(rule -> rule.ruleType() == activeType)
+        .filter(rule -> rule.active(now))
+        .toList();
+    boolean matched = rules.stream()
+        .anyMatch(rule -> IpNetwork.contains(rule.networkCidr(), normalizedIp));
+
+    if (mode == IpAccessMode.ALLOWLIST && !matched) {
+      throw new DataServiceForbiddenException("当前来源 IP 不在数据服务白名单中");
+    }
+    if (mode == IpAccessMode.DENYLIST && matched) {
+      throw new DataServiceForbiddenException("当前来源 IP 已被数据服务访问策略拒绝");
+    }
+  }
+}

--- a/yak-ops-business/yak-ops-business-data-service/src/main/java/io/yak/ops/business/dataservice/access/DataServiceIpAccessManager.java
+++ b/yak-ops-business/yak-ops-business-data-service/src/main/java/io/yak/ops/business/dataservice/access/DataServiceIpAccessManager.java
@@ -1,0 +1,145 @@
+package io.yak.ops.business.dataservice.access;
+
+import io.yak.ops.business.dataservice.domain.access.DataServiceIpAccessRule;
+import io.yak.ops.business.dataservice.domain.access.IpAccessMode;
+import io.yak.ops.business.dataservice.domain.access.IpAccessRuleType;
+import io.yak.ops.business.dataservice.query.DataServiceReader;
+import io.yak.ops.business.dataservice.repository.DataServiceIpAccessRepository;
+import io.yak.ops.business.datasource.config.ConditionalOnDataSourceEnabled;
+import java.time.LocalDateTime;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.util.StringUtils;
+
+@Component
+@ConditionalOnDataSourceEnabled
+@RequiredArgsConstructor
+public class DataServiceIpAccessManager {
+  private final DataServiceReader dataServiceReader;
+  private final DataServiceIpAccessRepository repository;
+
+  public IpAccessPolicyView getPolicy(Long apiId) {
+    dataServiceReader.require(apiId);
+    return view(apiId);
+  }
+
+  @Transactional
+  public IpAccessPolicyView setMode(Long apiId, String rawMode) {
+    dataServiceReader.require(apiId);
+    IpAccessMode mode;
+    try {
+      mode = IpAccessMode.parse(rawMode);
+    } catch (IllegalArgumentException exception) {
+      throw new IllegalArgumentException("未知 IP 访问模式：" + rawMode, exception);
+    }
+    repository.saveMode(apiId, mode, LocalDateTime.now());
+    return view(apiId);
+  }
+
+  @Transactional
+  public IpAccessRuleView createRule(Long apiId, IpAccessRuleInput input) {
+    dataServiceReader.require(apiId);
+    RuleValues values = normalize(input, null);
+    ensureUnique(apiId, values.ruleType(), values.networkCidr(), null);
+    LocalDateTime now = LocalDateTime.now();
+    return ruleView(repository.saveRule(new DataServiceIpAccessRule(
+        null, apiId, values.ruleType(), values.networkCidr(), values.description(),
+        values.enabled(), values.expiresAt(), now, now)));
+  }
+
+  @Transactional
+  public IpAccessRuleView updateRule(Long apiId, Long ruleId, IpAccessRuleInput input) {
+    DataServiceIpAccessRule current = requireRule(apiId, ruleId);
+    RuleValues values = normalize(input, current);
+    ensureUnique(apiId, values.ruleType(), values.networkCidr(), ruleId);
+    return ruleView(repository.saveRule(new DataServiceIpAccessRule(
+        current.id(), current.apiId(), values.ruleType(), values.networkCidr(), values.description(),
+        values.enabled(), values.expiresAt(), current.createTime(), LocalDateTime.now())));
+  }
+
+  @Transactional
+  public void deleteRule(Long apiId, Long ruleId) {
+    requireRule(apiId, ruleId);
+    if (!repository.deleteRule(ruleId)) throw new IllegalArgumentException("IP 访问规则不存在：" + ruleId);
+  }
+
+  @Transactional
+  public void deleteForApi(Long apiId) {
+    if (apiId != null) repository.deleteByApiId(apiId);
+  }
+
+  private IpAccessPolicyView view(Long apiId) {
+    return new IpAccessPolicyView(
+        repository.findMode(apiId), repository.findRules(apiId).stream().map(this::ruleView).toList());
+  }
+
+  private DataServiceIpAccessRule requireRule(Long apiId, Long ruleId) {
+    dataServiceReader.require(apiId);
+    if (ruleId == null) throw new IllegalArgumentException("IP 访问规则 ID 不能为空");
+    DataServiceIpAccessRule rule = repository.findRule(ruleId)
+        .orElseThrow(() -> new IllegalArgumentException("IP 访问规则不存在：" + ruleId));
+    if (!apiId.equals(rule.apiId())) throw new IllegalArgumentException("IP 访问规则不存在：" + ruleId);
+    return rule;
+  }
+
+  private RuleValues normalize(IpAccessRuleInput input, DataServiceIpAccessRule current) {
+    if (input == null) throw new IllegalArgumentException("IP 访问规则不能为空");
+    IpAccessRuleType type = StringUtils.hasText(input.ruleType())
+        ? parseType(input.ruleType())
+        : current == null ? null : current.ruleType();
+    if (type == null) throw new IllegalArgumentException("IP 访问规则类型不能为空");
+
+    String network = StringUtils.hasText(input.networkCidr())
+        ? IpNetwork.normalizeNetwork(input.networkCidr())
+        : current == null ? null : current.networkCidr();
+    if (!StringUtils.hasText(network)) throw new IllegalArgumentException("IP/CIDR 不能为空");
+
+    String description = input.description() == null
+        ? current == null ? null : current.description()
+        : normalizeDescription(input.description());
+    boolean enabled = input.enabled() == null
+        ? current == null || current.enabled()
+        : input.enabled();
+    LocalDateTime expiresAt = input.expiresAt();
+    if (expiresAt != null && !expiresAt.isAfter(LocalDateTime.now())) {
+      throw new IllegalArgumentException("规则过期时间必须晚于当前时间");
+    }
+    return new RuleValues(type, network, description, enabled, expiresAt);
+  }
+
+  private IpAccessRuleType parseType(String value) {
+    try {
+      return IpAccessRuleType.parse(value);
+    } catch (IllegalArgumentException exception) {
+      throw new IllegalArgumentException("未知 IP 访问规则类型：" + value, exception);
+    }
+  }
+
+  private String normalizeDescription(String value) {
+    String result = value == null ? null : value.trim();
+    if (!StringUtils.hasText(result)) return null;
+    if (result.length() > 255) throw new IllegalArgumentException("规则说明不能超过 255 个字符");
+    return result;
+  }
+
+  private void ensureUnique(
+      Long apiId, IpAccessRuleType type, String networkCidr, Long excludeId) {
+    if (repository.existsRule(apiId, type, networkCidr, excludeId)) {
+      throw new IllegalArgumentException("该名单中已存在相同 IP/CIDR：" + networkCidr);
+    }
+  }
+
+  private IpAccessRuleView ruleView(DataServiceIpAccessRule rule) {
+    return new IpAccessRuleView(
+        rule.id(), rule.apiId(), rule.ruleType(), rule.networkCidr(), rule.description(),
+        rule.enabled(), rule.expiresAt(), rule.createTime(), rule.updateTime());
+  }
+
+  private record RuleValues(
+      IpAccessRuleType ruleType,
+      String networkCidr,
+      String description,
+      boolean enabled,
+      LocalDateTime expiresAt) {}
+}

--- a/yak-ops-business/yak-ops-business-data-service/src/main/java/io/yak/ops/business/dataservice/access/DataServiceIpAccessManager.java
+++ b/yak-ops-business/yak-ops-business-data-service/src/main/java/io/yak/ops/business/dataservice/access/DataServiceIpAccessManager.java
@@ -95,14 +95,14 @@ public class DataServiceIpAccessManager {
         : current == null ? null : current.networkCidr();
     if (!StringUtils.hasText(network)) throw new IllegalArgumentException("IP/CIDR 不能为空");
 
-    String description = input.description() == null
-        ? current == null ? null : current.description()
-        : normalizeDescription(input.description());
+    String description = normalizeDescription(input.description());
     boolean enabled = input.enabled() == null
         ? current == null || current.enabled()
         : input.enabled();
     LocalDateTime expiresAt = input.expiresAt();
-    if (expiresAt != null && !expiresAt.isAfter(LocalDateTime.now())) {
+    if (expiresAt != null
+        && !expiresAt.isAfter(LocalDateTime.now())
+        && (current == null || !expiresAt.equals(current.expiresAt()))) {
       throw new IllegalArgumentException("规则过期时间必须晚于当前时间");
     }
     return new RuleValues(type, network, description, enabled, expiresAt);

--- a/yak-ops-business/yak-ops-business-data-service/src/main/java/io/yak/ops/business/dataservice/access/IpAccessPolicyView.java
+++ b/yak-ops-business/yak-ops-business-data-service/src/main/java/io/yak/ops/business/dataservice/access/IpAccessPolicyView.java
@@ -1,0 +1,6 @@
+package io.yak.ops.business.dataservice.access;
+
+import io.yak.ops.business.dataservice.domain.access.IpAccessMode;
+import java.util.List;
+
+public record IpAccessPolicyView(IpAccessMode mode, List<IpAccessRuleView> rules) {}

--- a/yak-ops-business/yak-ops-business-data-service/src/main/java/io/yak/ops/business/dataservice/access/IpAccessRuleInput.java
+++ b/yak-ops-business/yak-ops-business-data-service/src/main/java/io/yak/ops/business/dataservice/access/IpAccessRuleInput.java
@@ -1,0 +1,10 @@
+package io.yak.ops.business.dataservice.access;
+
+import java.time.LocalDateTime;
+
+public record IpAccessRuleInput(
+    String ruleType,
+    String networkCidr,
+    String description,
+    Boolean enabled,
+    LocalDateTime expiresAt) {}

--- a/yak-ops-business/yak-ops-business-data-service/src/main/java/io/yak/ops/business/dataservice/access/IpAccessRuleView.java
+++ b/yak-ops-business/yak-ops-business-data-service/src/main/java/io/yak/ops/business/dataservice/access/IpAccessRuleView.java
@@ -1,0 +1,15 @@
+package io.yak.ops.business.dataservice.access;
+
+import io.yak.ops.business.dataservice.domain.access.IpAccessRuleType;
+import java.time.LocalDateTime;
+
+public record IpAccessRuleView(
+    Long id,
+    Long apiId,
+    IpAccessRuleType ruleType,
+    String networkCidr,
+    String description,
+    boolean enabled,
+    LocalDateTime expiresAt,
+    LocalDateTime createTime,
+    LocalDateTime updateTime) {}

--- a/yak-ops-business/yak-ops-business-data-service/src/main/java/io/yak/ops/business/dataservice/access/IpNetwork.java
+++ b/yak-ops-business/yak-ops-business-data-service/src/main/java/io/yak/ops/business/dataservice/access/IpNetwork.java
@@ -1,0 +1,135 @@
+package io.yak.ops.business.dataservice.access;
+
+import java.net.InetAddress;
+import java.util.Arrays;
+
+/** Strict IP-literal/CIDR parsing used by Data Service access policy and trusted-proxy handling. */
+final class IpNetwork {
+  private IpNetwork() {}
+
+  static String normalizeNetwork(String raw) {
+    ParsedNetwork network = parseNetwork(raw);
+    byte[] normalized = Arrays.copyOf(network.address(), network.address().length);
+    zeroHostBits(normalized, network.prefixLength());
+    String address = canonical(normalized);
+    return network.explicitPrefix() ? address + "/" + network.prefixLength() : address;
+  }
+
+  static String normalizeAddress(String raw) {
+    if (raw == null || raw.isBlank() || raw.contains("/")) {
+      throw new IllegalArgumentException("IP 地址格式无效：" + raw);
+    }
+    return canonical(parseLiteral(stripBracketsAndZone(raw.trim())));
+  }
+
+  static String tryNormalizeAddress(String raw) {
+    try {
+      return normalizeAddress(raw);
+    } catch (RuntimeException exception) {
+      return null;
+    }
+  }
+
+  static boolean contains(String rawNetwork, String rawAddress) {
+    ParsedNetwork network = parseNetwork(rawNetwork);
+    byte[] address = parseLiteral(stripBracketsAndZone(rawAddress == null ? "" : rawAddress.trim()));
+    if (network.address().length != address.length) return false;
+    int wholeBytes = network.prefixLength() / 8;
+    int remainder = network.prefixLength() % 8;
+    for (int i = 0; i < wholeBytes; i++) {
+      if (network.address()[i] != address[i]) return false;
+    }
+    if (remainder == 0) return true;
+    int mask = (0xff << (8 - remainder)) & 0xff;
+    return (network.address()[wholeBytes] & mask) == (address[wholeBytes] & mask);
+  }
+
+  private static ParsedNetwork parseNetwork(String raw) {
+    if (raw == null || raw.isBlank()) throw new IllegalArgumentException("IP/CIDR 不能为空");
+    String value = raw.trim();
+    int slash = value.indexOf('/');
+    if (slash >= 0 && slash != value.lastIndexOf('/')) {
+      throw new IllegalArgumentException("IP/CIDR 格式无效：" + raw);
+    }
+    String addressPart = slash < 0 ? value : value.substring(0, slash).trim();
+    byte[] address = parseLiteral(stripBracketsAndZone(addressPart));
+    int maxPrefix = address.length * 8;
+    int prefix = maxPrefix;
+    if (slash >= 0) {
+      String prefixPart = value.substring(slash + 1).trim();
+      try {
+        prefix = Integer.parseInt(prefixPart);
+      } catch (NumberFormatException exception) {
+        throw new IllegalArgumentException("CIDR 前缀无效：" + raw, exception);
+      }
+      if (prefix < 0 || prefix > maxPrefix) {
+        throw new IllegalArgumentException("CIDR 前缀必须在 0~" + maxPrefix + " 之间：" + raw);
+      }
+    }
+    byte[] network = Arrays.copyOf(address, address.length);
+    zeroHostBits(network, prefix);
+    return new ParsedNetwork(network, prefix, slash >= 0);
+  }
+
+  private static byte[] parseLiteral(String value) {
+    if (value == null || value.isBlank()) throw new IllegalArgumentException("IP 地址不能为空");
+    if (!value.matches("[0-9A-Fa-f:.]+")) {
+      throw new IllegalArgumentException("仅支持 IPv4/IPv6 字面量：" + value);
+    }
+    if (!value.contains(":")) return parseIpv4(value);
+    try {
+      byte[] bytes = InetAddress.getByName(value).getAddress();
+      if (bytes.length != 16 && bytes.length != 4) {
+        throw new IllegalArgumentException("IP 地址格式无效：" + value);
+      }
+      return bytes;
+    } catch (Exception exception) {
+      throw new IllegalArgumentException("IP 地址格式无效：" + value, exception);
+    }
+  }
+
+  private static byte[] parseIpv4(String value) {
+    String[] parts = value.split("\\.", -1);
+    if (parts.length != 4) throw new IllegalArgumentException("IPv4 地址格式无效：" + value);
+    byte[] bytes = new byte[4];
+    for (int i = 0; i < parts.length; i++) {
+      if (!parts[i].matches("\\d{1,3}")) {
+        throw new IllegalArgumentException("IPv4 地址格式无效：" + value);
+      }
+      int octet = Integer.parseInt(parts[i]);
+      if (octet < 0 || octet > 255) throw new IllegalArgumentException("IPv4 地址格式无效：" + value);
+      bytes[i] = (byte) octet;
+    }
+    return bytes;
+  }
+
+  private static String stripBracketsAndZone(String value) {
+    String result = value == null ? "" : value.trim();
+    if (result.startsWith("[") && result.endsWith("]")) {
+      result = result.substring(1, result.length() - 1);
+    }
+    int zone = result.indexOf('%');
+    return zone < 0 ? result : result.substring(0, zone);
+  }
+
+  private static void zeroHostBits(byte[] address, int prefix) {
+    int wholeBytes = prefix / 8;
+    int remainder = prefix % 8;
+    if (wholeBytes < address.length && remainder > 0) {
+      int mask = (0xff << (8 - remainder)) & 0xff;
+      address[wholeBytes] = (byte) (address[wholeBytes] & mask);
+      wholeBytes++;
+    }
+    for (int i = wholeBytes; i < address.length; i++) address[i] = 0;
+  }
+
+  private static String canonical(byte[] address) {
+    try {
+      return InetAddress.getByAddress(address).getHostAddress();
+    } catch (Exception exception) {
+      throw new IllegalArgumentException("无法规范化 IP 地址", exception);
+    }
+  }
+
+  private record ParsedNetwork(byte[] address, int prefixLength, boolean explicitPrefix) {}
+}

--- a/yak-ops-business/yak-ops-business-data-service/src/main/java/io/yak/ops/business/dataservice/controller/v1/DataServiceAccessController.java
+++ b/yak-ops-business/yak-ops-business-data-service/src/main/java/io/yak/ops/business/dataservice/controller/v1/DataServiceAccessController.java
@@ -9,6 +9,10 @@ import io.yak.ops.business.dataservice.access.ApiKeyUpdate;
 import io.yak.ops.business.dataservice.access.ApiKeyView;
 import io.yak.ops.business.dataservice.access.CreatedApiKey;
 import io.yak.ops.business.dataservice.access.DataServiceApiKeyManager;
+import io.yak.ops.business.dataservice.access.DataServiceIpAccessManager;
+import io.yak.ops.business.dataservice.access.IpAccessPolicyView;
+import io.yak.ops.business.dataservice.access.IpAccessRuleInput;
+import io.yak.ops.business.dataservice.access.IpAccessRuleView;
 import io.yak.ops.business.datasource.config.ConditionalOnDataSourceEnabled;
 import io.yak.ops.common.constant.dataservice.DataServicePermissionCode;
 import io.yak.ops.core.project.ProjectMigrationMode;
@@ -33,24 +37,25 @@ import org.springframework.web.bind.annotation.RestController;
 @ProjectScope(ProjectMigrationMode.PROJECT_REQUIRED)
 @RequiresPermission(DataServicePermissionCode.ACCESS)
 public class DataServiceAccessController {
-  private final DataServiceApiKeyManager manager;
+  private final DataServiceApiKeyManager apiKeyManager;
+  private final DataServiceIpAccessManager ipAccessManager;
 
   @Operation(summary = "设置数据服务访问控制模式")
   @PutMapping("/{id}/auth-mode")
   public Result<String> setAuthMode(@PathVariable("id") Long id, @RequestParam("mode") String mode) {
-    return Result.success(manager.setAuthMode(id, mode).name());
+    return Result.success(apiKeyManager.setAuthMode(id, mode).name());
   }
 
   @Operation(summary = "查询数据服务 API Key")
   @GetMapping("/{id}/keys")
   public Result<List<ApiKeyView>> listKeys(@PathVariable("id") Long id) {
-    return Result.success(manager.listKeys(id));
+    return Result.success(apiKeyManager.listKeys(id));
   }
 
   @Operation(summary = "创建数据服务 API Key（明文仅返回一次）")
   @PostMapping("/{id}/keys")
   public Result<CreatedApiKey> createKey(@PathVariable("id") Long id, @RequestBody ApiKeyInput input) {
-    return Result.success(manager.createKey(id, input));
+    return Result.success(apiKeyManager.createKey(id, input));
   }
 
   @Operation(summary = "更新数据服务 API Key 配置")
@@ -59,7 +64,7 @@ public class DataServiceAccessController {
       @PathVariable("id") Long id,
       @PathVariable("keyId") Long keyId,
       @RequestBody ApiKeyUpdate input) {
-    return Result.success(manager.updateKey(id, keyId, input));
+    return Result.success(apiKeyManager.updateKey(id, keyId, input));
   }
 
   @Operation(summary = "启用或停用数据服务 API Key")
@@ -68,7 +73,7 @@ public class DataServiceAccessController {
       @PathVariable("id") Long id,
       @PathVariable("keyId") Long keyId,
       @RequestParam("enabled") boolean enabled) {
-    return Result.success(manager.setKeyEnabled(id, keyId, enabled));
+    return Result.success(apiKeyManager.setKeyEnabled(id, keyId, enabled));
   }
 
   @Operation(summary = "轮换数据服务 API Key（新明文仅返回一次）")
@@ -76,7 +81,7 @@ public class DataServiceAccessController {
   public Result<CreatedApiKey> rotateKey(
       @PathVariable("id") Long id,
       @PathVariable("keyId") Long keyId) {
-    return Result.success(manager.rotateKey(id, keyId));
+    return Result.success(apiKeyManager.rotateKey(id, keyId));
   }
 
   @Operation(summary = "删除数据服务 API Key")
@@ -84,7 +89,44 @@ public class DataServiceAccessController {
   public Result<Boolean> deleteKey(
       @PathVariable("id") Long id,
       @PathVariable("keyId") Long keyId) {
-    manager.deleteKey(id, keyId);
+    apiKeyManager.deleteKey(id, keyId);
+    return Result.success(Boolean.TRUE);
+  }
+
+  @Operation(summary = "查询数据服务 IP 黑白名单策略")
+  @GetMapping("/{id}/ip-access")
+  public Result<IpAccessPolicyView> getIpAccess(@PathVariable("id") Long id) {
+    return Result.success(ipAccessManager.getPolicy(id));
+  }
+
+  @Operation(summary = "设置数据服务 IP 访问模式")
+  @PutMapping("/{id}/ip-access/mode")
+  public Result<IpAccessPolicyView> setIpAccessMode(
+      @PathVariable("id") Long id, @RequestParam("mode") String mode) {
+    return Result.success(ipAccessManager.setMode(id, mode));
+  }
+
+  @Operation(summary = "新增数据服务 IP/CIDR 规则")
+  @PostMapping("/{id}/ip-access/rules")
+  public Result<IpAccessRuleView> createIpAccessRule(
+      @PathVariable("id") Long id, @RequestBody IpAccessRuleInput input) {
+    return Result.success(ipAccessManager.createRule(id, input));
+  }
+
+  @Operation(summary = "更新数据服务 IP/CIDR 规则")
+  @PutMapping("/{id}/ip-access/rules/{ruleId}")
+  public Result<IpAccessRuleView> updateIpAccessRule(
+      @PathVariable("id") Long id,
+      @PathVariable("ruleId") Long ruleId,
+      @RequestBody IpAccessRuleInput input) {
+    return Result.success(ipAccessManager.updateRule(id, ruleId, input));
+  }
+
+  @Operation(summary = "删除数据服务 IP/CIDR 规则")
+  @DeleteMapping("/{id}/ip-access/rules/{ruleId}")
+  public Result<Boolean> deleteIpAccessRule(
+      @PathVariable("id") Long id, @PathVariable("ruleId") Long ruleId) {
+    ipAccessManager.deleteRule(id, ruleId);
     return Result.success(Boolean.TRUE);
   }
 }

--- a/yak-ops-business/yak-ops-business-data-service/src/main/java/io/yak/ops/business/dataservice/controller/v1/DataServiceInvocationController.java
+++ b/yak-ops-business/yak-ops-business-data-service/src/main/java/io/yak/ops/business/dataservice/controller/v1/DataServiceInvocationController.java
@@ -3,9 +3,11 @@ package io.yak.ops.business.dataservice.controller.v1;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import io.yak.framework.common.Result;
+import io.yak.ops.business.dataservice.access.DataServiceClientIpResolver;
 import io.yak.ops.business.dataservice.domain.DataServiceQueryResponse;
 import io.yak.ops.business.dataservice.execution.DataServiceInvoker;
 import io.yak.ops.business.datasource.config.ConditionalOnDataSourceEnabled;
+import jakarta.servlet.http.HttpServletRequest;
 import java.util.Map;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -20,7 +22,7 @@ import org.springframework.web.bind.annotation.RestController;
  *
  * <p>This controller intentionally has no ProjectScope or Yak user RBAC requirement. External
  * callers identify a globally unique runtime path and are protected by the published service's
- * NONE/API_KEY access contract instead of Yak console Project headers.</p>
+ * IP access policy plus NONE/API_KEY access contract instead of Yak console Project headers.</p>
  */
 @Tag(name = "数据服务调用")
 @RestController
@@ -30,13 +32,16 @@ import org.springframework.web.bind.annotation.RestController;
 public class DataServiceInvocationController {
 
   private final DataServiceInvoker invoker;
+  private final DataServiceClientIpResolver clientIpResolver;
 
   @Operation(summary = "调用已发布的数据服务")
   @GetMapping("/runtime/{*servicePath}")
   public Result<DataServiceQueryResponse> invoke(
       @PathVariable("servicePath") String servicePath,
       @RequestHeader(value = "X-API-Key", required = false) String apiKey,
-      @RequestParam Map<String, String> parameters) {
-    return Result.success(invoker.invoke(servicePath, parameters, apiKey));
+      @RequestParam Map<String, String> parameters,
+      HttpServletRequest request) {
+    return Result.success(
+        invoker.invoke(servicePath, parameters, apiKey, clientIpResolver.resolve(request)));
   }
 }

--- a/yak-ops-business/yak-ops-business-data-service/src/main/java/io/yak/ops/business/dataservice/dao/mapper/DataServiceIpAccessPolicyMapper.java
+++ b/yak-ops-business/yak-ops-business-data-service/src/main/java/io/yak/ops/business/dataservice/dao/mapper/DataServiceIpAccessPolicyMapper.java
@@ -1,0 +1,8 @@
+package io.yak.ops.business.dataservice.dao.mapper;
+
+import com.baomidou.mybatisplus.core.mapper.BaseMapper;
+import io.yak.ops.business.dataservice.dao.model.DataServiceIpAccessPolicyPO;
+import org.apache.ibatis.annotations.Mapper;
+
+@Mapper
+public interface DataServiceIpAccessPolicyMapper extends BaseMapper<DataServiceIpAccessPolicyPO> {}

--- a/yak-ops-business/yak-ops-business-data-service/src/main/java/io/yak/ops/business/dataservice/dao/mapper/DataServiceIpAccessRuleMapper.java
+++ b/yak-ops-business/yak-ops-business-data-service/src/main/java/io/yak/ops/business/dataservice/dao/mapper/DataServiceIpAccessRuleMapper.java
@@ -1,0 +1,8 @@
+package io.yak.ops.business.dataservice.dao.mapper;
+
+import com.baomidou.mybatisplus.core.mapper.BaseMapper;
+import io.yak.ops.business.dataservice.dao.model.DataServiceIpAccessRulePO;
+import org.apache.ibatis.annotations.Mapper;
+
+@Mapper
+public interface DataServiceIpAccessRuleMapper extends BaseMapper<DataServiceIpAccessRulePO> {}

--- a/yak-ops-business/yak-ops-business-data-service/src/main/java/io/yak/ops/business/dataservice/dao/model/DataServiceIpAccessPolicyPO.java
+++ b/yak-ops-business/yak-ops-business-data-service/src/main/java/io/yak/ops/business/dataservice/dao/model/DataServiceIpAccessPolicyPO.java
@@ -1,0 +1,16 @@
+package io.yak.ops.business.dataservice.dao.model;
+
+import com.baomidou.mybatisplus.annotation.IdType;
+import com.baomidou.mybatisplus.annotation.TableId;
+import com.baomidou.mybatisplus.annotation.TableName;
+import java.time.LocalDateTime;
+import lombok.Data;
+
+@Data
+@TableName("yak_ops_data_service_ip_access_policy")
+public class DataServiceIpAccessPolicyPO {
+  @TableId(value = "api_id", type = IdType.INPUT)
+  private Long apiId;
+  private String mode;
+  private LocalDateTime updateTime;
+}

--- a/yak-ops-business/yak-ops-business-data-service/src/main/java/io/yak/ops/business/dataservice/dao/model/DataServiceIpAccessRulePO.java
+++ b/yak-ops-business/yak-ops-business-data-service/src/main/java/io/yak/ops/business/dataservice/dao/model/DataServiceIpAccessRulePO.java
@@ -1,0 +1,22 @@
+package io.yak.ops.business.dataservice.dao.model;
+
+import com.baomidou.mybatisplus.annotation.IdType;
+import com.baomidou.mybatisplus.annotation.TableId;
+import com.baomidou.mybatisplus.annotation.TableName;
+import java.time.LocalDateTime;
+import lombok.Data;
+
+@Data
+@TableName("yak_ops_data_service_ip_access_rule")
+public class DataServiceIpAccessRulePO {
+  @TableId(type = IdType.AUTO)
+  private Long id;
+  private Long apiId;
+  private String ruleType;
+  private String networkCidr;
+  private String description;
+  private Boolean enabled;
+  private LocalDateTime expiresAt;
+  private LocalDateTime createTime;
+  private LocalDateTime updateTime;
+}

--- a/yak-ops-business/yak-ops-business-data-service/src/main/java/io/yak/ops/business/dataservice/domain/access/DataServiceIpAccessRule.java
+++ b/yak-ops-business/yak-ops-business-data-service/src/main/java/io/yak/ops/business/dataservice/domain/access/DataServiceIpAccessRule.java
@@ -1,0 +1,20 @@
+package io.yak.ops.business.dataservice.domain.access;
+
+import java.time.LocalDateTime;
+
+/** Persisted IP/CIDR access rule owned by one Data Service. */
+public record DataServiceIpAccessRule(
+    Long id,
+    Long apiId,
+    IpAccessRuleType ruleType,
+    String networkCidr,
+    String description,
+    boolean enabled,
+    LocalDateTime expiresAt,
+    LocalDateTime createTime,
+    LocalDateTime updateTime) {
+
+  public boolean active(LocalDateTime now) {
+    return enabled && (expiresAt == null || now == null || expiresAt.isAfter(now));
+  }
+}

--- a/yak-ops-business/yak-ops-business-data-service/src/main/java/io/yak/ops/business/dataservice/domain/access/IpAccessMode.java
+++ b/yak-ops-business/yak-ops-business-data-service/src/main/java/io/yak/ops/business/dataservice/domain/access/IpAccessMode.java
@@ -1,0 +1,12 @@
+package io.yak.ops.business.dataservice.domain.access;
+
+public enum IpAccessMode {
+  NONE,
+  ALLOWLIST,
+  DENYLIST;
+
+  public static IpAccessMode parse(String value) {
+    if (value == null || value.isBlank()) return NONE;
+    return valueOf(value.trim().toUpperCase());
+  }
+}

--- a/yak-ops-business/yak-ops-business-data-service/src/main/java/io/yak/ops/business/dataservice/domain/access/IpAccessRuleType.java
+++ b/yak-ops-business/yak-ops-business-data-service/src/main/java/io/yak/ops/business/dataservice/domain/access/IpAccessRuleType.java
@@ -1,0 +1,13 @@
+package io.yak.ops.business.dataservice.domain.access;
+
+public enum IpAccessRuleType {
+  ALLOWLIST,
+  DENYLIST;
+
+  public static IpAccessRuleType parse(String value) {
+    if (value == null || value.isBlank()) {
+      throw new IllegalArgumentException("IP 访问规则类型不能为空");
+    }
+    return valueOf(value.trim().toUpperCase());
+  }
+}

--- a/yak-ops-business/yak-ops-business-data-service/src/main/java/io/yak/ops/business/dataservice/execution/DataServiceInvoker.java
+++ b/yak-ops-business/yak-ops-business-data-service/src/main/java/io/yak/ops/business/dataservice/execution/DataServiceInvoker.java
@@ -1,6 +1,7 @@
 package io.yak.ops.business.dataservice.execution;
 
 import io.yak.ops.business.dataservice.access.DataServiceAuthorizer;
+import io.yak.ops.business.dataservice.access.DataServiceForbiddenException;
 import io.yak.ops.business.dataservice.access.DataServiceRateLimitException;
 import io.yak.ops.business.dataservice.access.DataServiceUnauthorizedException;
 import io.yak.ops.business.dataservice.domain.DataServiceDefinition;
@@ -42,19 +43,35 @@ public class DataServiceInvoker {
   }
 
   public DataServiceQueryResponse invoke(String servicePath, Map<String, String> parameters, String rawApiKey) {
+    return invoke(servicePath, parameters, rawApiKey, null);
+  }
+
+  public DataServiceQueryResponse invoke(
+      String servicePath,
+      Map<String, String> parameters,
+      String rawApiKey,
+      String clientIp) {
     DataServiceDefinition definition = reader.requireByPath(normalizePath(servicePath));
     ProjectContext projectContext = requireProjectContext(definition);
     return projectContextScope.call(
         projectContext,
-        () -> invokeInProject(definition, parameters, rawApiKey));
+        () -> invokeInProject(definition, parameters, rawApiKey, clientIp));
   }
 
   private DataServiceQueryResponse invokeInProject(
-      DataServiceDefinition definition, Map<String, String> parameters, String rawApiKey) {
-    if (!definition.settings().enabled()) throw new IllegalStateException("数据服务未启用：" + definition.settings().path());
+      DataServiceDefinition definition,
+      Map<String, String> parameters,
+      String rawApiKey,
+      String clientIp) {
+    if (!definition.settings().enabled()) {
+      throw new IllegalStateException("数据服务未启用：" + definition.settings().path());
+    }
     AccessContext access;
     try {
-      access = authorizer.authorize(definition, rawApiKey);
+      access = authorizer.authorize(definition, rawApiKey, clientIp);
+    } catch (DataServiceForbiddenException exception) {
+      audit(definition, parameters, false, 0L, 0, safeMessage(exception), AccessContext.publicAccess());
+      throw exception;
     } catch (DataServiceUnauthorizedException | DataServiceRateLimitException exception) {
       audit(definition, parameters, false, 0L, 0, safeMessage(exception), AccessContext.rejectedApiKey());
       throw exception;
@@ -100,10 +117,7 @@ public class DataServiceInvoker {
     }
   }
 
-  /**
-   * Invocation audit is evidence, not the business result. A logging outage must never turn a
-   * successful query into a failed API call or replace the original invocation exception.
-   */
+  /** Invocation audit is evidence, not the business result. */
   private void audit(
       DataServiceDefinition definition,
       Map<String, String> parameters,
@@ -123,11 +137,7 @@ public class DataServiceInvoker {
     }
   }
 
-  /**
-   * Persisted monotonic generation is the primary cross-node cache namespace. Runtime-affecting
-   * settings/policy are also included so concurrent admin writes that observed the same generation
-   * still cannot reuse one another's cached results.
-   */
+  /** Persisted generation and runtime shape form the node-local cache namespace. */
   String runtimeNamespace(DataServiceDefinition definition) {
     SourceReference source = definition.sourceReference();
     RuntimePolicy policy = definition.runtimePolicy();
@@ -172,14 +182,21 @@ public class DataServiceInvoker {
     if (parameters == null || parameters.isEmpty()) return Map.of();
     if (!paginationEnabled) return parameters;
     Map<String, String> result = new LinkedHashMap<>(parameters);
-    result.remove("pageNum"); result.remove("pageSize"); result.remove("returnTotalNum");
+    result.remove("pageNum");
+    result.remove("pageSize");
+    result.remove("returnTotalNum");
     return result;
   }
 
   private int positiveInt(String raw, int fallback, String name) {
     if (!StringUtils.hasText(raw)) return fallback;
-    try { int value = Integer.parseInt(raw.trim()); if (value <= 0) throw new NumberFormatException(); return value; }
-    catch (NumberFormatException exception) { throw new IllegalArgumentException(name + " 必须是大于 0 的整数"); }
+    try {
+      int value = Integer.parseInt(raw.trim());
+      if (value <= 0) throw new NumberFormatException();
+      return value;
+    } catch (NumberFormatException exception) {
+      throw new IllegalArgumentException(name + " 必须是大于 0 的整数");
+    }
   }
 
   private boolean booleanValue(String raw, boolean fallback, String name) {
@@ -191,14 +208,20 @@ public class DataServiceInvoker {
 
   private String normalizePath(String path) {
     if (!StringUtils.hasText(path)) throw new IllegalArgumentException("服务路径不能为空");
-    String value = path.trim(); if (!value.startsWith("/")) value = "/" + value;
+    String value = path.trim();
+    if (!value.startsWith("/")) value = "/" + value;
     value = value.replaceAll("/{2,}", "/");
     if (value.length() > 1 && value.endsWith("/")) value = value.substring(0, value.length() - 1);
-    if (!value.matches("/[A-Za-z0-9._~/-]+")) throw new IllegalArgumentException("服务路径仅支持字母、数字、-、_、. 和 /：" + value);
+    if (!value.matches("/[A-Za-z0-9._~/-]+")) {
+      throw new IllegalArgumentException("服务路径仅支持字母、数字、-、_、. 和 /：" + value);
+    }
     return value;
   }
 
-  private long elapsedMs(long started) { return Math.max(0L, (System.nanoTime() - started) / 1_000_000L); }
+  private long elapsedMs(long started) {
+    return Math.max(0L, (System.nanoTime() - started) / 1_000_000L);
+  }
+
   private String safeMessage(Throwable throwable) {
     String message = throwable == null ? null : throwable.getMessage();
     return StringUtils.hasText(message) ? message : "数据服务调用失败";

--- a/yak-ops-business/yak-ops-business-data-service/src/main/java/io/yak/ops/business/dataservice/management/DataServiceManager.java
+++ b/yak-ops-business/yak-ops-business-data-service/src/main/java/io/yak/ops/business/dataservice/management/DataServiceManager.java
@@ -1,6 +1,7 @@
 package io.yak.ops.business.dataservice.management;
 
 import io.yak.ops.business.dataservice.access.DataServiceApiKeyManager;
+import io.yak.ops.business.dataservice.access.DataServiceIpAccessManager;
 import io.yak.ops.business.dataservice.domain.DataServiceDefinition;
 import io.yak.ops.business.dataservice.domain.DataServiceSettings;
 import io.yak.ops.business.dataservice.domain.PublishedRuntimeSnapshot;
@@ -24,6 +25,7 @@ public class DataServiceManager {
   private final DataServiceRepository repository;
   private final DataServiceReader reader;
   private final DataServiceApiKeyManager apiKeyManager;
+  private final DataServiceIpAccessManager ipAccessManager;
   private final DataServiceRuntimePolicyManager runtimeManager;
   private final CurrentProject currentProject;
 
@@ -74,6 +76,7 @@ public class DataServiceManager {
   public void delete(Long id) {
     reader.require(id);
     apiKeyManager.deleteKeysForApi(id);
+    ipAccessManager.deleteForApi(id);
     if (!repository.delete(id)) throw new IllegalArgumentException("数据服务不存在：" + id);
     runtimeManager.remove(id);
   }

--- a/yak-ops-business/yak-ops-business-data-service/src/main/java/io/yak/ops/business/dataservice/repository/DataServiceIpAccessRepository.java
+++ b/yak-ops-business/yak-ops-business-data-service/src/main/java/io/yak/ops/business/dataservice/repository/DataServiceIpAccessRepository.java
@@ -1,0 +1,19 @@
+package io.yak.ops.business.dataservice.repository;
+
+import io.yak.ops.business.dataservice.domain.access.DataServiceIpAccessRule;
+import io.yak.ops.business.dataservice.domain.access.IpAccessMode;
+import io.yak.ops.business.dataservice.domain.access.IpAccessRuleType;
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Optional;
+
+public interface DataServiceIpAccessRepository {
+  IpAccessMode findMode(Long apiId);
+  void saveMode(Long apiId, IpAccessMode mode, LocalDateTime updateTime);
+  List<DataServiceIpAccessRule> findRules(Long apiId);
+  Optional<DataServiceIpAccessRule> findRule(Long id);
+  boolean existsRule(Long apiId, IpAccessRuleType ruleType, String networkCidr, Long excludeId);
+  DataServiceIpAccessRule saveRule(DataServiceIpAccessRule rule);
+  boolean deleteRule(Long id);
+  void deleteByApiId(Long apiId);
+}

--- a/yak-ops-business/yak-ops-business-data-service/src/main/java/io/yak/ops/business/dataservice/repository/DataServiceIpAccessRepositoryAdapter.java
+++ b/yak-ops-business/yak-ops-business-data-service/src/main/java/io/yak/ops/business/dataservice/repository/DataServiceIpAccessRepositoryAdapter.java
@@ -1,0 +1,118 @@
+package io.yak.ops.business.dataservice.repository;
+
+import com.baomidou.mybatisplus.core.toolkit.Wrappers;
+import io.yak.ops.business.dataservice.dao.mapper.DataServiceIpAccessPolicyMapper;
+import io.yak.ops.business.dataservice.dao.mapper.DataServiceIpAccessRuleMapper;
+import io.yak.ops.business.dataservice.dao.model.DataServiceIpAccessPolicyPO;
+import io.yak.ops.business.dataservice.dao.model.DataServiceIpAccessRulePO;
+import io.yak.ops.business.dataservice.domain.access.DataServiceIpAccessRule;
+import io.yak.ops.business.dataservice.domain.access.IpAccessMode;
+import io.yak.ops.business.dataservice.domain.access.IpAccessRuleType;
+import io.yak.ops.business.datasource.config.ConditionalOnDataSourceEnabled;
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Optional;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Repository;
+
+@Repository
+@ConditionalOnDataSourceEnabled
+@RequiredArgsConstructor
+public class DataServiceIpAccessRepositoryAdapter implements DataServiceIpAccessRepository {
+  private final DataServiceIpAccessPolicyMapper policyMapper;
+  private final DataServiceIpAccessRuleMapper ruleMapper;
+
+  @Override
+  public IpAccessMode findMode(Long apiId) {
+    DataServiceIpAccessPolicyPO po = apiId == null ? null : policyMapper.selectById(apiId);
+    return po == null ? IpAccessMode.NONE : IpAccessMode.parse(po.getMode());
+  }
+
+  @Override
+  public void saveMode(Long apiId, IpAccessMode mode, LocalDateTime updateTime) {
+    if (apiId == null) throw new IllegalArgumentException("数据服务 API ID 不能为空");
+    DataServiceIpAccessPolicyPO po = policyMapper.selectById(apiId);
+    if (po == null) {
+      po = new DataServiceIpAccessPolicyPO();
+      po.setApiId(apiId);
+      po.setMode((mode == null ? IpAccessMode.NONE : mode).name());
+      po.setUpdateTime(updateTime);
+      policyMapper.insert(po);
+      return;
+    }
+    po.setMode((mode == null ? IpAccessMode.NONE : mode).name());
+    po.setUpdateTime(updateTime);
+    policyMapper.updateById(po);
+  }
+
+  @Override
+  public List<DataServiceIpAccessRule> findRules(Long apiId) {
+    if (apiId == null) return List.of();
+    return ruleMapper.selectList(
+            Wrappers.<DataServiceIpAccessRulePO>lambdaQuery()
+                .eq(DataServiceIpAccessRulePO::getApiId, apiId)
+                .orderByDesc(DataServiceIpAccessRulePO::getCreateTime)
+                .orderByDesc(DataServiceIpAccessRulePO::getId))
+        .stream().map(this::toDomain).toList();
+  }
+
+  @Override
+  public Optional<DataServiceIpAccessRule> findRule(Long id) {
+    return Optional.ofNullable(id == null ? null : ruleMapper.selectById(id)).map(this::toDomain);
+  }
+
+  @Override
+  public boolean existsRule(
+      Long apiId, IpAccessRuleType ruleType, String networkCidr, Long excludeId) {
+    if (apiId == null || ruleType == null || networkCidr == null) return false;
+    Long count = ruleMapper.selectCount(
+        Wrappers.<DataServiceIpAccessRulePO>lambdaQuery()
+            .eq(DataServiceIpAccessRulePO::getApiId, apiId)
+            .eq(DataServiceIpAccessRulePO::getRuleType, ruleType.name())
+            .eq(DataServiceIpAccessRulePO::getNetworkCidr, networkCidr)
+            .ne(excludeId != null, DataServiceIpAccessRulePO::getId, excludeId));
+    return count != null && count > 0L;
+  }
+
+  @Override
+  public DataServiceIpAccessRule saveRule(DataServiceIpAccessRule rule) {
+    DataServiceIpAccessRulePO po = toPo(rule);
+    if (rule.id() == null) ruleMapper.insert(po); else ruleMapper.updateById(po);
+    return toDomain(po);
+  }
+
+  @Override
+  public boolean deleteRule(Long id) {
+    return id != null && ruleMapper.deleteById(id) > 0;
+  }
+
+  @Override
+  public void deleteByApiId(Long apiId) {
+    if (apiId == null) return;
+    ruleMapper.delete(
+        Wrappers.<DataServiceIpAccessRulePO>lambdaQuery()
+            .eq(DataServiceIpAccessRulePO::getApiId, apiId));
+    policyMapper.deleteById(apiId);
+  }
+
+  private DataServiceIpAccessRule toDomain(DataServiceIpAccessRulePO po) {
+    return new DataServiceIpAccessRule(
+        po.getId(), po.getApiId(), IpAccessRuleType.parse(po.getRuleType()), po.getNetworkCidr(),
+        po.getDescription(), Boolean.TRUE.equals(po.getEnabled()), po.getExpiresAt(),
+        po.getCreateTime(), po.getUpdateTime());
+  }
+
+  private DataServiceIpAccessRulePO toPo(DataServiceIpAccessRule rule) {
+    DataServiceIpAccessRulePO po = new DataServiceIpAccessRulePO();
+    po.setId(rule.id());
+    po.setApiId(rule.apiId());
+    po.setRuleType(rule.ruleType().name());
+    po.setNetworkCidr(rule.networkCidr());
+    po.setDescription(rule.description());
+    po.setEnabled(rule.enabled());
+    po.setExpiresAt(rule.expiresAt());
+    po.setCreateTime(rule.createTime());
+    po.setUpdateTime(rule.updateTime());
+    return po;
+  }
+}

--- a/yak-ops-business/yak-ops-business-data-service/src/main/resources/db/migration/yak-data-service/V2__ip_access_policy.sql
+++ b/yak-ops-business/yak-ops-business-data-service/src/main/resources/db/migration/yak-data-service/V2__ip_access_policy.sql
@@ -1,0 +1,31 @@
+-- Data Service IP/CIDR allowlist and denylist policy.
+
+CREATE TABLE IF NOT EXISTS yak_ops_data_service_ip_access_policy (
+    api_id BIGINT UNSIGNED NOT NULL COMMENT 'Data Service API ID',
+    mode VARCHAR(16) NOT NULL DEFAULT 'NONE' COMMENT 'NONE/ALLOWLIST/DENYLIST',
+    update_time DATETIME(3) NOT NULL DEFAULT CURRENT_TIMESTAMP(3)
+        ON UPDATE CURRENT_TIMESTAMP(3) COMMENT '更新时间',
+    PRIMARY KEY (api_id)
+) ENGINE=InnoDB
+  DEFAULT CHARSET=utf8mb4
+  COLLATE=utf8mb4_unicode_ci
+  COMMENT='Yak Ops Data Service IP access policy';
+
+CREATE TABLE IF NOT EXISTS yak_ops_data_service_ip_access_rule (
+    id BIGINT UNSIGNED NOT NULL AUTO_INCREMENT COMMENT '主键',
+    api_id BIGINT UNSIGNED NOT NULL COMMENT 'Data Service API ID',
+    rule_type VARCHAR(16) NOT NULL COMMENT 'ALLOWLIST/DENYLIST',
+    network_cidr VARCHAR(80) NOT NULL COMMENT '规范化 IP 或 CIDR',
+    description VARCHAR(255) DEFAULT NULL COMMENT '规则说明',
+    enabled TINYINT(1) NOT NULL DEFAULT 1 COMMENT '是否启用',
+    expires_at DATETIME(3) DEFAULT NULL COMMENT '过期时间，NULL 表示永久',
+    create_time DATETIME(3) NOT NULL DEFAULT CURRENT_TIMESTAMP(3) COMMENT '创建时间',
+    update_time DATETIME(3) NOT NULL DEFAULT CURRENT_TIMESTAMP(3)
+        ON UPDATE CURRENT_TIMESTAMP(3) COMMENT '更新时间',
+    PRIMARY KEY (id),
+    UNIQUE KEY uk_yak_ops_data_service_ip_rule (api_id, rule_type, network_cidr),
+    KEY idx_yak_ops_data_service_ip_rule_active (api_id, rule_type, enabled, expires_at)
+) ENGINE=InnoDB
+  DEFAULT CHARSET=utf8mb4
+  COLLATE=utf8mb4_unicode_ci
+  COMMENT='Yak Ops Data Service IP allowlist/denylist rules';

--- a/yak-ops-business/yak-ops-business-data-service/src/test/java/io/yak/ops/business/dataservice/access/DataServiceAuthorizerTest.java
+++ b/yak-ops-business/yak-ops-business-data-service/src/test/java/io/yak/ops/business/dataservice/access/DataServiceAuthorizerTest.java
@@ -1,0 +1,39 @@
+package io.yak.ops.business.dataservice.access;
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.when;
+
+import io.yak.ops.business.dataservice.domain.DataServiceDefinition;
+import io.yak.ops.business.dataservice.repository.DataServiceApiKeyRepository;
+import org.junit.jupiter.api.Test;
+
+class DataServiceAuthorizerTest {
+
+  @Test
+  void ipPolicyRejectsBeforeApiKeyLookupOrRateLimit() {
+    DataServiceApiKeyRepository repository = mock(DataServiceApiKeyRepository.class);
+    ApiKeySecretGenerator secrets = mock(ApiKeySecretGenerator.class);
+    DataServiceRateLimiter rateLimiter = mock(DataServiceRateLimiter.class);
+    DataServiceIpAccessAuthorizer ipAccessAuthorizer = mock(DataServiceIpAccessAuthorizer.class);
+    DataServiceDefinition definition = mock(DataServiceDefinition.class);
+    when(definition.id()).thenReturn(7L);
+    DataServiceForbiddenException forbidden =
+        new DataServiceForbiddenException("blocked by network policy");
+    org.mockito.Mockito.doThrow(forbidden)
+        .when(ipAccessAuthorizer)
+        .authorize(7L, "203.0.113.9");
+
+    DataServiceAuthorizer authorizer = new DataServiceAuthorizer(
+        repository, secrets, rateLimiter, ipAccessAuthorizer);
+
+    assertThatThrownBy(
+        () -> authorizer.authorize(definition, "yak-key", "203.0.113.9"))
+        .isSameAs(forbidden);
+
+    verify(ipAccessAuthorizer).authorize(7L, "203.0.113.9");
+    verifyNoInteractions(repository, secrets, rateLimiter);
+  }
+}

--- a/yak-ops-business/yak-ops-business-data-service/src/test/java/io/yak/ops/business/dataservice/access/DataServiceClientIpResolverTest.java
+++ b/yak-ops-business/yak-ops-business-data-service/src/test/java/io/yak/ops/business/dataservice/access/DataServiceClientIpResolverTest.java
@@ -1,0 +1,63 @@
+package io.yak.ops.business.dataservice.access;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import jakarta.servlet.http.HttpServletRequest;
+import org.junit.jupiter.api.Test;
+
+class DataServiceClientIpResolverTest {
+
+  @Test
+  void forwardingHeadersAreIgnoredWhenDirectPeerIsNotTrusted() {
+    DataServiceClientIpResolver resolver = new DataServiceClientIpResolver("");
+    HttpServletRequest request = request(
+        "10.0.0.10", "203.0.113.7", "198.51.100.8");
+
+    assertThat(resolver.resolve(request)).isEqualTo("10.0.0.10");
+  }
+
+  @Test
+  void trustedProxyChainResolvesFirstUntrustedHopFromTheRight() {
+    DataServiceClientIpResolver resolver = new DataServiceClientIpResolver("10.0.0.0/8");
+    HttpServletRequest request = request(
+        "10.0.0.10", "198.51.100.7, 10.0.0.9", null);
+
+    assertThat(resolver.resolve(request)).isEqualTo("198.51.100.7");
+  }
+
+  @Test
+  void prependedSpoofedForwardedAddressCannotOverrideExternalClient() {
+    DataServiceClientIpResolver resolver = new DataServiceClientIpResolver("10.0.0.0/8");
+    HttpServletRequest request = request(
+        "10.0.0.10", "1.1.1.1, 198.51.100.7, 10.0.0.9", null);
+
+    assertThat(resolver.resolve(request)).isEqualTo("198.51.100.7");
+  }
+
+  @Test
+  void malformedForwardedChainFallsBackToDirectTrustedPeer() {
+    DataServiceClientIpResolver resolver = new DataServiceClientIpResolver("10.0.0.0/8");
+    HttpServletRequest request = request(
+        "10.0.0.10", "not-an-ip", "198.51.100.8");
+
+    assertThat(resolver.resolve(request)).isEqualTo("10.0.0.10");
+  }
+
+  @Test
+  void realIpIsUsedOnlyBehindTrustedPeerWhenForwardedForIsAbsent() {
+    DataServiceClientIpResolver resolver = new DataServiceClientIpResolver("10.0.0.0/8");
+    HttpServletRequest request = request("10.0.0.10", null, "198.51.100.8");
+
+    assertThat(resolver.resolve(request)).isEqualTo("198.51.100.8");
+  }
+
+  private HttpServletRequest request(String remote, String forwardedFor, String realIp) {
+    HttpServletRequest request = mock(HttpServletRequest.class);
+    when(request.getRemoteAddr()).thenReturn(remote);
+    when(request.getHeader("X-Forwarded-For")).thenReturn(forwardedFor);
+    when(request.getHeader("X-Real-IP")).thenReturn(realIp);
+    return request;
+  }
+}

--- a/yak-ops-business/yak-ops-business-data-service/src/test/java/io/yak/ops/business/dataservice/access/DataServiceIpAccessAuthorizerTest.java
+++ b/yak-ops-business/yak-ops-business-data-service/src/test/java/io/yak/ops/business/dataservice/access/DataServiceIpAccessAuthorizerTest.java
@@ -1,0 +1,83 @@
+package io.yak.ops.business.dataservice.access;
+
+import static org.assertj.core.api.Assertions.assertThatCode;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import io.yak.ops.business.dataservice.domain.access.DataServiceIpAccessRule;
+import io.yak.ops.business.dataservice.domain.access.IpAccessMode;
+import io.yak.ops.business.dataservice.domain.access.IpAccessRuleType;
+import io.yak.ops.business.dataservice.repository.DataServiceIpAccessRepository;
+import java.time.LocalDateTime;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+
+class DataServiceIpAccessAuthorizerTest {
+
+  private final DataServiceIpAccessRepository repository = mock(DataServiceIpAccessRepository.class);
+  private final DataServiceIpAccessAuthorizer authorizer = new DataServiceIpAccessAuthorizer(repository);
+
+  @Test
+  void noneModeDoesNotRequireClientIp() {
+    when(repository.findMode(7L)).thenReturn(IpAccessMode.NONE);
+
+    assertThatCode(() -> authorizer.authorize(7L, null)).doesNotThrowAnyException();
+  }
+
+  @Test
+  void allowlistOnlyAdmitsMatchingActiveNetwork() {
+    when(repository.findMode(7L)).thenReturn(IpAccessMode.ALLOWLIST);
+    when(repository.findRules(7L)).thenReturn(List.of(rule(
+        IpAccessRuleType.ALLOWLIST, "10.20.0.0/16", true, null)));
+
+    assertThatCode(() -> authorizer.authorize(7L, "10.20.8.9")).doesNotThrowAnyException();
+    assertThatThrownBy(() -> authorizer.authorize(7L, "10.21.8.9"))
+        .isInstanceOf(DataServiceForbiddenException.class)
+        .hasMessageContaining("白名单");
+  }
+
+  @Test
+  void activeAllowlistFailsClosedWhenClientIpCannotBeResolved() {
+    when(repository.findMode(7L)).thenReturn(IpAccessMode.ALLOWLIST);
+    when(repository.findRules(7L)).thenReturn(List.of());
+
+    assertThatThrownBy(() -> authorizer.authorize(7L, null))
+        .isInstanceOf(DataServiceForbiddenException.class)
+        .hasMessageContaining("无法确认");
+  }
+
+  @Test
+  void denylistRejectsMatchButIgnoresExpiredRule() {
+    when(repository.findMode(7L)).thenReturn(IpAccessMode.DENYLIST);
+    when(repository.findRules(7L)).thenReturn(List.of(
+        rule(IpAccessRuleType.DENYLIST, "203.0.113.0/24", true, null),
+        rule(
+            IpAccessRuleType.DENYLIST,
+            "198.51.100.0/24",
+            true,
+            LocalDateTime.of(2000, 1, 1, 0, 0))));
+
+    assertThatThrownBy(() -> authorizer.authorize(7L, "203.0.113.9"))
+        .isInstanceOf(DataServiceForbiddenException.class);
+    assertThatCode(() -> authorizer.authorize(7L, "198.51.100.9"))
+        .doesNotThrowAnyException();
+  }
+
+  private DataServiceIpAccessRule rule(
+      IpAccessRuleType type,
+      String network,
+      boolean enabled,
+      LocalDateTime expiresAt) {
+    return new DataServiceIpAccessRule(
+        1L,
+        7L,
+        type,
+        network,
+        null,
+        enabled,
+        expiresAt,
+        LocalDateTime.of(2026, 1, 1, 0, 0),
+        LocalDateTime.of(2026, 1, 1, 0, 0));
+  }
+}

--- a/yak-ops-business/yak-ops-business-data-service/src/test/java/io/yak/ops/business/dataservice/access/IpNetworkTest.java
+++ b/yak-ops-business/yak-ops-business-data-service/src/test/java/io/yak/ops/business/dataservice/access/IpNetworkTest.java
@@ -1,0 +1,38 @@
+package io.yak.ops.business.dataservice.access;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import org.junit.jupiter.api.Test;
+
+class IpNetworkTest {
+
+  @Test
+  void normalizesIpv4HostBitsAndMatchesCidr() {
+    assertThat(IpNetwork.normalizeNetwork("10.20.30.40/24"))
+        .isEqualTo("10.20.30.0/24");
+    assertThat(IpNetwork.contains("10.20.0.0/16", "10.20.99.8")).isTrue();
+    assertThat(IpNetwork.contains("10.20.0.0/16", "10.21.0.1")).isFalse();
+  }
+
+  @Test
+  void exactAddressActsAsHostNetwork() {
+    assertThat(IpNetwork.normalizeNetwork("203.0.113.7")).isEqualTo("203.0.113.7");
+    assertThat(IpNetwork.contains("203.0.113.7", "203.0.113.7")).isTrue();
+    assertThat(IpNetwork.contains("203.0.113.7", "203.0.113.8")).isFalse();
+  }
+
+  @Test
+  void supportsIpv6Networks() {
+    assertThat(IpNetwork.contains("2001:db8::/32", "2001:db8:1234::1")).isTrue();
+    assertThat(IpNetwork.contains("2001:db8::/32", "2001:db9::1")).isFalse();
+  }
+
+  @Test
+  void rejectsHostnamesAndInvalidPrefix() {
+    assertThatThrownBy(() -> IpNetwork.normalizeNetwork("example.com"))
+        .isInstanceOf(IllegalArgumentException.class);
+    assertThatThrownBy(() -> IpNetwork.normalizeNetwork("10.0.0.1/33"))
+        .isInstanceOf(IllegalArgumentException.class);
+  }
+}

--- a/yak-ops-business/yak-ops-business-data-service/src/test/java/io/yak/ops/business/dataservice/architecture/DataServiceFlywayContractTest.java
+++ b/yak-ops-business/yak-ops-business-data-service/src/test/java/io/yak/ops/business/dataservice/architecture/DataServiceFlywayContractTest.java
@@ -22,11 +22,11 @@ class DataServiceFlywayContractTest {
   }
 
   @Test
-  void dedicatedNamespaceContainsBaselineAndProjectContract() throws IOException {
+  void dedicatedNamespaceContainsBaselineAndIpAccessPolicy() throws IOException {
     assertThat(sqlFiles(dedicatedMigrationRoot()))
         .containsExactly(
             "V1__baseline_data_service.sql",
-            "V2__contract_project_scope.sql");
+            "V2__ip_access_policy.sql");
 
     String baseline = Files.readString(
         dedicatedMigrationRoot().resolve("V1__baseline_data_service.sql"));
@@ -41,13 +41,14 @@ class DataServiceFlywayContractTest {
         .contains("runtime_generation")
         .doesNotContain("ALTER TABLE");
 
-    String contract = Files.readString(
-        dedicatedMigrationRoot().resolve("V2__contract_project_scope.sql"));
-    assertThat(contract)
-        .contains("ALTER TABLE yak_ops_data_service_api")
-        .contains("ALTER TABLE yak_ops_data_service_call_log")
-        .contains("project_id BIGINT UNSIGNED NOT NULL")
-        .doesNotContain("UPDATE yak_ops_data_service");
+    String accessPolicy = Files.readString(
+        dedicatedMigrationRoot().resolve("V2__ip_access_policy.sql"));
+    assertThat(accessPolicy)
+        .contains("CREATE TABLE IF NOT EXISTS yak_ops_data_service_ip_access_policy")
+        .contains("CREATE TABLE IF NOT EXISTS yak_ops_data_service_ip_access_rule")
+        .contains("ALLOWLIST")
+        .contains("DENYLIST")
+        .doesNotContain("ALTER TABLE yak_ops_data_service_api");
   }
 
   @Test

--- a/yak-ops-business/yak-ops-business-data-service/src/test/java/io/yak/ops/business/dataservice/execution/DataServiceInvokerTest.java
+++ b/yak-ops-business/yak-ops-business-data-service/src/test/java/io/yak/ops/business/dataservice/execution/DataServiceInvokerTest.java
@@ -63,7 +63,7 @@ class DataServiceInvokerTest {
         projectContextScope);
     definition = definition();
     when(reader.requireByPath("/orders")).thenReturn(definition);
-    when(authorizer.authorize(definition, null)).thenReturn(AccessContext.publicAccess());
+    when(authorizer.authorize(definition, null, null)).thenReturn(AccessContext.publicAccess());
   }
 
   @Test
@@ -75,6 +75,19 @@ class DataServiceInvokerTest {
     invoker.invoke("orders", Map.of("id", "1"), null);
 
     verify(projectContextScope).call(eq(new ProjectContext(3L, null)), any());
+  }
+
+  @Test
+  void publicInvocationPassesResolvedClientIpIntoAccessAuthorization() {
+    DataServiceQueryResponse response = new DataServiceQueryResponse(
+        List.of("id"), List.of(Map.of("id", 1L)), false, 1, 8L);
+    when(authorizer.authorize(definition, null, "203.0.113.8"))
+        .thenReturn(AccessContext.publicAccess());
+    when(executor.execute(eq(definition), any(), isNull())).thenReturn(response);
+
+    invoker.invoke("orders", Map.of("id", "1"), null, "203.0.113.8");
+
+    verify(authorizer).authorize(definition, null, "203.0.113.8");
   }
 
   @Test
@@ -112,7 +125,7 @@ class DataServiceInvokerTest {
   void authorizationFailureKeepsItsOriginalHttpSemanticWhenAuditFails() {
     DataServiceUnauthorizedException unauthorized =
         new DataServiceUnauthorizedException("invalid api key");
-    when(authorizer.authorize(definition, "bad-key")).thenThrow(unauthorized);
+    when(authorizer.authorize(definition, "bad-key", null)).thenThrow(unauthorized);
     doThrow(new IllegalStateException("audit db down"))
         .when(recorder)
         .record(eq(definition), any(), eq(false), eq(0L), eq(0), eq("invalid api key"), any());

--- a/yak-ops-ui/src/pages/data-service/components/DataServiceAccessControlPanel.tsx
+++ b/yak-ops-ui/src/pages/data-service/components/DataServiceAccessControlPanel.tsx
@@ -1,0 +1,428 @@
+import { YakButton, YakEmpty, YakTab } from '@/components/ui';
+import {
+  createDataServiceIpAccessRule,
+  deleteDataServiceIpAccessRule,
+  getDataServiceIpAccess,
+  setDataServiceIpAccessMode,
+  updateDataServiceIpAccessRule,
+  type DataServiceIpAccessMode,
+  type DataServiceIpAccessRule,
+  type DataServiceIpAccessRuleType,
+} from '@/services/data-service';
+import { DatePicker, Form, Input, Modal, Spin, Switch, message } from 'antd';
+import dayjs, { type Dayjs } from 'dayjs';
+import { Pencil, Plus, Shield, Trash2 } from 'lucide-react';
+import { useCallback, useEffect, useMemo, useState } from 'react';
+
+interface DataServiceAccessControlPanelProps {
+  apiId: number;
+}
+
+interface RuleFormValues {
+  networkCidr: string;
+  description?: string;
+  expiresAt?: Dayjs | null;
+  enabled: boolean;
+}
+
+const MODE_OPTIONS: Array<{
+  key: DataServiceIpAccessMode;
+  title: string;
+  description: string;
+}> = [
+  { key: 'NONE', title: '不限制', description: '不按来源 IP 限制调用' },
+  { key: 'ALLOWLIST', title: '白名单', description: '仅允许白名单中的 IP/CIDR' },
+  { key: 'DENYLIST', title: '黑名单', description: '拒绝黑名单中的 IP/CIDR' },
+];
+
+const formatTime = (value?: string | null) =>
+  value ? value.replace('T', ' ').slice(0, 19) : '永久';
+
+const isExpired = (rule: DataServiceIpAccessRule) =>
+  Boolean(rule.expiresAt && dayjs(rule.expiresAt).isBefore(dayjs()));
+
+const ruleStatus = (rule: DataServiceIpAccessRule) => {
+  if (!rule.enabled) return '已停用';
+  if (isExpired(rule)) return '已过期';
+  return '生效中';
+};
+
+export default function DataServiceAccessControlPanel({
+  apiId,
+}: DataServiceAccessControlPanelProps) {
+  const [form] = Form.useForm<RuleFormValues>();
+  const [loading, setLoading] = useState(true);
+  const [mode, setMode] = useState<DataServiceIpAccessMode>('NONE');
+  const [rules, setRules] = useState<DataServiceIpAccessRule[]>([]);
+  const [activeList, setActiveList] = useState<DataServiceIpAccessRuleType>('ALLOWLIST');
+  const [modeSaving, setModeSaving] = useState(false);
+  const [ruleModalOpen, setRuleModalOpen] = useState(false);
+  const [editingRule, setEditingRule] = useState<DataServiceIpAccessRule>();
+  const [ruleSaving, setRuleSaving] = useState(false);
+  const [busyRuleId, setBusyRuleId] = useState<number>();
+
+  const load = useCallback(async () => {
+    setLoading(true);
+    try {
+      const policy = await getDataServiceIpAccess(apiId);
+      setMode(policy.mode);
+      setRules(policy.rules || []);
+      if (policy.mode !== 'NONE') setActiveList(policy.mode);
+    } catch (error: any) {
+      message.error(error?.message || '加载访问控制策略失败');
+    } finally {
+      setLoading(false);
+    }
+  }, [apiId]);
+
+  useEffect(() => {
+    void load();
+  }, [load]);
+
+  const visibleRules = useMemo(
+    () => rules.filter((item) => item.ruleType === activeList),
+    [activeList, rules],
+  );
+
+  const activeAllowRules = useMemo(
+    () => rules.filter(
+      (item) => item.ruleType === 'ALLOWLIST' && item.enabled && !isExpired(item),
+    ).length,
+    [rules],
+  );
+
+  const saveMode = async (nextMode: DataServiceIpAccessMode) => {
+    if (nextMode === mode || modeSaving) return;
+    setModeSaving(true);
+    try {
+      const policy = await setDataServiceIpAccessMode(apiId, nextMode);
+      setMode(policy.mode);
+      setRules(policy.rules || []);
+      if (nextMode !== 'NONE') setActiveList(nextMode);
+      message.success('来源访问策略已更新');
+    } catch (error: any) {
+      message.error(error?.message || '更新来源访问策略失败');
+    } finally {
+      setModeSaving(false);
+    }
+  };
+
+  const handleModeChange = (nextMode: DataServiceIpAccessMode) => {
+    if (nextMode === 'ALLOWLIST' && activeAllowRules === 0) {
+      Modal.confirm({
+        title: '启用空白名单？',
+        content: '当前没有生效中的白名单规则。启用后，所有外部来源都会被拒绝，直到添加可用规则。',
+        okText: '仍然启用',
+        cancelText: '取消',
+        onOk: () => saveMode(nextMode),
+      });
+      return;
+    }
+    void saveMode(nextMode);
+  };
+
+  const openCreate = () => {
+    setEditingRule(undefined);
+    form.resetFields();
+    form.setFieldsValue({ enabled: true });
+    setRuleModalOpen(true);
+  };
+
+  const openEdit = (rule: DataServiceIpAccessRule) => {
+    setEditingRule(rule);
+    setActiveList(rule.ruleType);
+    form.setFieldsValue({
+      networkCidr: rule.networkCidr,
+      description: rule.description || undefined,
+      expiresAt: rule.expiresAt ? dayjs(rule.expiresAt) : null,
+      enabled: rule.enabled,
+    });
+    setRuleModalOpen(true);
+  };
+
+  const closeModal = () => {
+    if (ruleSaving) return;
+    setRuleModalOpen(false);
+    setEditingRule(undefined);
+    form.resetFields();
+  };
+
+  const submitRule = async (values: RuleFormValues) => {
+    setRuleSaving(true);
+    try {
+      const payload = {
+        ruleType: editingRule?.ruleType || activeList,
+        networkCidr: values.networkCidr.trim(),
+        description: values.description?.trim() || null,
+        enabled: values.enabled,
+        expiresAt: values.expiresAt
+          ? values.expiresAt.format('YYYY-MM-DDTHH:mm:ss')
+          : null,
+      };
+      if (editingRule) {
+        const updated = await updateDataServiceIpAccessRule(
+          apiId,
+          editingRule.id,
+          payload,
+        );
+        setRules((current) =>
+          current.map((item) => (item.id === updated.id ? updated : item)),
+        );
+        message.success('访问规则已更新');
+      } else {
+        const created = await createDataServiceIpAccessRule(apiId, payload);
+        setRules((current) => [created, ...current]);
+        message.success('访问规则已添加');
+      }
+      closeModal();
+    } catch (error: any) {
+      message.error(error?.message || '保存访问规则失败');
+    } finally {
+      setRuleSaving(false);
+    }
+  };
+
+  const toggleRule = async (rule: DataServiceIpAccessRule, enabled: boolean) => {
+    setBusyRuleId(rule.id);
+    try {
+      const updated = await updateDataServiceIpAccessRule(apiId, rule.id, {
+        ruleType: rule.ruleType,
+        networkCidr: rule.networkCidr,
+        description: rule.description || null,
+        enabled,
+        expiresAt: rule.expiresAt || null,
+      });
+      setRules((current) =>
+        current.map((item) => (item.id === updated.id ? updated : item)),
+      );
+      message.success(enabled ? '规则已启用' : '规则已停用');
+    } catch (error: any) {
+      message.error(error?.message || '更新规则状态失败');
+    } finally {
+      setBusyRuleId(undefined);
+    }
+  };
+
+  const removeRule = (rule: DataServiceIpAccessRule) => {
+    Modal.confirm({
+      title: '删除访问规则',
+      content: `确认删除 ${rule.networkCidr}？`,
+      okText: '删除',
+      okButtonProps: { danger: true },
+      cancelText: '取消',
+      onOk: async () => {
+        setBusyRuleId(rule.id);
+        try {
+          await deleteDataServiceIpAccessRule(apiId, rule.id);
+          setRules((current) => current.filter((item) => item.id !== rule.id));
+          message.success('访问规则已删除');
+        } catch (error: any) {
+          message.error(error?.message || '删除访问规则失败');
+        } finally {
+          setBusyRuleId(undefined);
+        }
+      },
+    });
+  };
+
+  if (loading) {
+    return (
+      <div className="flex min-h-[360px] items-center justify-center rounded-lg bg-white">
+        <Spin />
+      </div>
+    );
+  }
+
+  return (
+    <div className="space-y-3">
+      <section className="rounded-lg bg-white p-5">
+        <div className="flex items-start gap-3">
+          <div className="flex h-9 w-9 shrink-0 items-center justify-center rounded-md bg-[#f5f6f8] text-[#475467]">
+            <Shield size={17} />
+          </div>
+          <div className="min-w-0 flex-1">
+            <div className="text-[15px] font-semibold text-[#161823]">来源访问策略</div>
+            <div className="mt-1 text-[11px] leading-5 text-[#8a8f98]">
+              在 API Key 鉴权和限流之前按客户端 IP/CIDR 拦截请求。
+            </div>
+          </div>
+        </div>
+
+        <div className="mt-5 grid gap-2 md:grid-cols-3">
+          {MODE_OPTIONS.map((item) => (
+            <button
+              key={item.key}
+              type="button"
+              disabled={modeSaving}
+              onClick={() => handleModeChange(item.key)}
+              className={[
+                'rounded-lg border border-solid px-4 py-3 text-left transition-colors',
+                mode === item.key
+                  ? 'border-[#161823] bg-[#f7f7f8]'
+                  : 'border-[#eceef1] bg-white hover:bg-[#fafafa]',
+              ].join(' ')}
+            >
+              <div className="flex items-center gap-2 text-[13px] font-medium text-[#161823]">
+                <span
+                  className={[
+                    'h-2 w-2 rounded-full',
+                    mode === item.key ? 'bg-[#161823]' : 'bg-[#d0d5dd]',
+                  ].join(' ')}
+                />
+                {item.title}
+              </div>
+              <div className="mt-1.5 text-[11px] leading-5 text-[#8a8f98]">
+                {item.description}
+              </div>
+            </button>
+          ))}
+        </div>
+      </section>
+
+      <section className="rounded-lg bg-white">
+        <div className="flex items-center justify-between gap-4 px-5 pt-4">
+          <div>
+            <div className="text-[15px] font-semibold text-[#161823]">黑白名单</div>
+            <div className="mt-1 text-[11px] text-[#8a8f98]">
+              支持单 IP 与 IPv4/IPv6 CIDR；规则可单独停用或设置有效期。
+            </div>
+          </div>
+          <YakButton icon={<Plus size={14} />} onClick={openCreate}>
+            添加规则
+          </YakButton>
+        </div>
+
+        <div className="px-5">
+          <YakTab
+            activeKey={activeList}
+            onChange={(key) => setActiveList(key as DataServiceIpAccessRuleType)}
+            items={[
+              {
+                key: 'ALLOWLIST',
+                label: `白名单 ${rules.filter((item) => item.ruleType === 'ALLOWLIST').length}`,
+              },
+              {
+                key: 'DENYLIST',
+                label: `黑名单 ${rules.filter((item) => item.ruleType === 'DENYLIST').length}`,
+              },
+            ]}
+          />
+        </div>
+
+        <div className="px-5 pb-5">
+          {visibleRules.length ? (
+            <div className="overflow-hidden rounded-lg border border-solid border-[#eceef1]">
+              {visibleRules.map((rule, index) => (
+                <div
+                  key={rule.id}
+                  className={[
+                    'grid gap-3 px-4 py-3 md:grid-cols-[minmax(180px,1fr)_minmax(180px,1.2fr)_140px_100px_116px] md:items-center',
+                    index ? 'border-t border-solid border-[#eceef1]' : '',
+                  ].join(' ')}
+                >
+                  <div className="min-w-0">
+                    <div className="truncate font-mono text-[12px] font-medium text-[#161823]">
+                      {rule.networkCidr}
+                    </div>
+                    <div className="mt-1 text-[10px] text-[#98a2b3]">{ruleStatus(rule)}</div>
+                  </div>
+                  <div className="truncate text-[12px] text-[#667085]">
+                    {rule.description || '—'}
+                  </div>
+                  <div className="text-[11px] text-[#667085]">
+                    {formatTime(rule.expiresAt)}
+                  </div>
+                  <Switch
+                    size="small"
+                    checked={rule.enabled}
+                    loading={busyRuleId === rule.id}
+                    onChange={(checked) => void toggleRule(rule, checked)}
+                  />
+                  <div className="flex justify-end gap-1">
+                    <YakButton
+                      type="text"
+                      iconOnly
+                      icon={<Pencil size={14} />}
+                      onClick={() => openEdit(rule)}
+                    />
+                    <YakButton
+                      type="text"
+                      danger
+                      iconOnly
+                      loading={busyRuleId === rule.id}
+                      icon={<Trash2 size={14} />}
+                      onClick={() => removeRule(rule)}
+                    />
+                  </div>
+                </div>
+              ))}
+            </div>
+          ) : (
+            <YakEmpty
+              compact
+              title={activeList === 'ALLOWLIST' ? '暂无白名单规则' : '暂无黑名单规则'}
+              description="添加 IP 或 CIDR 后，可通过上方来源访问策略启用对应名单。"
+            />
+          )}
+        </div>
+      </section>
+
+      <section className="rounded-lg bg-white px-5 py-4">
+        <div className="text-[12px] font-medium text-[#344054]">反向代理与真实 IP</div>
+        <div className="mt-1 text-[11px] leading-5 text-[#8a8f98]">
+          默认不信任 X-Forwarded-For / X-Real-IP。只有直接上游命中
+          <code className="mx-1 rounded bg-[#f5f6f8] px-1.5 py-0.5 text-[10px] text-[#475467]">
+            yak.data-service.access.trusted-proxies
+          </code>
+          配置后，才会从可信代理链解析真实客户端 IP；否则始终以 TCP 对端地址为准。
+        </div>
+      </section>
+
+      <Modal
+        title={editingRule ? '编辑访问规则' : `添加${activeList === 'ALLOWLIST' ? '白名单' : '黑名单'}规则`}
+        open={ruleModalOpen}
+        onCancel={closeModal}
+        onOk={() => form.submit()}
+        confirmLoading={ruleSaving}
+        okText={editingRule ? '保存' : '添加'}
+        cancelText="取消"
+        destroyOnClose
+      >
+        <Form<RuleFormValues>
+          form={form}
+          layout="vertical"
+          onFinish={(values) => void submitRule(values)}
+          initialValues={{ enabled: true }}
+          className="pt-2"
+        >
+          <Form.Item
+            name="networkCidr"
+            label="IP / CIDR"
+            rules={[{ required: true, message: '请输入 IP 或 CIDR' }]}
+          >
+            <Input
+              variant="filled"
+              placeholder="例如 10.20.30.40 或 10.20.0.0/16"
+              autoComplete="off"
+            />
+          </Form.Item>
+          <Form.Item name="description" label="说明">
+            <Input variant="filled" maxLength={255} placeholder="例如：生产应用出口 IP" />
+          </Form.Item>
+          <Form.Item name="expiresAt" label="有效期">
+            <DatePicker
+              variant="filled"
+              showTime
+              className="w-full"
+              placeholder="不设置表示永久"
+              disabledDate={(date) => date.endOf('day').isBefore(dayjs())}
+            />
+          </Form.Item>
+          <Form.Item name="enabled" label="状态" valuePropName="checked">
+            <Switch checkedChildren="启用" unCheckedChildren="停用" />
+          </Form.Item>
+        </Form>
+      </Modal>
+    </div>
+  );
+}

--- a/yak-ops-ui/src/pages/data-service/detail/index.tsx
+++ b/yak-ops-ui/src/pages/data-service/detail/index.tsx
@@ -28,9 +28,10 @@ import {
 import { ArrowLeft, PlayCircle } from 'lucide-react';
 import { useCallback, useEffect, useMemo, useState, type ReactNode } from 'react';
 
+import DataServiceAccessControlPanel from '../components/DataServiceAccessControlPanel';
 import DataServiceApiCallPanel from '../components/DataServiceApiCallPanel';
 
-type DetailTabKey = 'overview' | 'access' | 'runtime' | 'logs';
+type DetailTabKey = 'overview' | 'access' | 'network' | 'runtime' | 'logs';
 
 const formatTime = (value?: string | null) =>
   value ? value.replace('T', ' ').slice(0, 19) : '-';
@@ -322,6 +323,10 @@ export default function DataServiceDetailPage() {
     />
   );
 
+  const networkAccessContent = (
+    <DataServiceAccessControlPanel apiId={service.id} />
+  );
+
   const runtimeContent = (
     <div className="grid gap-3 xl:grid-cols-2">
       <SectionCard title="运行指标">
@@ -385,6 +390,9 @@ export default function DataServiceDetailPage() {
   }> = [
     { key: 'overview', label: '总览', children: overviewContent },
     { key: 'access', label: 'API 调用', children: accessContent },
+    ...(canManageAccess
+      ? [{ key: 'network' as const, label: '访问控制', children: networkAccessContent }]
+      : []),
     ...(canRuntime ? [{ key: 'runtime' as const, label: 'Runtime', children: runtimeContent }] : []),
     ...(canObserve ? [{ key: 'logs' as const, label: '调用记录', children: logsContent }] : []),
   ];

--- a/yak-ops-ui/src/services/data-service/api.ts
+++ b/yak-ops-ui/src/services/data-service/api.ts
@@ -14,6 +14,10 @@ import type {
   DataServiceCallLog,
   DataServiceDocumentation,
   DataServiceDocumentationInput,
+  DataServiceIpAccessMode,
+  DataServiceIpAccessPolicy,
+  DataServiceIpAccessRule,
+  DataServiceIpAccessRuleInput,
   DataServicePublishPayload,
   DataServiceQueryResult,
   DataServiceRuntimeConfig,
@@ -191,6 +195,50 @@ export const deleteDataServiceKey = async (
 ): Promise<void> => {
   await HttpUtils.deleteData<boolean>(
     `${DATA_SERVICE_API_PREFIX}/${id}/keys/${keyId}`,
+  );
+};
+
+export const getDataServiceIpAccess = (
+  id: number,
+): Promise<DataServiceIpAccessPolicy> =>
+  HttpUtils.getData<DataServiceIpAccessPolicy>(
+    `${DATA_SERVICE_API_PREFIX}/${id}/ip-access`,
+  );
+
+export const setDataServiceIpAccessMode = (
+  id: number,
+  mode: DataServiceIpAccessMode,
+): Promise<DataServiceIpAccessPolicy> =>
+  HttpUtils.putData<DataServiceIpAccessPolicy>(
+    `${DATA_SERVICE_API_PREFIX}/${id}/ip-access/mode${queryString({ mode })}`,
+    {},
+  );
+
+export const createDataServiceIpAccessRule = (
+  id: number,
+  payload: DataServiceIpAccessRuleInput,
+): Promise<DataServiceIpAccessRule> =>
+  HttpUtils.postData<DataServiceIpAccessRule>(
+    `${DATA_SERVICE_API_PREFIX}/${id}/ip-access/rules`,
+    payload,
+  );
+
+export const updateDataServiceIpAccessRule = (
+  id: number,
+  ruleId: number,
+  payload: DataServiceIpAccessRuleInput,
+): Promise<DataServiceIpAccessRule> =>
+  HttpUtils.putData<DataServiceIpAccessRule>(
+    `${DATA_SERVICE_API_PREFIX}/${id}/ip-access/rules/${ruleId}`,
+    payload,
+  );
+
+export const deleteDataServiceIpAccessRule = async (
+  id: number,
+  ruleId: number,
+): Promise<void> => {
+  await HttpUtils.deleteData<boolean>(
+    `${DATA_SERVICE_API_PREFIX}/${id}/ip-access/rules/${ruleId}`,
   );
 };
 

--- a/yak-ops-ui/src/services/data-service/types.ts
+++ b/yak-ops-ui/src/services/data-service/types.ts
@@ -59,6 +59,8 @@ export interface DataServiceUpdatePayload {
 }
 
 export type DataServiceAuthMode = 'NONE' | 'API_KEY';
+export type DataServiceIpAccessMode = 'NONE' | 'ALLOWLIST' | 'DENYLIST';
+export type DataServiceIpAccessRuleType = 'ALLOWLIST' | 'DENYLIST';
 
 export type DataServiceSchemaType =
   | 'STRING'
@@ -182,6 +184,31 @@ export interface DataServiceApiKeyUpdate extends DataServiceApiKeyInput {
 export interface CreatedDataServiceApiKey {
   key: DataServiceApiKey;
   secret: string;
+}
+
+export interface DataServiceIpAccessRule {
+  id: number;
+  apiId: number;
+  ruleType: DataServiceIpAccessRuleType;
+  networkCidr: string;
+  description?: string | null;
+  enabled: boolean;
+  expiresAt?: string | null;
+  createTime?: string;
+  updateTime?: string;
+}
+
+export interface DataServiceIpAccessPolicy {
+  mode: DataServiceIpAccessMode;
+  rules: DataServiceIpAccessRule[];
+}
+
+export interface DataServiceIpAccessRuleInput {
+  ruleType: DataServiceIpAccessRuleType;
+  networkCidr: string;
+  description?: string | null;
+  enabled?: boolean;
+  expiresAt?: string | null;
 }
 
 export interface DataServiceQueryResult {


### PR DESCRIPTION
## Summary

Add service-level **IP/CIDR access control** to Data Service and expose it through a new **访问控制** tab on the API detail page.

This is PR 2 after the API invocation/API Key UI in #980.

## Behavior

Public Data Service invocation now follows this order:

```text
resolve client IP
  -> IP allowlist / denylist
  -> NONE / API_KEY auth
  -> cluster-wide per-key RPM
  -> local circuit/cache
  -> SQL execution
```

### Access modes

- `NONE`: no source-IP restriction
- `ALLOWLIST`: only active matching IP/CIDR rules are admitted; an empty allowlist fails closed
- `DENYLIST`: active matching IP/CIDR rules are rejected
- rejected network access returns HTTP `403`

Rules support:

- IPv4 / IPv6 literal
- IPv4 / IPv6 CIDR
- normalized network values
- description
- enabled/disabled state
- optional expiration

## Trusted proxy boundary

Forwarding headers are **not trusted by default**.

`X-Forwarded-For` / `X-Real-IP` are only considered when the TCP direct peer matches an explicitly configured CIDR in:

```properties
yak.data-service.access.trusted-proxies=10.0.0.0/8,192.168.0.0/16
```

For XFF, the chain is walked right-to-left through trusted proxies and stops at the first untrusted hop, so a client cannot override the result by prepending a forged address. Malformed XFF falls back to the direct peer instead of trusting another forwarding header.

## Backend

- add persisted `IpAccessMode` and IP/CIDR rules
- add project-scoped management API under existing `data-service:access` permission
- enforce IP policy before API Key lookup/hash/rate-limit work
- delete access policy/rules with the parent Data Service
- add `V2__ip_access_policy.sql` in the dedicated Data Service Flyway namespace
- correct the stale Flyway contract test so it reflects the real V1 baseline + new V2 history

## Frontend

Add **访问控制** to Data Service detail:

- 不限制 / 白名单 / 黑名单 mode cards
- separate 白名单 / 黑名单 tabs
- add/edit/delete rules
- enable/disable rules
- expiration and description
- explicit warning before enabling an empty allowlist
- trusted-proxy deployment note

## Tests / guards

Added coverage for:

- IPv4/IPv6 CIDR normalization and matching
- allowlist / denylist semantics and fail-closed behavior
- trusted proxy / XFF spoof-resistance behavior
- network policy being evaluated before API Key/rate-limit admission
- passing the resolved client IP through the invocation chain
- Data Service Flyway V1/V2 contract

## Scope

This PR intentionally does not turn Data Service into a general API Gateway/WAF. It only adds service-level source IP/CIDR access policy and trusted client-IP resolution.

## Verification

- [x] source-level architecture/Flyway guards updated
- [x] focused unit tests added
- [ ] GitHub CI / build
- [ ] manual UI smoke test
