### PR TITLE
refactor(ui): align sync node height with start

### DIFF
--- a/yak-ops-ui/src/pages/workflow/definition/components/canvas/node/WorkflowNode.tsx
+++ b/yak-ops-ui/src/pages/workflow/definition/components/canvas/node/WorkflowNode.tsx
@@ -100,6 +100,7 @@ const WorkflowNode = ({ id, data, selected }: NodeProps<WorkflowNodeData>) => {
   const duration = formatRuntimeDuration(runtime?.elapsedMillis);
   const runtimeActive = isWorkflowNodeActive(runtime?.status);
   const errorTitle = runtime?.errorMessage || runtime?.failureReason;
+  const compactSync = (data.taskType || '').trim().toUpperCase() === 'SYNC';
 
   return (
     <div className="group relative w-60">
@@ -118,7 +119,8 @@ const WorkflowNode = ({ id, data, selected }: NodeProps<WorkflowNodeData>) => {
       <div
         title={errorTitle}
         className={[
-          'relative rounded-[15px] border bg-white px-3 py-3',
+          'relative rounded-[15px] border bg-white px-3',
+          compactSync ? 'py-2' : 'py-3',
           'shadow-[0_1px_2px_rgba(22,24,35,.06)]',
           'transition-[border-color,box-shadow,opacity] duration-200',
           runtimeActive ? '' : 'group-hover:shadow-[0_6px_18px_rgba(22,24,35,.10)]',
@@ -129,7 +131,12 @@ const WorkflowNode = ({ id, data, selected }: NodeProps<WorkflowNodeData>) => {
           selected && visual ? 'ring-1 ring-[rgba(97,114,243,.22)]' : '',
         ].join(' ')}
       >
-        <div className="flex min-h-9 items-center gap-2.5">
+        <div
+          className={[
+            'flex items-center gap-2.5',
+            compactSync ? 'min-h-8' : 'min-h-9',
+          ].join(' ')}
+        >
           <WorkflowNodeIcon taskType={data.taskType} />
 
           <div className="min-w-0 flex-1 truncate text-[14px] font-semibold leading-5 text-[#161823]">


### PR DESCRIPTION
## What changed
- reduce the default data-sync (`SYNC`) workflow node vertical padding
- use the same compact header height as the Start node card
- keep the existing LLM-style sync icon, width, borders, runtime badges and interactions unchanged

## Why
The Start node's inner white card is about 50px tall, while regular task nodes use a 36px minimum header plus 12px vertical padding on each side, making an idle sync node visibly taller. This change gives `SYNC` nodes an 8px vertical padding and 32px minimum header, matching the Start card height while preserving runtime detail rows when they appear.

## Scope
Frontend-only workflow canvas refinement. Only `WorkflowNode.tsx` changes, and the compact sizing applies only to `SYNC` nodes.

## Validation
- reviewed the final diff
- branch is 1 commit ahead of `main` and 0 commits behind
- only one workflow canvas file changed