### PR TITLE
feat(data-service): add access control page and menu

### DIFF
--- a/.github/workflows/navigation-menu-contract.yml
+++ b/.github/workflows/navigation-menu-contract.yml
@@ -7,6 +7,7 @@ on:
       - 'yak-ops-ui/src/config/navigationMenuContract.test.ts'
       - 'yak-ops-ui/src/constants/securityMenuCodes.ts'
       - 'yak-ops-boot/src/main/resources/yak-security/db/migration/V2006__reconcile_menu_permission_catalog.sql'
+      - 'yak-ops-boot/src/main/resources/yak-security/db/migration/V2007__register_data_service_access_page.sql'
       - '.github/workflows/navigation-menu-contract.yml'
   workflow_dispatch:
 

--- a/yak-ops-boot/src/main/resources/yak-security/db/migration/V2007__register_data_service_access_page.sql
+++ b/yak-ops-boot/src/main/resources/yak-security/db/migration/V2007__register_data_service_access_page.sql
@@ -1,0 +1,86 @@
+-- Give Data Service access management its own visible capability page.
+--
+-- V2005/V2006 already define data-service:access, but historically bind it to API Marketplace.
+-- Keep those migrations immutable and repair the catalog with this forward migration.
+
+INSERT INTO yak_security_menu
+(menu_code, menu_name, parent_code, route_path, icon_key, menu_type,
+ sort_order, visible, active, required_permission_code, description, app_name)
+VALUES
+('data-service-access', '访问控制', 'data-service', '/data-service/access', 'api', 2,
+ 20, 1, 1, 'data-service:access', '数据服务认证、API Key 与 IP/CIDR 来源访问控制', '${appName}')
+ON DUPLICATE KEY UPDATE
+menu_name = VALUES(menu_name),
+parent_code = VALUES(parent_code),
+route_path = VALUES(route_path),
+icon_key = VALUES(icon_key),
+menu_type = VALUES(menu_type),
+sort_order = VALUES(sort_order),
+visible = VALUES(visible),
+active = VALUES(active),
+required_permission_code = VALUES(required_permission_code),
+description = VALUES(description),
+is_delete = 0;
+
+UPDATE yak_security_permission
+SET permission_name = '管理数据服务访问控制',
+    description = '配置认证方式、API Key、调用配额与 IP/CIDR 来源访问策略',
+    menu_code = 'data-service-access',
+    active = 1,
+    is_delete = 0
+WHERE permission_code = 'data-service:access'
+  AND app_name = '${appName}';
+
+-- Keep visible Data Service children in the same order as frontend navigation.
+UPDATE yak_security_menu
+SET sort_order = CASE menu_code
+    WHEN 'data-service-debug' THEN 30
+    WHEN 'data-service-overview' THEN 40
+    WHEN 'data-service-logs' THEN 50
+    ELSE sort_order
+END
+WHERE app_name = '${appName}'
+  AND parent_code = 'data-service'
+  AND menu_code IN ('data-service-debug', 'data-service-overview', 'data-service-logs')
+  AND is_delete = 0;
+
+-- Existing roles that already own data-service:access receive the new page automatically.
+INSERT INTO yak_security_role_menu(role_id, menu_id, app_name)
+SELECT DISTINCT role_permission.role_id,
+                access_menu.id,
+                role_permission.app_name
+FROM yak_security_role_permission role_permission
+JOIN yak_security_permission permission_row
+  ON permission_row.id = role_permission.permission_id
+ AND permission_row.permission_code = 'data-service:access'
+ AND permission_row.app_name = role_permission.app_name
+ AND permission_row.is_delete = 0
+ AND permission_row.active = 1
+JOIN yak_security_menu access_menu
+  ON access_menu.menu_code = 'data-service-access'
+ AND access_menu.app_name = role_permission.app_name
+ AND access_menu.is_delete = 0
+ AND access_menu.active = 1
+WHERE role_permission.app_name = '${appName}'
+  AND role_permission.is_delete = 0
+ON DUPLICATE KEY UPDATE is_delete = 0;
+
+-- A role with a Data Service child page must also be able to see the parent group.
+INSERT INTO yak_security_role_menu(role_id, menu_id, app_name)
+SELECT DISTINCT child_role_menu.role_id,
+                parent_menu.id,
+                child_role_menu.app_name
+FROM yak_security_role_menu child_role_menu
+JOIN yak_security_menu child_menu
+  ON child_menu.id = child_role_menu.menu_id
+ AND child_menu.menu_code = 'data-service-access'
+ AND child_menu.app_name = child_role_menu.app_name
+ AND child_menu.is_delete = 0
+JOIN yak_security_menu parent_menu
+  ON parent_menu.menu_code = 'data-service'
+ AND parent_menu.app_name = child_role_menu.app_name
+ AND parent_menu.is_delete = 0
+ AND parent_menu.active = 1
+WHERE child_role_menu.app_name = '${appName}'
+  AND child_role_menu.is_delete = 0
+ON DUPLICATE KEY UPDATE is_delete = 0;

--- a/yak-ops-boot/src/test/java/io/yak/ops/boot/architecture/DataServiceAccessMenuMigrationTest.java
+++ b/yak-ops-boot/src/test/java/io/yak/ops/boot/architecture/DataServiceAccessMenuMigrationTest.java
@@ -1,0 +1,35 @@
+package io.yak.ops.boot.architecture;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import org.junit.jupiter.api.Test;
+
+class DataServiceAccessMenuMigrationTest {
+
+  @Test
+  void accessPermissionOwnsDedicatedVisiblePage() throws IOException {
+    String migration = Files.readString(migrationSource());
+
+    assertThat(migration)
+        .contains("'data-service-access', '访问控制'")
+        .contains("'/data-service/access'")
+        .contains("'data-service:access'")
+        .contains("menu_code = 'data-service-access'")
+        .contains("yak_security_role_menu")
+        .contains("WHEN 'data-service-debug' THEN 30")
+        .contains("WHEN 'data-service-overview' THEN 40")
+        .contains("WHEN 'data-service-logs' THEN 50");
+  }
+
+  private Path migrationSource() {
+    Path local = Path.of(
+        "src/main/resources/yak-security/db/migration/V2007__register_data_service_access_page.sql");
+    if (Files.isRegularFile(local)) return local;
+    return Path.of(
+        "yak-ops-boot", "src", "main", "resources", "yak-security", "db", "migration",
+        "V2007__register_data_service_access_page.sql");
+  }
+}

