### PR TITLE
refactor(ui): compact development workflow nodes

### DIFF
--- a/yak-ops-ui/src/pages/workflow/definition/components/canvas/node/WorkflowNode.tsx
+++ b/yak-ops-ui/src/pages/workflow/definition/components/canvas/node/WorkflowNode.tsx
@@ -27,6 +27,14 @@ interface RuntimeVisual {
   icon: ReactNode;
 }
 
+const COMPACT_TASK_TYPES = new Set([
+  'SYNC',
+  'SQL',
+  'SHELL',
+  'PYTHON',
+  'JAVA',
+]);
+
 const runtimeVisual = (status?: string): RuntimeVisual | undefined => {
   switch (status) {
     case 'WAITING':
@@ -100,7 +108,8 @@ const WorkflowNode = ({ id, data, selected }: NodeProps<WorkflowNodeData>) => {
   const duration = formatRuntimeDuration(runtime?.elapsedMillis);
   const runtimeActive = isWorkflowNodeActive(runtime?.status);
   const errorTitle = runtime?.errorMessage || runtime?.failureReason;
-  const compactSync = (data.taskType || '').trim().toUpperCase() === 'SYNC';
+  const normalizedTaskType = (data.taskType || '').trim().toUpperCase();
+  const compactNode = COMPACT_TASK_TYPES.has(normalizedTaskType);
 
   return (
     <div className="group relative w-60">
@@ -120,7 +129,7 @@ const WorkflowNode = ({ id, data, selected }: NodeProps<WorkflowNodeData>) => {
         title={errorTitle}
         className={[
           'relative rounded-[15px] border bg-white px-3',
-          compactSync ? 'py-2' : 'py-3',
+          compactNode ? 'py-2' : 'py-3',
           'shadow-[0_1px_2px_rgba(22,24,35,.06)]',
           'transition-[border-color,box-shadow,opacity] duration-200',
           runtimeActive ? '' : 'group-hover:shadow-[0_6px_18px_rgba(22,24,35,.10)]',
@@ -134,7 +143,7 @@ const WorkflowNode = ({ id, data, selected }: NodeProps<WorkflowNodeData>) => {
         <div
           className={[
             'flex items-center gap-2.5',
-            compactSync ? 'min-h-8' : 'min-h-9',
+            compactNode ? 'min-h-8' : 'min-h-9',
           ].join(' ')}
         >
           <WorkflowNodeIcon taskType={data.taskType} />

--- a/yak-ops-ui/src/pages/workflow/definition/components/canvas/node/icons/WorkflowNodeIcon.tsx
+++ b/yak-ops-ui/src/pages/workflow/definition/components/canvas/node/icons/WorkflowNodeIcon.tsx
@@ -127,9 +127,6 @@ const DevelopmentTaskGlyph = ({
 };
 
 const developmentContainerClassName = (taskType: string) => {
-  if (taskType === 'SQL') {
-    return 'border-[#fed7aa] bg-[#fff7ed] text-[#c2410c]';
-  }
   if (taskType === 'SHELL') {
     return 'border-[#d9ddff] bg-[#f4f5ff] text-[#6172f3]';
   }
@@ -165,6 +162,19 @@ const WorkflowNodeIcon = ({ taskType, size = 'md' }: WorkflowNodeIconProps) => {
         ].join(' ')}
       >
         <QualityEndGlyph className={COMPACT_ICON_SIZE[size]} />
+      </span>
+    );
+  }
+
+  if (normalizedTaskType === 'SQL') {
+    return (
+      <span
+        className={[
+          'flex shrink-0 items-center justify-center bg-[#f79009] text-white',
+          COMPACT_CONTAINER_SIZE[size],
+        ].join(' ')}
+      >
+        <DevelopmentTaskGlyph taskType={normalizedTaskType} size={size} />
       </span>
     );
   }


### PR DESCRIPTION
## What changed
- make workflow data-development nodes (`SQL` / `SHELL` / `PYTHON` / `JAVA`) use the same compact node height as the existing sync node
- keep runtime detail rows able to expand naturally when execution status is shown
- restyle only the workflow SQL icon to a solid orange container with white `SQL` text and no border
- keep the Data Development module's own SQL / Java / Python icons unchanged, so workflow and Data Development can evolve as two separate icon systems
- preserve the existing Java, Python, Shell, sync and quality icon behavior

## Visual intent
Idle data-development nodes now align with the compact Start / Sync node rhythm instead of appearing taller. The workflow SQL icon also matches the stronger solid-color workflow icon language rather than the bordered light-background treatment.

## Scope
Frontend-only workflow canvas refinement. Only `WorkflowNode.tsx` and `WorkflowNodeIcon.tsx` change; Data Development pages, task behavior, runtime state, drag/drop and backend contracts are untouched.

## Validation
- reviewed the final branch diff
- branch is 1 commit ahead of `main` and 0 commits behind
- only two workflow canvas files changed