--- a/yak-ops-business/yak-ops-business-data-service/src/main/java/io/yak/ops/business/dataservice/controller/v1/DataServiceAccessController.java
+++ b/yak-ops-business/yak-ops-business-data-service/src/main/java/io/yak/ops/business/dataservice/controller/v1/DataServiceAccessController.java
@@ -13,6 +13,8 @@ import io.yak.ops.business.dataservice.access.DataServiceIpAccessManager;
 import io.yak.ops.business.dataservice.access.IpAccessPolicyView;
 import io.yak.ops.business.dataservice.access.IpAccessRuleInput;
 import io.yak.ops.business.dataservice.access.IpAccessRuleView;
+import io.yak.ops.business.dataservice.query.DataServiceAccessOverviewItem;
+import io.yak.ops.business.dataservice.query.DataServiceAccessOverviewReader;
 import io.yak.ops.business.datasource.config.ConditionalOnDataSourceEnabled;
 import io.yak.ops.common.constant.dataservice.DataServicePermissionCode;
 import io.yak.ops.core.project.ProjectMigrationMode;
@@ -39,6 +41,13 @@ import org.springframework.web.bind.annotation.RestController;
 public class DataServiceAccessController {
   private final DataServiceApiKeyManager apiKeyManager;
   private final DataServiceIpAccessManager ipAccessManager;
+  private final DataServiceAccessOverviewReader accessOverviewReader;
+
+  @Operation(summary = "查询当前项目的数据服务访问控制概览")
+  @GetMapping("/access-overview")
+  public Result<List<DataServiceAccessOverviewItem>> accessOverview() {
+    return Result.success(accessOverviewReader.list());
+  }
 
   @Operation(summary = "设置数据服务访问控制模式")
   @PutMapping("/{id}/auth-mode")

--- a/yak-ops-business/yak-ops-business-data-service/src/main/java/io/yak/ops/business/dataservice/query/DataServiceAccessOverviewItem.java
+++ b/yak-ops-business/yak-ops-business-data-service/src/main/java/io/yak/ops/business/dataservice/query/DataServiceAccessOverviewItem.java
@@ -1,0 +1,22 @@
+package io.yak.ops.business.dataservice.query;
+
+import io.yak.ops.business.dataservice.domain.access.AuthMode;
+import io.yak.ops.business.dataservice.domain.access.IpAccessMode;
+import java.time.LocalDateTime;
+
+/** Access-management projection for one Data Service in the current Project Space. */
+public record DataServiceAccessOverviewItem(
+    Long apiId,
+    String name,
+    String path,
+    String runtimePath,
+    boolean enabled,
+    AuthMode authMode,
+    IpAccessMode ipAccessMode,
+    int apiKeyCount,
+    int activeApiKeyCount,
+    int allowlistRuleCount,
+    int activeAllowlistRuleCount,
+    int denylistRuleCount,
+    int activeDenylistRuleCount,
+    LocalDateTime updateTime) {}

--- a/yak-ops-business/yak-ops-business-data-service/src/main/java/io/yak/ops/business/dataservice/query/DataServiceAccessOverviewItem.java
+++ b/yak-ops-business/yak-ops-business-data-service/src/main/java/io/yak/ops/business/dataservice/query/DataServiceAccessOverviewItem.java
@@ -3,6 +3,7 @@ package io.yak.ops.business.dataservice.query;
 import io.yak.ops.business.dataservice.domain.access.AuthMode;
 import io.yak.ops.business.dataservice.domain.access.IpAccessMode;
 import java.time.LocalDateTime;
+import java.util.List;
 
 /** Access-management projection for one Data Service in the current Project Space. */
 public record DataServiceAccessOverviewItem(
@@ -10,6 +11,7 @@ public record DataServiceAccessOverviewItem(
     String name,
     String path,
     String runtimePath,
+    List<String> parameterNames,
     boolean enabled,
     AuthMode authMode,
     IpAccessMode ipAccessMode,

--- a/yak-ops-business/yak-ops-business-data-service/src/main/java/io/yak/ops/business/dataservice/query/DataServiceAccessOverviewReader.java
+++ b/yak-ops-business/yak-ops-business-data-service/src/main/java/io/yak/ops/business/dataservice/query/DataServiceAccessOverviewReader.java
@@ -1,0 +1,70 @@
+package io.yak.ops.business.dataservice.query;
+
+import io.yak.ops.business.dataservice.domain.DataServiceDefinition;
+import io.yak.ops.business.dataservice.domain.access.DataServiceApiKey;
+import io.yak.ops.business.dataservice.domain.access.DataServiceIpAccessRule;
+import io.yak.ops.business.dataservice.domain.access.IpAccessRuleType;
+import io.yak.ops.business.dataservice.repository.DataServiceApiKeyRepository;
+import io.yak.ops.business.dataservice.repository.DataServiceIpAccessRepository;
+import io.yak.ops.business.datasource.config.ConditionalOnDataSourceEnabled;
+import java.time.LocalDateTime;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+/** Read model for the standalone Data Service access-control management page. */
+@Component
+@ConditionalOnDataSourceEnabled
+@RequiredArgsConstructor
+public class DataServiceAccessOverviewReader {
+  private static final String RUNTIME_PREFIX = "/api/v1/data-service/runtime";
+
+  private final DataServiceReader dataServiceReader;
+  private final DataServiceApiKeyRepository apiKeyRepository;
+  private final DataServiceIpAccessRepository ipAccessRepository;
+
+  public List<DataServiceAccessOverviewItem> list() {
+    LocalDateTime now = LocalDateTime.now();
+    return dataServiceReader.list().stream()
+        .map(definition -> summarize(definition, now))
+        .toList();
+  }
+
+  private DataServiceAccessOverviewItem summarize(
+      DataServiceDefinition definition, LocalDateTime now) {
+    List<DataServiceApiKey> keys = apiKeyRepository.findByApiId(definition.id());
+    int activeApiKeys = (int) keys.stream()
+        .filter(key -> key.enabled() && !key.expired(now))
+        .count();
+
+    int allowlistRules = 0;
+    int activeAllowlistRules = 0;
+    int denylistRules = 0;
+    int activeDenylistRules = 0;
+    for (DataServiceIpAccessRule rule : ipAccessRepository.findRules(definition.id())) {
+      if (rule.ruleType() == IpAccessRuleType.ALLOWLIST) {
+        allowlistRules++;
+        if (rule.active(now)) activeAllowlistRules++;
+      } else if (rule.ruleType() == IpAccessRuleType.DENYLIST) {
+        denylistRules++;
+        if (rule.active(now)) activeDenylistRules++;
+      }
+    }
+
+    return new DataServiceAccessOverviewItem(
+        definition.id(),
+        definition.settings().name(),
+        definition.settings().path(),
+        RUNTIME_PREFIX + definition.settings().path(),
+        definition.settings().enabled(),
+        definition.authMode(),
+        ipAccessRepository.findMode(definition.id()),
+        keys.size(),
+        activeApiKeys,
+        allowlistRules,
+        activeAllowlistRules,
+        denylistRules,
+        activeDenylistRules,
+        definition.updateTime());
+  }
+}

--- a/yak-ops-business/yak-ops-business-data-service/src/main/java/io/yak/ops/business/dataservice/query/DataServiceAccessOverviewReader.java
+++ b/yak-ops-business/yak-ops-business-data-service/src/main/java/io/yak/ops/business/dataservice/query/DataServiceAccessOverviewReader.java
@@ -20,6 +20,7 @@ public class DataServiceAccessOverviewReader {
   private static final String RUNTIME_PREFIX = "/api/v1/data-service/runtime";
 
   private final DataServiceReader dataServiceReader;
+  private final DataServiceParameterNameReader parameterNameReader;
   private final DataServiceApiKeyRepository apiKeyRepository;
   private final DataServiceIpAccessRepository ipAccessRepository;
 
@@ -56,6 +57,7 @@ public class DataServiceAccessOverviewReader {
         definition.settings().name(),
         definition.settings().path(),
         RUNTIME_PREFIX + definition.settings().path(),
+        parameterNameReader.parameterNames(definition.runtimeSnapshot().sql()),
         definition.settings().enabled(),
         definition.authMode(),
         ipAccessRepository.findMode(definition.id()),

--- a/yak-ops-business/yak-ops-business-data-service/src/test/java/io/yak/ops/business/dataservice/query/DataServiceAccessOverviewReaderTest.java
+++ b/yak-ops-business/yak-ops-business-data-service/src/test/java/io/yak/ops/business/dataservice/query/DataServiceAccessOverviewReaderTest.java
@@ -1,0 +1,73 @@
+package io.yak.ops.business.dataservice.query;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import io.yak.ops.business.dataservice.domain.DataServiceDefinition;
+import io.yak.ops.business.dataservice.domain.DataServiceSettings;
+import io.yak.ops.business.dataservice.domain.PublishedRuntimeSnapshot;
+import io.yak.ops.business.dataservice.domain.RuntimePolicy;
+import io.yak.ops.business.dataservice.domain.SourceReference;
+import io.yak.ops.business.dataservice.domain.access.AuthMode;
+import io.yak.ops.business.dataservice.domain.access.DataServiceApiKey;
+import io.yak.ops.business.dataservice.domain.access.DataServiceIpAccessRule;
+import io.yak.ops.business.dataservice.domain.access.IpAccessMode;
+import io.yak.ops.business.dataservice.domain.access.IpAccessRuleType;
+import io.yak.ops.business.dataservice.repository.DataServiceApiKeyRepository;
+import io.yak.ops.business.dataservice.repository.DataServiceIpAccessRepository;
+import java.time.LocalDateTime;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+
+class DataServiceAccessOverviewReaderTest {
+
+  @Test
+  void projectsAccessStateWithoutRequiringGeneralReadPermission() {
+    DataServiceReader dataServiceReader = mock(DataServiceReader.class);
+    DataServiceApiKeyRepository keyRepository = mock(DataServiceApiKeyRepository.class);
+    DataServiceIpAccessRepository ipRepository = mock(DataServiceIpAccessRepository.class);
+    DataServiceAccessOverviewReader reader =
+        new DataServiceAccessOverviewReader(dataServiceReader, keyRepository, ipRepository);
+
+    DataServiceDefinition definition = DataServiceDefinition.restore(
+        7L,
+        3L,
+        4L,
+        new DataServiceSettings("Orders", "/orders", 100, 30, true, null, false),
+        new PublishedRuntimeSnapshot(9L, "select id from orders"),
+        new SourceReference("TEST", "orders", 11L, 1),
+        RuntimePolicy.defaults(false),
+        AuthMode.API_KEY,
+        LocalDateTime.of(2026, 9, 1, 9, 0),
+        LocalDateTime.of(2026, 9, 2, 9, 0));
+
+    when(dataServiceReader.list()).thenReturn(List.of(definition));
+    when(keyRepository.findByApiId(7L)).thenReturn(List.of(
+        new DataServiceApiKey(1L, 7L, "active", "yak_a", "hash-a", true, 60,
+            LocalDateTime.of(2099, 1, 1, 0, 0), null, null, null),
+        new DataServiceApiKey(2L, 7L, "expired", "yak_b", "hash-b", true, 60,
+            LocalDateTime.of(2020, 1, 1, 0, 0), null, null, null)));
+    when(ipRepository.findMode(7L)).thenReturn(IpAccessMode.DENYLIST);
+    when(ipRepository.findRules(7L)).thenReturn(List.of(
+        new DataServiceIpAccessRule(1L, 7L, IpAccessRuleType.ALLOWLIST, "10.0.0.0/8",
+            null, true, null, null, null),
+        new DataServiceIpAccessRule(2L, 7L, IpAccessRuleType.ALLOWLIST, "192.168.0.0/16",
+            null, false, null, null, null),
+        new DataServiceIpAccessRule(3L, 7L, IpAccessRuleType.DENYLIST, "203.0.113.9/32",
+            null, true, null, null, null)));
+
+    DataServiceAccessOverviewItem item = reader.list().getFirst();
+
+    assertThat(item.apiId()).isEqualTo(7L);
+    assertThat(item.runtimePath()).isEqualTo("/api/v1/data-service/runtime/orders");
+    assertThat(item.authMode()).isEqualTo(AuthMode.API_KEY);
+    assertThat(item.ipAccessMode()).isEqualTo(IpAccessMode.DENYLIST);
+    assertThat(item.apiKeyCount()).isEqualTo(2);
+    assertThat(item.activeApiKeyCount()).isEqualTo(1);
+    assertThat(item.allowlistRuleCount()).isEqualTo(2);
+    assertThat(item.activeAllowlistRuleCount()).isEqualTo(1);
+    assertThat(item.denylistRuleCount()).isEqualTo(1);
+    assertThat(item.activeDenylistRuleCount()).isEqualTo(1);
+  }
+}

--- a/yak-ops-business/yak-ops-business-data-service/src/test/java/io/yak/ops/business/dataservice/query/DataServiceAccessOverviewReaderTest.java
+++ b/yak-ops-business/yak-ops-business-data-service/src/test/java/io/yak/ops/business/dataservice/query/DataServiceAccessOverviewReaderTest.java
@@ -25,17 +25,18 @@ class DataServiceAccessOverviewReaderTest {
   @Test
   void projectsAccessStateWithoutRequiringGeneralReadPermission() {
     DataServiceReader dataServiceReader = mock(DataServiceReader.class);
+    DataServiceParameterNameReader parameterNameReader = mock(DataServiceParameterNameReader.class);
     DataServiceApiKeyRepository keyRepository = mock(DataServiceApiKeyRepository.class);
     DataServiceIpAccessRepository ipRepository = mock(DataServiceIpAccessRepository.class);
-    DataServiceAccessOverviewReader reader =
-        new DataServiceAccessOverviewReader(dataServiceReader, keyRepository, ipRepository);
+    DataServiceAccessOverviewReader reader = new DataServiceAccessOverviewReader(
+        dataServiceReader, parameterNameReader, keyRepository, ipRepository);
 
     DataServiceDefinition definition = DataServiceDefinition.restore(
         7L,
         3L,
         4L,
         new DataServiceSettings("Orders", "/orders", 100, 30, true, null, false),
-        new PublishedRuntimeSnapshot(9L, "select id from orders"),
+        new PublishedRuntimeSnapshot(9L, "select id from orders where id = :id"),
         new SourceReference("TEST", "orders", 11L, 1),
         RuntimePolicy.defaults(false),
         AuthMode.API_KEY,
@@ -43,6 +44,8 @@ class DataServiceAccessOverviewReaderTest {
         LocalDateTime.of(2026, 9, 2, 9, 0));
 
     when(dataServiceReader.list()).thenReturn(List.of(definition));
+    when(parameterNameReader.parameterNames("select id from orders where id = :id"))
+        .thenReturn(List.of("id"));
     when(keyRepository.findByApiId(7L)).thenReturn(List.of(
         new DataServiceApiKey(1L, 7L, "active", "yak_a", "hash-a", true, 60,
             LocalDateTime.of(2099, 1, 1, 0, 0), null, null, null),
@@ -57,10 +60,11 @@ class DataServiceAccessOverviewReaderTest {
         new DataServiceIpAccessRule(3L, 7L, IpAccessRuleType.DENYLIST, "203.0.113.9/32",
             null, true, null, null, null)));
 
-    DataServiceAccessOverviewItem item = reader.list().getFirst();
+    DataServiceAccessOverviewItem item = reader.list().get(0);
 
     assertThat(item.apiId()).isEqualTo(7L);
     assertThat(item.runtimePath()).isEqualTo("/api/v1/data-service/runtime/orders");
+    assertThat(item.parameterNames()).containsExactly("id");
     assertThat(item.authMode()).isEqualTo(AuthMode.API_KEY);
     assertThat(item.ipAccessMode()).isEqualTo(IpAccessMode.DENYLIST);
     assertThat(item.apiKeyCount()).isEqualTo(2);

--- a/yak-ops-ui/src/config/navigation.ts
+++ b/yak-ops-ui/src/config/navigation.ts
@@ -67,9 +67,10 @@ export const appRoutes: readonly NavigationRoute[] = [
   { id: 'data-analysis-chart', path: '/data-analysis/chart-analysis', title: '图表分析', component: './data-analysis/chart-analysis-redirect', hidden: true, parentId: 'dashboard' },
   { id: 'data-service-api', menuCode: YAK_OPS_MENU_CODES.dataServiceApi, mode: 'one', permission: 'data-service:read', path: '/data-service', title: 'API 集市', component: './data-service', iconKey: 'api', menuGroup: 'data-service', order: 10 },
   { id: 'data-service-api-detail', path: '/data-service/api/:id', title: 'API 详情', component: './data-service/detail', hidden: true, parentId: 'data-service-api' },
-  { id: 'data-service-debug', menuCode: YAK_OPS_MENU_CODES.dataServiceDebug, mode: 'all', permissions: ['data-service:read', 'data-service:runtime'], path: '/data-service/debug', title: 'API 调试', component: './data-service/debug', iconKey: 'api', menuGroup: 'data-service', order: 20 },
-  { id: 'data-service-overview', menuCode: YAK_OPS_MENU_CODES.dataServiceOverview, mode: 'one', permission: 'data-service:observe', path: '/data-service/overview', title: '运行概览', component: './data-service/overview', iconKey: 'monitor', menuGroup: 'data-service', order: 30 },
-  { id: 'data-service-logs', menuCode: YAK_OPS_MENU_CODES.dataServiceLogs, mode: 'one', permission: 'data-service:observe', path: '/data-service/logs', title: '调用记录', component: './data-service/logs', iconKey: 'report', menuGroup: 'data-service', order: 40 },
+  { id: 'data-service-access', menuCode: YAK_OPS_MENU_CODES.dataServiceAccess, mode: 'one', permission: 'data-service:access', path: '/data-service/access', title: '访问控制', component: './data-service/access', iconKey: 'api', menuGroup: 'data-service', order: 20 },
+  { id: 'data-service-debug', menuCode: YAK_OPS_MENU_CODES.dataServiceDebug, mode: 'all', permissions: ['data-service:read', 'data-service:runtime'], path: '/data-service/debug', title: 'API 调试', component: './data-service/debug', iconKey: 'api', menuGroup: 'data-service', order: 30 },
+  { id: 'data-service-overview', menuCode: YAK_OPS_MENU_CODES.dataServiceOverview, mode: 'one', permission: 'data-service:observe', path: '/data-service/overview', title: '运行概览', component: './data-service/overview', iconKey: 'monitor', menuGroup: 'data-service', order: 40 },
+  { id: 'data-service-logs', menuCode: YAK_OPS_MENU_CODES.dataServiceLogs, mode: 'one', permission: 'data-service:observe', path: '/data-service/logs', title: '调用记录', component: './data-service/logs', iconKey: 'report', menuGroup: 'data-service', order: 50 },
   { id: 'settings', mode: 'public', path: '/settings', title: '设置', component: './settings', hidden: true, order: 30 },
   {
     id: 'batch-link-up', menuCode: YAK_OPS_MENU_CODES.batchLinkUp,

--- a/yak-ops-ui/src/config/navigationMenuContract.test.ts
+++ b/yak-ops-ui/src/config/navigationMenuContract.test.ts
@@ -22,31 +22,28 @@ type MenuCatalogRow = {
   requiredPermissionCode: string | null;
 };
 
-const FINAL_CATALOG_MIGRATION = path.resolve(
+const SECURITY_MIGRATION_ROOT = path.resolve(
   __dirname,
-  '../../../yak-ops-boot/src/main/resources/yak-security/db/migration/V2006__reconcile_menu_permission_catalog.sql',
+  '../../../yak-ops-boot/src/main/resources/yak-security/db/migration',
 );
+const BASE_CATALOG_MIGRATION = path.join(
+  SECURITY_MIGRATION_ROOT,
+  'V2006__reconcile_menu_permission_catalog.sql',
+);
+const CATALOG_EXTENSION_MIGRATIONS = [
+  path.join(
+    SECURITY_MIGRATION_ROOT,
+    'V2007__register_data_service_access_page.sql',
+  ),
+];
 
 const sqlValue = (token: string): string | null =>
   token === 'NULL' ? null : token.slice(1, -1);
 
-const parseFinalYakOpsMenuCatalog = (): MenuCatalogRow[] => {
-  const sql = readFileSync(FINAL_CATALOG_MIGRATION, 'utf8');
-  const sectionStart = sql.indexOf(
-    '-- 3. Upsert the complete set of current visible Yak Ops menus.',
-  );
-  const sectionEnd = sql.indexOf('ON DUPLICATE KEY UPDATE', sectionStart);
-
-  if (sectionStart < 0 || sectionEnd < 0) {
-    throw new Error(
-      'Cannot locate the final Yak Ops menu catalog in V2006__reconcile_menu_permission_catalog.sql',
-    );
-  }
-
-  const section = sql.slice(sectionStart, sectionEnd);
+const parseMenuRows = (sql: string): MenuCatalogRow[] => {
   const rowPattern = /\(\s*'([^']+)'\s*,\s*'[^']*'\s*,\s*(NULL|'[^']*')\s*,\s*(NULL|'[^']*')\s*,\s*'[^']*'\s*,\s*(\d+)\s*,\s*\d+\s*,\s*(\d+)\s*,\s*(\d+)\s*,\s*(NULL|'[^']*')\s*,\s*'[^']*'\s*,\s*'\$\{appName\}'\s*\)/g;
 
-  const rows = [...section.matchAll(rowPattern)].map((match) => ({
+  return [...sql.matchAll(rowPattern)].map((match) => ({
     menuCode: match[1],
     parentCode: sqlValue(match[2]),
     routePath: sqlValue(match[3]),
@@ -55,9 +52,34 @@ const parseFinalYakOpsMenuCatalog = (): MenuCatalogRow[] => {
     active: match[6] === '1',
     requiredPermissionCode: sqlValue(match[7]),
   }));
+};
 
+const parseFinalYakOpsMenuCatalog = (): MenuCatalogRow[] => {
+  const sql = readFileSync(BASE_CATALOG_MIGRATION, 'utf8');
+  const sectionStart = sql.indexOf(
+    '-- 3. Upsert the complete set of current visible Yak Ops menus.',
+  );
+  const sectionEnd = sql.indexOf('ON DUPLICATE KEY UPDATE', sectionStart);
+
+  if (sectionStart < 0 || sectionEnd < 0) {
+    throw new Error(
+      'Cannot locate the baseline Yak Ops menu catalog in V2006__reconcile_menu_permission_catalog.sql',
+    );
+  }
+
+  let rows = parseMenuRows(sql.slice(sectionStart, sectionEnd));
   if (rows.length === 0) {
-    throw new Error('Parsed zero rows from the final Yak Ops menu catalog');
+    throw new Error('Parsed zero rows from the V2006 Yak Ops menu catalog');
+  }
+
+  for (const migrationPath of CATALOG_EXTENSION_MIGRATIONS) {
+    const extensionRows = parseMenuRows(readFileSync(migrationPath, 'utf8'));
+    for (const extension of extensionRows) {
+      rows = [
+        ...rows.filter((row) => row.menuCode !== extension.menuCode),
+        extension,
+      ];
+    }
   }
 
   return rows;
@@ -123,7 +145,7 @@ describe('Navigation ↔ Yak Security menu catalog contract', () => {
     expect(errors).toEqual([]);
   });
 
-  it('keeps the frontend Yak Ops menu-code set exactly aligned with the final Flyway catalog', () => {
+  it('keeps the frontend Yak Ops menu-code set exactly aligned with the effective Flyway catalog', () => {
     const frontendEntries = [
       ...navigationGroups
         .filter((group) => yakOpsCodeSet.has(group.menuCode))

--- a/yak-ops-ui/src/constants/securityMenuCodes.ts
+++ b/yak-ops-ui/src/constants/securityMenuCodes.ts
@@ -31,6 +31,7 @@ export const YAK_OPS_MENU_CODES = {
   digitalScreen: 'digital-screen',
   dataService: 'data-service',
   dataServiceApi: 'data-service-api',
+  dataServiceAccess: 'data-service-access',
   dataServiceDebug: 'data-service-debug',
   dataServiceOverview: 'data-service-overview',
   dataServiceLogs: 'data-service-logs',

--- a/yak-ops-ui/src/pages/data-service/access/index.tsx
+++ b/yak-ops-ui/src/pages/data-service/access/index.tsx
@@ -1,0 +1,408 @@
+import { YakButton, YakEmpty, YakTab } from '@/components/ui';
+import {
+  listDataServiceAccessOverview,
+  listDataServiceKeys,
+  type DataServiceAccessOverviewItem,
+  type DataServiceApi,
+  type DataServiceApiKey,
+  type DataServiceAuthMode,
+  type DataServiceIpAccessMode,
+} from '@/services/data-service';
+import {
+  Drawer,
+  Input,
+  Select,
+  Spin,
+  Table,
+  message,
+  type TableColumnsType,
+} from 'antd';
+import { KeyRound, Network, RefreshCw, Search, ShieldCheck } from 'lucide-react';
+import { useCallback, useEffect, useMemo, useState } from 'react';
+
+import DataServiceAccessControlPanel from '../components/DataServiceAccessControlPanel';
+import DataServiceApiCallPanel from '../components/DataServiceApiCallPanel';
+
+type AuthFilter = 'ALL' | DataServiceAuthMode;
+type IpFilter = 'ALL' | DataServiceIpAccessMode;
+type AccessDrawerTab = 'AUTH' | 'IP';
+
+const formatTime = (value?: string | null) =>
+  value ? value.replace('T', ' ').slice(0, 19) : '-';
+
+const ipModeLabel: Record<DataServiceIpAccessMode, string> = {
+  NONE: '不限制',
+  ALLOWLIST: '白名单',
+  DENYLIST: '黑名单',
+};
+
+const isActiveKey = (key: DataServiceApiKey) => {
+  if (!key.enabled) return false;
+  if (!key.expiresAt) return true;
+  return new Date(key.expiresAt).getTime() > Date.now();
+};
+
+const toApiCallService = (item: DataServiceAccessOverviewItem): DataServiceApi => ({
+  id: item.apiId,
+  name: item.name,
+  path: item.path,
+  runtimePath: item.runtimePath,
+  dataSourceId: 0,
+  sql: '',
+  parameterNames: item.parameterNames || [],
+  maxRows: 0,
+  timeoutSeconds: 0,
+  enabled: item.enabled,
+  authMode: item.authMode,
+});
+
+const Metric = ({ label, value, note }: { label: string; value: number; note: string }) => (
+  <div className="min-w-0 px-4 py-3">
+    <div className="text-[11px] text-[#98a2b3]">{label}</div>
+    <div className="mt-1 text-[20px] font-semibold tracking-[-.02em] text-[#161823]">{value}</div>
+    <div className="mt-0.5 truncate text-[10px] text-[#a0a5ad]">{note}</div>
+  </div>
+);
+
+export default function DataServiceAccessPage() {
+  const [records, setRecords] = useState<DataServiceAccessOverviewItem[]>([]);
+  const [loading, setLoading] = useState(false);
+  const [keyword, setKeyword] = useState('');
+  const [authFilter, setAuthFilter] = useState<AuthFilter>('ALL');
+  const [ipFilter, setIpFilter] = useState<IpFilter>('ALL');
+  const [selected, setSelected] = useState<DataServiceAccessOverviewItem>();
+  const [drawerTab, setDrawerTab] = useState<AccessDrawerTab>('AUTH');
+  const [keys, setKeys] = useState<DataServiceApiKey[]>([]);
+  const [keysLoading, setKeysLoading] = useState(false);
+
+  const load = useCallback(async () => {
+    setLoading(true);
+    try {
+      setRecords((await listDataServiceAccessOverview()) || []);
+    } catch (error: any) {
+      message.error(error?.message || '加载数据服务访问控制失败');
+      setRecords([]);
+    } finally {
+      setLoading(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    void load();
+  }, [load]);
+
+  const metrics = useMemo(() => ({
+    total: records.length,
+    apiKey: records.filter((item) => item.authMode === 'API_KEY').length,
+    network: records.filter((item) => item.ipAccessMode !== 'NONE').length,
+    dual: records.filter(
+      (item) => item.authMode === 'API_KEY' && item.ipAccessMode !== 'NONE',
+    ).length,
+  }), [records]);
+
+  const filtered = useMemo(() => {
+    const text = keyword.trim().toLowerCase();
+    return records.filter((item) => {
+      if (authFilter !== 'ALL' && item.authMode !== authFilter) return false;
+      if (ipFilter !== 'ALL' && item.ipAccessMode !== ipFilter) return false;
+      if (!text) return true;
+      return item.name.toLowerCase().includes(text)
+        || item.path.toLowerCase().includes(text)
+        || item.runtimePath.toLowerCase().includes(text);
+    });
+  }, [authFilter, ipFilter, keyword, records]);
+
+  const patchItem = useCallback((apiId: number, patch: Partial<DataServiceAccessOverviewItem>) => {
+    setRecords((current) => current.map((item) =>
+      item.apiId === apiId ? { ...item, ...patch } : item));
+    setSelected((current) => current?.apiId === apiId
+      ? { ...current, ...patch }
+      : current);
+  }, []);
+
+  const openConfig = async (item: DataServiceAccessOverviewItem) => {
+    setSelected(item);
+    setDrawerTab('AUTH');
+    setKeys([]);
+    setKeysLoading(true);
+    try {
+      setKeys((await listDataServiceKeys(item.apiId)) || []);
+    } catch (error: any) {
+      message.error(error?.message || '加载 API Key 失败');
+    } finally {
+      setKeysLoading(false);
+    }
+  };
+
+  const closeConfig = () => {
+    setSelected(undefined);
+    setKeys([]);
+    void load();
+  };
+
+  const handleAuthModeChange = (mode: DataServiceAuthMode) => {
+    if (!selected) return;
+    patchItem(selected.apiId, { authMode: mode });
+  };
+
+  const handleKeysChange = (nextKeys: DataServiceApiKey[]) => {
+    setKeys(nextKeys);
+    if (!selected) return;
+    patchItem(selected.apiId, {
+      apiKeyCount: nextKeys.length,
+      activeApiKeyCount: nextKeys.filter(isActiveKey).length,
+    });
+  };
+
+  const columns: TableColumnsType<DataServiceAccessOverviewItem> = [
+    {
+      title: 'API',
+      key: 'api',
+      minWidth: 220,
+      render: (_, record) => (
+        <div className="min-w-0 py-0.5">
+          <div className="truncate text-[12px] font-medium text-[#344054]">{record.name}</div>
+          <div className="mt-0.5 truncate font-mono text-[10px] text-[#98a2b3]">{record.path}</div>
+        </div>
+      ),
+    },
+    {
+      title: '状态',
+      dataIndex: 'enabled',
+      width: 88,
+      render: (enabled: boolean) => (
+        <span className="inline-flex items-center gap-1.5 text-[11px] text-[#667085]">
+          <span className={`h-1.5 w-1.5 rounded-full ${enabled ? 'bg-[#20c77a]' : 'bg-[#b0b5bd]'}`} />
+          {enabled ? '运行中' : '已停用'}
+        </span>
+      ),
+    },
+    {
+      title: '调用认证',
+      key: 'auth',
+      width: 165,
+      render: (_, record) => (
+        <div>
+          <div className="text-[11px] font-medium text-[#475467]">
+            {record.authMode === 'API_KEY' ? 'API Key' : '公开访问'}
+          </div>
+          <div className="mt-0.5 text-[10px] text-[#98a2b3]">
+            {record.authMode === 'API_KEY'
+              ? `${record.activeApiKeyCount}/${record.apiKeyCount} 个有效 Key`
+              : `${record.apiKeyCount} 个 Key`}
+          </div>
+        </div>
+      ),
+    },
+    {
+      title: '来源限制',
+      key: 'network',
+      width: 165,
+      render: (_, record) => {
+        const active = record.ipAccessMode === 'ALLOWLIST'
+          ? record.activeAllowlistRuleCount
+          : record.ipAccessMode === 'DENYLIST'
+            ? record.activeDenylistRuleCount
+            : 0;
+        return (
+          <div>
+            <div className="text-[11px] font-medium text-[#475467]">
+              {ipModeLabel[record.ipAccessMode]}
+            </div>
+            <div className="mt-0.5 text-[10px] text-[#98a2b3]">
+              {record.ipAccessMode === 'NONE' ? '未启用 IP 限制' : `${active} 条规则生效`}
+            </div>
+          </div>
+        );
+      },
+    },
+    {
+      title: '规则',
+      key: 'rules',
+      width: 130,
+      render: (_, record) => (
+        <span className="text-[10px] text-[#667085]">
+          白 {record.allowlistRuleCount} · 黑 {record.denylistRuleCount}
+        </span>
+      ),
+    },
+    {
+      title: '更新时间',
+      dataIndex: 'updateTime',
+      width: 150,
+      render: (value?: string | null) => (
+        <span className="text-[10px] text-[#98a2b3]">{formatTime(value)}</span>
+      ),
+    },
+    {
+      title: '操作',
+      key: 'action',
+      width: 96,
+      fixed: 'right',
+      render: (_, record) => (
+        <YakButton
+          type="text"
+          size="small"
+          icon={<ShieldCheck size={13} />}
+          onClick={() => void openConfig(record)}
+        >
+          配置
+        </YakButton>
+      ),
+    },
+  ];
+
+  const callService = selected ? toApiCallService(selected) : undefined;
+
+  return (
+    <div className="h-full overflow-y-auto bg-[#f6f7f8] p-3">
+      <div className="min-h-full rounded-[10px] bg-white px-5 pb-5 pt-4">
+        <div className="flex flex-wrap items-start justify-between gap-3">
+          <div>
+            <h1 className="m-0 text-[17px] font-semibold text-[#161823]">访问控制</h1>
+            <div className="mt-1 text-[12px] text-[#98a2b3]">
+              集中管理 API Key 认证、调用配额与 IP/CIDR 黑白名单
+            </div>
+          </div>
+          <YakButton
+            type="text"
+            icon={<RefreshCw size={14} />}
+            loading={loading}
+            onClick={() => void load()}
+            className="bg-[#f5f6f7]"
+          >
+            刷新
+          </YakButton>
+        </div>
+
+        <div className="my-4 border-t border-[#f0f0f0]" />
+
+        <div className="grid grid-cols-2 divide-x divide-[#f0f0f0] rounded-[8px] bg-[#f8f9fa] md:grid-cols-4">
+          <Metric label="数据服务" value={metrics.total} note="当前项目空间" />
+          <Metric label="API Key 认证" value={metrics.apiKey} note="需要调用凭证" />
+          <Metric label="来源限制" value={metrics.network} note="已启用黑/白名单" />
+          <Metric label="双重保护" value={metrics.dual} note="Key + IP 同时启用" />
+        </div>
+
+        <div className="mt-4 flex flex-wrap items-center gap-2">
+          <Input
+            value={keyword}
+            onChange={(event) => setKeyword(event.target.value)}
+            allowClear
+            variant="filled"
+            prefix={<Search size={13} className="text-[#98a2b3]" />}
+            placeholder="搜索 API 名称或路径"
+            className="w-[280px]"
+          />
+          <Select<AuthFilter>
+            value={authFilter}
+            onChange={setAuthFilter}
+            variant="filled"
+            className="w-[150px]"
+            options={[
+              { value: 'ALL', label: '全部认证方式' },
+              { value: 'NONE', label: '公开访问' },
+              { value: 'API_KEY', label: 'API Key' },
+            ]}
+          />
+          <Select<IpFilter>
+            value={ipFilter}
+            onChange={setIpFilter}
+            variant="filled"
+            className="w-[150px]"
+            options={[
+              { value: 'ALL', label: '全部来源策略' },
+              { value: 'NONE', label: '不限制' },
+              { value: 'ALLOWLIST', label: '白名单' },
+              { value: 'DENYLIST', label: '黑名单' },
+            ]}
+          />
+          <div className="ml-auto text-[11px] text-[#98a2b3]">共 {filtered.length} 个 API</div>
+        </div>
+
+        <div className="mt-3">
+          <Table<DataServiceAccessOverviewItem>
+            rowKey="apiId"
+            size="small"
+            loading={loading}
+            columns={columns}
+            dataSource={filtered}
+            scroll={{ x: 1050 }}
+            pagination={{
+              pageSize: 10,
+              showSizeChanger: true,
+              pageSizeOptions: [10, 20, 50],
+              showTotal: (total) => `共 ${total} 条`,
+            }}
+            locale={{
+              emptyText: (
+                <YakEmpty
+                  compact
+                  title="暂无可管理的数据服务"
+                  description="发布数据服务后，可在这里统一配置调用认证和来源访问策略。"
+                />
+              ),
+            }}
+            className="[&_.ant-table-container]:!border-t [&_.ant-table-container]:!border-[#f0f0f0] [&_.ant-table-thead>tr>th]:!bg-[#fafafa] [&_.ant-table-thead>tr>th]:!text-[11px] [&_.ant-table-tbody>tr>td]:!py-3"
+          />
+        </div>
+      </div>
+
+      <Drawer
+        open={Boolean(selected)}
+        width={920}
+        onClose={closeConfig}
+        title={selected ? (
+          <div className="min-w-0">
+            <div className="truncate text-[14px] font-semibold text-[#161823]">{selected.name}</div>
+            <div className="mt-0.5 truncate font-mono text-[10px] font-normal text-[#98a2b3]">
+              {selected.runtimePath}
+            </div>
+          </div>
+        ) : '访问控制'}
+      >
+        {selected ? (
+          <div className="-mt-3">
+            <YakTab
+              activeKey={drawerTab}
+              onChange={(key) => setDrawerTab(key as AccessDrawerTab)}
+              items={[
+                { key: 'AUTH', label: '调用认证' },
+                { key: 'IP', label: 'IP 黑白名单' },
+              ]}
+            />
+
+            <div className="mt-3 rounded-lg bg-[#f7f7f8] p-3">
+              {drawerTab === 'AUTH' ? (
+                keysLoading || !callService ? (
+                  <div className="flex min-h-[360px] items-center justify-center rounded-lg bg-white">
+                    <Spin />
+                  </div>
+                ) : (
+                  <DataServiceApiCallPanel
+                    service={callService}
+                    keys={keys}
+                    canManageAccess
+                    onAuthModeChange={handleAuthModeChange}
+                    onKeysChange={handleKeysChange}
+                  />
+                )
+              ) : (
+                <DataServiceAccessControlPanel key={selected.apiId} apiId={selected.apiId} />
+              )}
+            </div>
+
+            <div className="mt-3 flex items-start gap-2 rounded-lg bg-[#f7f7f8] px-3 py-2.5 text-[10px] leading-5 text-[#667085]">
+              {drawerTab === 'AUTH' ? <KeyRound size={13} className="mt-1 shrink-0" /> : <Network size={13} className="mt-1 shrink-0" />}
+              <span>
+                {drawerTab === 'AUTH'
+                  ? 'API Key 与每分钟调用上限属于调用身份策略；切换认证方式不会改变已发布 SQL。'
+                  : '来源 IP 策略会在 API Key 鉴权和限流之前执行，命中拒绝规则时直接返回 403。'}
+              </span>
+            </div>
+          </div>
+        ) : null}
+      </Drawer>
+    </div>
+  );
+}

--- a/yak-ops-ui/src/services/data-service/access.ts
+++ b/yak-ops-ui/src/services/data-service/access.ts
@@ -1,0 +1,28 @@
+import HttpUtils from '@/utils/HttpUtils';
+
+import { DATA_SERVICE_API_PREFIX } from './constants';
+import type { DataServiceAuthMode, DataServiceIpAccessMode } from './types';
+
+/** Read model used only by the standalone access-control management page. */
+export interface DataServiceAccessOverviewItem {
+  apiId: number;
+  name: string;
+  path: string;
+  runtimePath: string;
+  parameterNames: string[];
+  enabled: boolean;
+  authMode: DataServiceAuthMode;
+  ipAccessMode: DataServiceIpAccessMode;
+  apiKeyCount: number;
+  activeApiKeyCount: number;
+  allowlistRuleCount: number;
+  activeAllowlistRuleCount: number;
+  denylistRuleCount: number;
+  activeDenylistRuleCount: number;
+  updateTime?: string | null;
+}
+
+export const listDataServiceAccessOverview = (): Promise<DataServiceAccessOverviewItem[]> =>
+  HttpUtils.getData<DataServiceAccessOverviewItem[]>(
+    `${DATA_SERVICE_API_PREFIX}/access-overview`,
+  );

--- a/yak-ops-ui/src/services/data-service/index.ts
+++ b/yak-ops-ui/src/services/data-service/index.ts
@@ -1,3 +1,4 @@
+export * from './access';
 export * from './api';
 export * from './constants';
 export * from './overview';


### PR DESCRIPTION
## Summary

Complete the Data Service access-control management surface after #982.

The IP/CIDR and API Key capabilities already exist, but `data-service:access` was still attached to **API 集市** and there was no dedicated sidebar page. This PR adds a real **访问控制** page and repairs the Yak Security menu/permission catalog with a forward migration.

## What changes

### Frontend

Add a new visible Data Service route:

```text
数据服务
├── API 集市
├── 访问控制      <- new
├── API 调试
├── 运行概览
└── 调用记录
```

`/data-service/access` provides:

- project-scoped Data Service access overview
- API name/path search
- filled auth-mode and IP-policy filters
- service / API Key / IP restriction / dual-protection summary metrics
- API Key mode and active-key counts
- allowlist / denylist mode and rule counts
- one configuration drawer with `调用认证` and `IP 黑白名单` tabs
- reuse of the existing API Key and IP/CIDR management panels from #982

### Permission / menu catalog

Add `V2007__register_data_service_access_page.sql` instead of rewriting V2005/V2006 history.

The migration:

- creates menu code `data-service-access`
- registers route `/data-service/access`
- binds it to existing permission `data-service:access`
- moves `data-service:access` ownership away from `data-service-api`
- shifts the remaining Data Service child-menu sort order
- backfills the new child menu to roles that already own `data-service:access`
- ensures those roles also retain the Data Service parent menu

No new overlapping permission vocabulary is introduced; the existing backend capability permission remains the source of truth.

### Backend

Add a dedicated `GET /api/v1/data-service/access-overview` read model under `DataServiceAccessController`.

It intentionally requires only the existing class-level `data-service:access` permission and `PROJECT_REQUIRED` scope. The page therefore does **not** need to borrow `data-service:read` just to enumerate services it is allowed to manage.

The projection includes:

- API identity/path/runtime path
- parameter names needed by the existing call-auth panel
- enabled/auth mode
- IP access mode
- total/active API Key counts
- total/active allowlist and denylist counts

## Permission semantics

```text
/data-service/access
  -> menu: data-service-access
  -> permission: data-service:access
  -> Project Space required
```

This fixes the previous mismatch where `data-service:access` was a backend permission but had no corresponding dedicated UI menu/page.

## Tests / guards

- access overview projection unit test
- security migration source contract test
- menu ordering and permission binding assertions
- branch updated to latest `main`

## Verification

- [x] branch is based on latest main
- [x] focused backend unit/contract tests added
- [x] existing Flyway migrations left immutable
- [ ] GitHub CI / build
- [ ] manual browser smoke test
