### PR TITLE
refactor(ui): align data service caller editor with sync layout

### DIFF
--- a/yak-ops-ui/src/pages/data-service/access/ConsumerApiAccessPanel.tsx
+++ b/yak-ops-ui/src/pages/data-service/access/ConsumerApiAccessPanel.tsx
@@ -6,7 +6,7 @@ import {
   type DataServiceConsumerAccessScope,
 } from '@/services/data-service';
 import { Select, message } from 'antd';
-import { CheckCircle2, Layers3 } from 'lucide-react';
+import { Layers3 } from 'lucide-react';
 import { useEffect, useMemo, useState } from 'react';
 
 interface ConsumerApiAccessPanelProps {
@@ -54,88 +54,68 @@ export default function ConsumerApiAccessPanel({
   };
 
   return (
-    <div className="space-y-3">
-      <section className="rounded-lg bg-white p-5">
-        <div className="flex items-start gap-3">
-          <div className="flex h-9 w-9 shrink-0 items-center justify-center rounded-md bg-[#f5f6f8] text-[#475467]">
-            <Layers3 size={17} />
-          </div>
-          <div className="min-w-0 flex-1">
-            <div className="text-[15px] font-semibold text-[#161823]">API 权限</div>
-            <div className="mt-1 text-[11px] leading-5 text-[#8a8f98]">
-              一个调用方使用同一组凭证访问多个 API，不再为每个接口重复创建 Key。
-            </div>
-          </div>
+    <section className="rounded-lg bg-white p-5">
+      <div className="flex items-center gap-3">
+        <div className="flex h-9 w-9 shrink-0 items-center justify-center rounded-md bg-[#f5f6f8] text-[#475467]">
+          <Layers3 size={17} />
         </div>
+        <div className="text-[15px] font-semibold text-[#161823]">API 权限</div>
+      </div>
 
-        <div className="mt-5 grid gap-2 md:grid-cols-2">
-          {([
-            {
-              key: 'ALL' as const,
-              title: '所有数据服务',
-              description: `自动覆盖当前项目空间的全部 ${apis.length} 个 API，也包含后续新发布的 API。`,
-            },
-            {
-              key: 'SELECTED' as const,
-              title: '指定 API',
-              description: '只允许调用明确授权的数据服务，适合第三方、合作方和最小权限场景。',
-            },
-          ]).map((item) => (
-            <button
-              key={item.key}
-              type="button"
-              onClick={() => setScope(item.key)}
-              className={[
-                'rounded-lg border border-solid px-4 py-3 text-left transition-colors',
-                scope === item.key
-                  ? 'border-[#161823] bg-[#f7f7f8]'
-                  : 'border-[#eceef1] bg-white hover:bg-[#fafafa]',
-              ].join(' ')}
-            >
+      <div className="mt-5 grid gap-2 md:grid-cols-2">
+        {([
+          { key: 'ALL' as const, title: '所有数据服务', meta: `${apis.length} 个 API` },
+          { key: 'SELECTED' as const, title: '指定 API', meta: `${apiIds.length} 个已选` },
+        ]).map((item) => (
+          <button
+            key={item.key}
+            type="button"
+            onClick={() => setScope(item.key)}
+            className={[
+              'rounded-lg border border-solid px-4 py-3 text-left transition-colors',
+              scope === item.key
+                ? 'border-[#161823] bg-[#f7f7f8]'
+                : 'border-[#eceef1] bg-white hover:bg-[#fafafa]',
+            ].join(' ')}
+          >
+            <div className="flex items-center justify-between gap-3">
               <div className="flex items-center gap-2 text-[13px] font-medium text-[#161823]">
-                <span className={[
-                  'h-2 w-2 rounded-full',
-                  scope === item.key ? 'bg-[#161823]' : 'bg-[#d0d5dd]',
-                ].join(' ')} />
+                <span
+                  className={[
+                    'h-2 w-2 rounded-full',
+                    scope === item.key ? 'bg-[#161823]' : 'bg-[#d0d5dd]',
+                  ].join(' ')}
+                />
                 {item.title}
               </div>
-              <div className="mt-1.5 text-[11px] leading-5 text-[#8a8f98]">
-                {item.description}
-              </div>
-            </button>
-          ))}
-        </div>
-
-        {scope === 'SELECTED' ? (
-          <div className="mt-5">
-            <div className="mb-2 text-[12px] font-medium text-[#475467]">可访问 API</div>
-            <Select<number[]>
-              mode="multiple"
-              value={apiIds}
-              onChange={setApiIds}
-              variant="filled"
-              options={options}
-              optionFilterProp="label"
-              placeholder="选择允许调用的数据服务"
-              className="w-full"
-              maxTagCount="responsive"
-            />
-            <div className="mt-2 text-[10px] text-[#98a2b3]">
-              当前选择 {apiIds.length} 个 API。未授权 API 即使使用有效 Key 也会被拒绝。
+              <span className="text-[10px] text-[#98a2b3]">{item.meta}</span>
             </div>
-          </div>
-        ) : null}
+          </button>
+        ))}
+      </div>
 
-        <div className="mt-5 flex items-center justify-between border-t border-solid border-[#f0f0f0] pt-4">
-          <div className="flex items-center gap-1.5 text-[10px] text-[#98a2b3]">
-            <CheckCircle2 size={12} />
-            已进入调用方访问模型的 API 会保持鉴权兜底，移除授权不会意外变成公开访问。
-          </div>
-          <YakButton loading={saving} onClick={() => void save()}>
-            保存权限
-          </YakButton>
+      {scope === 'SELECTED' ? (
+        <div className="mt-5">
+          <div className="mb-2 text-[12px] font-medium text-[#475467]">可访问 API</div>
+          <Select<number[]>
+            mode="multiple"
+            value={apiIds}
+            onChange={setApiIds}
+            variant="filled"
+            options={options}
+            optionFilterProp="label"
+            placeholder="选择允许调用的数据服务"
+            className="w-full"
+            maxTagCount="responsive"
+          />
         </div>
-      </section>
-    </div>
+      ) : null}
+
+      <div className="mt-5 flex justify-end border-t border-solid border-[#f0f0f0] pt-4">
+        <YakButton loading={saving} onClick={() => void save()}>
+          保存权限
+        </YakButton>
+      </div>
+    </section>
   );
 }

--- a/yak-ops-ui/src/pages/data-service/access/ConsumerEditor.tsx
+++ b/yak-ops-ui/src/pages/data-service/access/ConsumerEditor.tsx
@@ -1,0 +1,272 @@
+import { YakButton } from '@/components/ui';
+import { BRAND_THEME } from '@/styles/brand';
+import {
+  ConfigProvider,
+  Form,
+  Input,
+  InputNumber,
+  Switch,
+  type FormInstance,
+} from 'antd';
+import { useCallback, useEffect, useRef, useState, type ReactNode } from 'react';
+
+export interface ConsumerEditorValues {
+  name: string;
+  description?: string;
+  enabled: boolean;
+  defaultRateLimitPerMinute: number;
+}
+
+interface ConsumerEditorProps {
+  form: FormInstance<ConsumerEditorValues>;
+  editing: boolean;
+  saving: boolean;
+  onCancel: () => void;
+  onSubmit: (values: ConsumerEditorValues) => void | Promise<void>;
+}
+
+const SECTION_ITEMS = [
+  { key: 'consumer-basic', label: '基本信息' },
+  { key: 'consumer-runtime', label: '调用配置' },
+] as const;
+
+type SectionKey = (typeof SECTION_ITEMS)[number]['key'];
+
+function EditorSection({ title, children }: { title: string; children: ReactNode }) {
+  return (
+    <section className="overflow-hidden rounded-xl bg-white">
+      <header className="px-7 pt-5">
+        <h2 className="m-0 text-[17px] font-semibold leading-6 text-[#161823]">
+          {title}
+        </h2>
+      </header>
+      <div className="px-7 py-6">{children}</div>
+    </section>
+  );
+}
+
+function EditorField({
+  label,
+  required = false,
+  children,
+}: {
+  label: string;
+  required?: boolean;
+  children: ReactNode;
+}) {
+  return (
+    <div className="grid grid-cols-[116px_minmax(0,1fr)] items-start gap-5 max-md:grid-cols-1 max-md:gap-2">
+      <div className="pt-2.5 text-[13px] font-medium text-[#344054]">
+        {label}
+        {required ? <span className="ml-1 text-[var(--yak-brand-color)]">*</span> : null}
+      </div>
+      <div className="min-w-0">{children}</div>
+    </div>
+  );
+}
+
+function SectionNavigator({
+  activeKey,
+  onSelect,
+}: {
+  activeKey: SectionKey;
+  onSelect: (key: SectionKey) => void;
+}) {
+  return (
+    <nav className="rounded-xl bg-white px-3 py-4" aria-label="配置区块定位">
+      <div className="mb-3 px-2 text-[12px] font-semibold text-[#344054]">快速定位</div>
+      <div className="relative">
+        <span className="absolute bottom-4 left-[13px] top-4 w-px bg-[#e4e7ec]" aria-hidden />
+        <div className="space-y-1">
+          {SECTION_ITEMS.map((item) => {
+            const active = activeKey === item.key;
+            return (
+              <button
+                key={item.key}
+                type="button"
+                onClick={() => onSelect(item.key)}
+                className={[
+                  'group relative flex w-full cursor-pointer items-center gap-3 rounded-lg border-0 px-2 py-2 text-left transition-colors',
+                  active ? 'bg-[rgba(254,44,85,0.08)]' : 'bg-transparent hover:bg-[#f7f8fa]',
+                ].join(' ')}
+              >
+                <span
+                  className={[
+                    'relative z-10 h-[11px] w-[11px] shrink-0 rounded-full border transition-all duration-200',
+                    active
+                      ? 'border-[var(--yak-brand-color)] bg-[var(--yak-brand-color)] shadow-[0_0_0_3px_rgba(254,44,85,0.12)]'
+                      : 'border-[#d0d5dd] bg-[#98a2b3]',
+                  ].join(' ')}
+                  aria-hidden
+                />
+                <span
+                  className={[
+                    'text-[12px] leading-5 transition-colors',
+                    active
+                      ? 'font-semibold text-[var(--yak-brand-color)]'
+                      : 'font-normal text-[#667085] group-hover:text-[#344054]',
+                  ].join(' ')}
+                >
+                  {item.label}
+                </span>
+              </button>
+            );
+          })}
+        </div>
+      </div>
+    </nav>
+  );
+}
+
+export default function ConsumerEditor({
+  form,
+  editing,
+  saving,
+  onCancel,
+  onSubmit,
+}: ConsumerEditorProps) {
+  const pageRootRef = useRef<HTMLDivElement>(null);
+  const [activeSection, setActiveSection] = useState<SectionKey>('consumer-basic');
+
+  const updateActiveSection = useCallback(() => {
+    const container = pageRootRef.current;
+    if (!container) return;
+
+    const threshold = container.getBoundingClientRect().top + 120;
+    let next: SectionKey = SECTION_ITEMS[0].key;
+    SECTION_ITEMS.forEach((item) => {
+      const element = document.getElementById(item.key);
+      if (element && element.getBoundingClientRect().top <= threshold) next = item.key;
+    });
+    setActiveSection(next);
+  }, []);
+
+  useEffect(() => {
+    const container = pageRootRef.current;
+    if (!container) return undefined;
+    container.addEventListener('scroll', updateActiveSection, { passive: true });
+    updateActiveSection();
+    return () => container.removeEventListener('scroll', updateActiveSection);
+  }, [updateActiveSection]);
+
+  const locateSection = (key: SectionKey) => {
+    const container = pageRootRef.current;
+    const element = document.getElementById(key);
+    if (!container || !element) return;
+
+    const containerRect = container.getBoundingClientRect();
+    const elementRect = element.getBoundingClientRect();
+    container.scrollTo({
+      top: container.scrollTop + elementRect.top - containerRect.top - 24,
+      behavior: 'smooth',
+    });
+    setActiveSection(key);
+  };
+
+  return (
+    <ConfigProvider theme={BRAND_THEME}>
+      <div className="h-full min-h-[calc(100vh-64px)] overflow-hidden bg-[#f7f8fa] text-[#161823]">
+        <div ref={pageRootRef} className="h-full overflow-y-auto overscroll-contain scroll-smooth">
+          <div className="mx-auto grid w-full max-w-[1280px] grid-cols-1 gap-6 px-6 pb-6 pt-6 max-xl:max-w-[1040px] xl:grid-cols-[minmax(0,1fr)_160px]">
+            <div className="min-w-0">
+              <Form<ConsumerEditorValues>
+                form={form}
+                layout="vertical"
+                onFinish={(values) => void onSubmit(values)}
+              >
+                <main className="space-y-5 pb-4">
+                  <div id="consumer-basic" className="scroll-mt-6">
+                    <EditorSection title="基本信息">
+                      <div className="space-y-5">
+                        <EditorField label="调用方名称" required>
+                          <Form.Item
+                            name="name"
+                            className="!mb-0"
+                            rules={[{ required: true, message: '请输入调用方名称' }]}
+                          >
+                            <Input
+                              variant="filled"
+                              maxLength={128}
+                              showCount
+                              placeholder="请输入调用方名称"
+                            />
+                          </Form.Item>
+                        </EditorField>
+
+                        <EditorField label="说明">
+                          <Form.Item name="description" className="!mb-0">
+                            <Input.TextArea
+                              variant="filled"
+                              rows={4}
+                              maxLength={500}
+                              showCount
+                              placeholder="请输入说明"
+                            />
+                          </Form.Item>
+                        </EditorField>
+                      </div>
+                    </EditorSection>
+                  </div>
+
+                  <div id="consumer-runtime" className="scroll-mt-6">
+                    <EditorSection title="调用配置">
+                      <div className="space-y-5">
+                        <EditorField label="默认限流" required>
+                          <Form.Item
+                            name="defaultRateLimitPerMinute"
+                            className="!mb-0"
+                            rules={[{ required: true, message: '请输入调用上限' }]}
+                          >
+                            <InputNumber
+                              variant="filled"
+                              min={1}
+                              max={100000}
+                              addonAfter="次 / 分钟"
+                              className="w-full"
+                            />
+                          </Form.Item>
+                        </EditorField>
+
+                        <EditorField label="状态">
+                          <Form.Item name="enabled" valuePropName="checked" className="!mb-0">
+                            <Switch checkedChildren="可调用" unCheckedChildren="停用" />
+                          </Form.Item>
+                        </EditorField>
+                      </div>
+                    </EditorSection>
+                  </div>
+                </main>
+
+                <footer className="sticky bottom-0 z-50 overflow-hidden rounded-t-lg border border-b-0 border-[#eaecf0] bg-white shadow-[0_-8px_16px_rgba(0,0,0,0.06)]">
+                  <div className="flex min-h-[80px] items-center gap-3 px-8 py-4">
+                    <YakButton
+                      type="primary"
+                      htmlType="submit"
+                      loading={saving}
+                      className="!h-9 !min-w-[120px] !rounded-lg !px-6 !font-medium"
+                    >
+                      {editing ? '保存配置' : '创建调用方'}
+                    </YakButton>
+                    <YakButton
+                      disabled={saving}
+                      onClick={onCancel}
+                      className="!h-9 !min-w-[120px] !rounded-lg !border-0 !bg-[#f2f3f5] !px-5 !font-medium !text-[#344054] hover:!bg-[#e9eaec]"
+                    >
+                      取消
+                    </YakButton>
+                  </div>
+                </footer>
+              </Form>
+            </div>
+
+            <aside className="hidden xl:block">
+              <div className="sticky top-6">
+                <SectionNavigator activeKey={activeSection} onSelect={locateSection} />
+              </div>
+            </aside>
+          </div>
+        </div>
+      </div>
+    </ConfigProvider>
+  );
+}

--- a/yak-ops-ui/src/pages/data-service/access/ConsumerIpAccessPanel.tsx
+++ b/yak-ops-ui/src/pages/data-service/access/ConsumerIpAccessPanel.tsx
@@ -12,7 +12,7 @@ import {
 } from '@/services/data-service';
 import { DatePicker, Form, Input, Modal, Spin, Switch, message } from 'antd';
 import dayjs, { type Dayjs } from 'dayjs';
-import { Plus, Shield, Trash2, Pencil } from 'lucide-react';
+import { Pencil, Plus, Shield, Trash2 } from 'lucide-react';
 import { useCallback, useEffect, useMemo, useState } from 'react';
 
 interface ConsumerIpAccessPanelProps {
@@ -30,11 +30,10 @@ interface RuleFormValues {
 const MODES: Array<{
   key: DataServiceIpAccessMode;
   title: string;
-  description: string;
 }> = [
-  { key: 'NONE', title: '不限制', description: '该调用方不额外限制来源 IP' },
-  { key: 'ALLOWLIST', title: '白名单', description: '仅允许名单中的 IP/CIDR 使用该调用方凭证' },
-  { key: 'DENYLIST', title: '黑名单', description: '拒绝名单中的 IP/CIDR 使用该调用方凭证' },
+  { key: 'NONE', title: '不限制' },
+  { key: 'ALLOWLIST', title: '白名单' },
+  { key: 'DENYLIST', title: '黑名单' },
 ];
 
 const formatTime = (value?: string | null) =>
@@ -86,6 +85,7 @@ export default function ConsumerIpAccessPanel({
     () => rules.filter((rule) => rule.ruleType === activeList),
     [activeList, rules],
   );
+
   const activeAllow = useMemo(
     () => rules.filter((rule) => rule.ruleType === 'ALLOWLIST' && rule.enabled && !expired(rule)).length,
     [rules],
@@ -228,19 +228,17 @@ export default function ConsumerIpAccessPanel({
     );
   }
 
+  const allowCount = rules.filter((rule) => rule.ruleType === 'ALLOWLIST').length;
+  const denyCount = rules.filter((rule) => rule.ruleType === 'DENYLIST').length;
+
   return (
     <div className="space-y-3">
       <section className="rounded-lg bg-white p-5">
-        <div className="flex items-start gap-3">
+        <div className="flex items-center gap-3">
           <div className="flex h-9 w-9 shrink-0 items-center justify-center rounded-md bg-[#f5f6f8] text-[#475467]">
             <Shield size={17} />
           </div>
-          <div>
-            <div className="text-[15px] font-semibold text-[#161823]">调用方来源策略</div>
-            <div className="mt-1 text-[11px] leading-5 text-[#8a8f98]">
-              IP/CIDR 跟随调用方，而不是复制到每个 API。API 自身的来源规则仍作为更高优先级硬闸门保留。
-            </div>
-          </div>
+          <div className="text-[15px] font-semibold text-[#161823]">来源策略</div>
         </div>
 
         <div className="mt-5 grid gap-2 md:grid-cols-3">
@@ -258,13 +256,14 @@ export default function ConsumerIpAccessPanel({
               ].join(' ')}
             >
               <div className="flex items-center gap-2 text-[13px] font-medium text-[#161823]">
-                <span className={[
-                  'h-2 w-2 rounded-full',
-                  mode === item.key ? 'bg-[#161823]' : 'bg-[#d0d5dd]',
-                ].join(' ')} />
+                <span
+                  className={[
+                    'h-2 w-2 rounded-full',
+                    mode === item.key ? 'bg-[#161823]' : 'bg-[#d0d5dd]',
+                  ].join(' ')}
+                />
                 {item.title}
               </div>
-              <div className="mt-1.5 text-[11px] leading-5 text-[#8a8f98]">{item.description}</div>
             </button>
           ))}
         </div>
@@ -272,10 +271,7 @@ export default function ConsumerIpAccessPanel({
 
       <section className="rounded-lg bg-white">
         <div className="flex items-center justify-between gap-4 px-5 pt-4">
-          <div>
-            <div className="text-[15px] font-semibold text-[#161823]">黑白名单</div>
-            <div className="mt-1 text-[11px] text-[#8a8f98]">支持单 IP、IPv4/IPv6 CIDR、有效期和单规则启停。</div>
-          </div>
+          <div className="text-[15px] font-semibold text-[#161823]">黑白名单</div>
           <YakButton icon={<Plus size={14} />} onClick={openCreate}>添加规则</YakButton>
         </div>
         <div className="px-5">
@@ -283,8 +279,8 @@ export default function ConsumerIpAccessPanel({
             activeKey={activeList}
             onChange={(key) => setActiveList(key as DataServiceIpAccessRuleType)}
             items={[
-              { key: 'ALLOWLIST', label: `白名单 ${rules.filter((rule) => rule.ruleType === 'ALLOWLIST').length}` },
-              { key: 'DENYLIST', label: `黑名单 ${rules.filter((rule) => rule.ruleType === 'DENYLIST').length}` },
+              { key: 'ALLOWLIST', label: `白名单 ${allowCount}` },
+              { key: 'DENYLIST', label: `黑名单 ${denyCount}` },
             ]}
           />
         </div>
@@ -305,20 +301,28 @@ export default function ConsumerIpAccessPanel({
                   </div>
                   <div className="truncate text-[12px] text-[#667085]">{rule.description || '—'}</div>
                   <div className="text-[11px] text-[#667085]">{formatTime(rule.expiresAt)}</div>
-                  <Switch size="small" checked={rule.enabled} loading={busyId === rule.id} onChange={(checked) => void toggle(rule, checked)} />
+                  <Switch
+                    size="small"
+                    checked={rule.enabled}
+                    loading={busyId === rule.id}
+                    onChange={(checked) => void toggle(rule, checked)}
+                  />
                   <div className="flex justify-end gap-1">
                     <YakButton type="text" iconOnly icon={<Pencil size={14} />} onClick={() => openEdit(rule)} />
-                    <YakButton type="text" danger iconOnly icon={<Trash2 size={14} />} loading={busyId === rule.id} onClick={() => remove(rule)} />
+                    <YakButton
+                      type="text"
+                      danger
+                      iconOnly
+                      icon={<Trash2 size={14} />}
+                      loading={busyId === rule.id}
+                      onClick={() => remove(rule)}
+                    />
                   </div>
                 </div>
               ))}
             </div>
           ) : (
-            <YakEmpty
-              compact
-              title={activeList === 'ALLOWLIST' ? '暂无白名单规则' : '暂无黑名单规则'}
-              description="添加 IP 或 CIDR 后，再启用对应来源策略。"
-            />
+            <YakEmpty compact title={activeList === 'ALLOWLIST' ? '暂无白名单规则' : '暂无黑名单规则'} />
           )}
         </div>
       </section>

--- a/yak-ops-ui/src/pages/data-service/access/index.tsx
+++ b/yak-ops-ui/src/pages/data-service/access/index.tsx
@@ -13,41 +13,30 @@ import {
   Drawer,
   Form,
   Input,
-  InputNumber,
   Modal,
   Select,
-  Switch,
   Table,
   message,
   type TableColumnsType,
 } from 'antd';
 import {
-  KeyRound,
-  Network,
   Pencil,
   Plus,
   RefreshCw,
   Search,
   Settings2,
-  ShieldCheck,
   Trash2,
   Users,
 } from 'lucide-react';
 import { useCallback, useEffect, useMemo, useState } from 'react';
 
 import ConsumerApiAccessPanel from './ConsumerApiAccessPanel';
+import ConsumerEditor, { type ConsumerEditorValues } from './ConsumerEditor';
 import ConsumerIpAccessPanel from './ConsumerIpAccessPanel';
 import ConsumerKeyPanel from './ConsumerKeyPanel';
 
 type StatusFilter = 'ALL' | 'ENABLED' | 'DISABLED';
 type DrawerTab = 'OVERVIEW' | 'KEYS' | 'APIS' | 'IP';
-
-interface ConsumerFormValues {
-  name: string;
-  description?: string;
-  enabled: boolean;
-  defaultRateLimitPerMinute: number;
-}
 
 const formatTime = (value?: string | null) =>
   value ? value.replace('T', ' ').slice(0, 19) : '-';
@@ -58,16 +47,15 @@ const ipModeLabel = {
   DENYLIST: '黑名单',
 } as const;
 
-const Metric = ({ label, value, note }: { label: string; value: number; note: string }) => (
+const Metric = ({ label, value }: { label: string; value: number }) => (
   <div className="min-w-0 px-4 py-3">
     <div className="text-[11px] text-[#98a2b3]">{label}</div>
     <div className="mt-1 text-[20px] font-semibold tracking-[-.02em] text-[#161823]">{value}</div>
-    <div className="mt-0.5 truncate text-[10px] text-[#a0a5ad]">{note}</div>
   </div>
 );
 
 export default function DataServiceAccessPage() {
-  const [form] = Form.useForm<ConsumerFormValues>();
+  const [form] = Form.useForm<ConsumerEditorValues>();
   const [records, setRecords] = useState<DataServiceConsumer[]>([]);
   const [apis, setApis] = useState<DataServiceAccessOverviewItem[]>([]);
   const [loading, setLoading] = useState(false);
@@ -75,7 +63,7 @@ export default function DataServiceAccessPage() {
   const [statusFilter, setStatusFilter] = useState<StatusFilter>('ALL');
   const [selected, setSelected] = useState<DataServiceConsumer>();
   const [drawerTab, setDrawerTab] = useState<DrawerTab>('OVERVIEW');
-  const [formOpen, setFormOpen] = useState(false);
+  const [editorOpen, setEditorOpen] = useState(false);
   const [editing, setEditing] = useState<DataServiceConsumer>();
   const [saving, setSaving] = useState(false);
 
@@ -131,7 +119,7 @@ export default function DataServiceAccessPage() {
     setEditing(undefined);
     form.resetFields();
     form.setFieldsValue({ enabled: true, defaultRateLimitPerMinute: 60 });
-    setFormOpen(true);
+    setEditorOpen(true);
   };
 
   const openEdit = (consumer: DataServiceConsumer) => {
@@ -142,17 +130,17 @@ export default function DataServiceAccessPage() {
       enabled: consumer.enabled,
       defaultRateLimitPerMinute: consumer.defaultRateLimitPerMinute,
     });
-    setFormOpen(true);
+    setEditorOpen(true);
   };
 
-  const closeForm = () => {
+  const closeEditor = () => {
     if (saving) return;
-    setFormOpen(false);
+    setEditorOpen(false);
     setEditing(undefined);
     form.resetFields();
   };
 
-  const submitConsumer = async (values: ConsumerFormValues) => {
+  const submitConsumer = async (values: ConsumerEditorValues) => {
     setSaving(true);
     try {
       const payload = {
@@ -171,9 +159,11 @@ export default function DataServiceAccessPage() {
         setRecords((current) => [next, ...current]);
         setSelected(next);
         setDrawerTab('APIS');
-        message.success('调用方已创建，请继续配置 API 权限和凭证');
+        message.success('调用方已创建');
       }
-      closeForm();
+      setEditorOpen(false);
+      setEditing(undefined);
+      form.resetFields();
     } catch (error: any) {
       message.error(error?.message || (editing ? '更新调用方失败' : '创建调用方失败'));
     } finally {
@@ -201,6 +191,18 @@ export default function DataServiceAccessPage() {
     });
   };
 
+  if (editorOpen) {
+    return (
+      <ConsumerEditor
+        form={form}
+        editing={Boolean(editing)}
+        saving={saving}
+        onCancel={closeEditor}
+        onSubmit={submitConsumer}
+      />
+    );
+  }
+
   const columns: TableColumnsType<DataServiceConsumer> = [
     {
       title: '调用方',
@@ -209,9 +211,9 @@ export default function DataServiceAccessPage() {
       render: (_, record) => (
         <div className="min-w-0 py-0.5">
           <div className="truncate text-[12px] font-medium text-[#344054]">{record.name}</div>
-          <div className="mt-0.5 truncate text-[10px] text-[#98a2b3]">
-            {record.description || '未填写说明'}
-          </div>
+          {record.description ? (
+            <div className="mt-0.5 truncate text-[10px] text-[#98a2b3]">{record.description}</div>
+          ) : null}
         </div>
       ),
     },
@@ -220,13 +222,8 @@ export default function DataServiceAccessPage() {
       key: 'apis',
       width: 150,
       render: (_, record) => (
-        <div>
-          <div className="text-[11px] font-medium text-[#475467]">
-            {record.accessScope === 'ALL' ? '所有 API' : `${record.apiCount} 个 API`}
-          </div>
-          <div className="mt-0.5 text-[10px] text-[#98a2b3]">
-            {record.accessScope === 'ALL' ? '自动包含新发布 API' : '最小权限授权'}
-          </div>
+        <div className="text-[11px] font-medium text-[#475467]">
+          {record.accessScope === 'ALL' ? '所有 API' : `${record.apiCount} 个 API`}
         </div>
       ),
     },
@@ -248,7 +245,9 @@ export default function DataServiceAccessPage() {
       render: (_, record) => (
         <div>
           <div className="text-[11px] font-medium text-[#475467]">{ipModeLabel[record.ipAccessMode]}</div>
-          <div className="mt-0.5 text-[10px] text-[#98a2b3]">{record.ipRuleCount} 条规则</div>
+          {record.ipRuleCount > 0 ? (
+            <div className="mt-0.5 text-[10px] text-[#98a2b3]">{record.ipRuleCount} 条规则</div>
+          ) : null}
         </div>
       ),
     },
@@ -293,15 +292,16 @@ export default function DataServiceAccessPage() {
   return (
     <div className="h-full overflow-y-auto bg-[#f6f7f8] p-3">
       <div className="min-h-full rounded-[10px] bg-white px-5 pb-5 pt-4">
-        <div className="flex flex-wrap items-start justify-between gap-3">
-          <div>
-            <h1 className="m-0 text-[17px] font-semibold text-[#161823]">API 调用</h1>
-            <div className="mt-1 text-[12px] text-[#98a2b3]">
-              以调用方为中心管理 API Key、API 权限、调用配额与 IP/CIDR 来源策略
-            </div>
-          </div>
+        <div className="flex flex-wrap items-center justify-between gap-3">
+          <h1 className="m-0 text-[17px] font-semibold text-[#161823]">API 调用</h1>
           <div className="flex gap-2">
-            <YakButton type="text" icon={<RefreshCw size={14} />} loading={loading} onClick={() => void load()} className="bg-[#f5f6f7]">
+            <YakButton
+              type="text"
+              icon={<RefreshCw size={14} />}
+              loading={loading}
+              onClick={() => void load()}
+              className="bg-[#f5f6f7]"
+            >
               刷新
             </YakButton>
             <YakButton icon={<Plus size={14} />} onClick={openCreate}>新建调用方</YakButton>
@@ -311,10 +311,10 @@ export default function DataServiceAccessPage() {
         <div className="my-4 border-t border-[#f0f0f0]" />
 
         <div className="grid grid-cols-2 divide-x divide-[#f0f0f0] rounded-[8px] bg-[#f8f9fa] md:grid-cols-4">
-          <Metric label="调用方" value={metrics.total} note="当前项目空间" />
-          <Metric label="有效凭证" value={metrics.credentials} note="可用 API Key" />
-          <Metric label="全部 API" value={metrics.allAccess} note="自动继承新发布 API" />
-          <Metric label="来源限制" value={metrics.network} note="启用黑/白名单" />
+          <Metric label="调用方" value={metrics.total} />
+          <Metric label="有效凭证" value={metrics.credentials} />
+          <Metric label="全部 API" value={metrics.allAccess} />
+          <Metric label="来源限制" value={metrics.network} />
         </div>
 
         <div className="mt-4 flex flex-wrap items-center gap-2">
@@ -324,7 +324,7 @@ export default function DataServiceAccessPage() {
             allowClear
             variant="filled"
             prefix={<Search size={13} className="text-[#98a2b3]" />}
-            placeholder="搜索调用方名称或说明"
+            placeholder="搜索调用方"
             className="w-[300px]"
           />
           <Select<StatusFilter>
@@ -349,16 +349,13 @@ export default function DataServiceAccessPage() {
             columns={columns}
             dataSource={filtered}
             scroll={{ x: 1050 }}
-            pagination={{ pageSize: 10, showSizeChanger: true, pageSizeOptions: [10, 20, 50], showTotal: (total) => `共 ${total} 条` }}
-            locale={{
-              emptyText: (
-                <YakEmpty
-                  compact
-                  title="暂无调用方"
-                  description="创建调用方后，一组 API Key 就可以按权限访问多个数据服务，不再逐个接口重复配置。"
-                />
-              ),
+            pagination={{
+              pageSize: 10,
+              showSizeChanger: true,
+              pageSizeOptions: [10, 20, 50],
+              showTotal: (total) => `共 ${total} 条`,
             }}
+            locale={{ emptyText: <YakEmpty compact title="暂无调用方" /> }}
             className="[&_.ant-table-container]:!border-t [&_.ant-table-container]:!border-[#f0f0f0] [&_.ant-table-thead>tr>th]:!bg-[#fafafa] [&_.ant-table-thead>tr>th]:!text-[11px] [&_.ant-table-tbody>tr>td]:!py-3"
           />
         </div>
@@ -369,13 +366,7 @@ export default function DataServiceAccessPage() {
         width={960}
         onClose={() => setSelected(undefined)}
         title={selected ? (
-          <div className="min-w-0">
-            <div className="truncate text-[14px] font-semibold text-[#161823]">{selected.name}</div>
-            <div className="mt-0.5 truncate text-[10px] font-normal text-[#98a2b3]">
-              {selected.accessScope === 'ALL' ? '可访问所有数据服务' : `已授权 ${selected.apiCount} 个 API`}
-              {' · '}{selected.activeKeyCount} 个有效 Key
-            </div>
-          </div>
+          <div className="truncate text-[14px] font-semibold text-[#161823]">{selected.name}</div>
         ) : 'API 调用'}
       >
         {selected ? (
@@ -397,39 +388,42 @@ export default function DataServiceAccessPage() {
                   <section className="rounded-lg bg-white p-5">
                     <div className="flex items-start justify-between gap-4">
                       <div className="flex items-start gap-3">
-                        <div className="flex h-9 w-9 items-center justify-center rounded-md bg-[#f5f6f8] text-[#475467]"><Users size={17} /></div>
+                        <div className="flex h-9 w-9 items-center justify-center rounded-md bg-[#f5f6f8] text-[#475467]">
+                          <Users size={17} />
+                        </div>
                         <div>
                           <div className="text-[15px] font-semibold text-[#161823]">{selected.name}</div>
-                          <div className="mt-1 text-[11px] leading-5 text-[#8a8f98]">{selected.description || '未填写调用方说明'}</div>
+                          {selected.description ? (
+                            <div className="mt-1 text-[11px] leading-5 text-[#8a8f98]">{selected.description}</div>
+                          ) : null}
                         </div>
                       </div>
                       <YakButton type="text" icon={<Pencil size={14} />} onClick={() => openEdit(selected)}>编辑</YakButton>
                     </div>
                     <div className="mt-5 grid gap-2 sm:grid-cols-2 xl:grid-cols-4">
-                      <div className="rounded-lg bg-[#f7f7f8] p-3"><div className="text-[10px] text-[#98a2b3]">API 权限</div><div className="mt-1 text-[13px] font-medium text-[#344054]">{selected.accessScope === 'ALL' ? '所有 API' : `${selected.apiCount} 个 API`}</div></div>
-                      <div className="rounded-lg bg-[#f7f7f8] p-3"><div className="text-[10px] text-[#98a2b3]">有效凭证</div><div className="mt-1 text-[13px] font-medium text-[#344054]">{selected.activeKeyCount}/{selected.keyCount}</div></div>
-                      <div className="rounded-lg bg-[#f7f7f8] p-3"><div className="text-[10px] text-[#98a2b3]">默认限流</div><div className="mt-1 text-[13px] font-medium text-[#344054]">{selected.defaultRateLimitPerMinute}/min</div></div>
-                      <div className="rounded-lg bg-[#f7f7f8] p-3"><div className="text-[10px] text-[#98a2b3]">来源策略</div><div className="mt-1 text-[13px] font-medium text-[#344054]">{ipModeLabel[selected.ipAccessMode]}</div></div>
-                    </div>
-                  </section>
-
-                  <section className="rounded-lg bg-white p-5">
-                    <div className="flex items-center gap-2 text-[12px] font-medium text-[#344054]"><ShieldCheck size={14} /> 调用链路</div>
-                    <div className="mt-3 flex flex-wrap items-center gap-2 text-[11px] text-[#667085]">
-                      <span className="rounded-md bg-[#f5f6f8] px-2.5 py-1.5">API 硬闸门</span>
-                      <span>→</span>
-                      <span className="rounded-md bg-[#f5f6f8] px-2.5 py-1.5">调用方 API Key</span>
-                      <span>→</span>
-                      <span className="rounded-md bg-[#f5f6f8] px-2.5 py-1.5">API 权限</span>
-                      <span>→</span>
-                      <span className="rounded-md bg-[#f5f6f8] px-2.5 py-1.5">调用方 IP/CIDR</span>
-                      <span>→</span>
-                      <span className="rounded-md bg-[#f5f6f8] px-2.5 py-1.5">Key 限流</span>
+                      <div className="rounded-lg bg-[#f7f7f8] p-3">
+                        <div className="text-[10px] text-[#98a2b3]">API 权限</div>
+                        <div className="mt-1 text-[13px] font-medium text-[#344054]">{selected.accessScope === 'ALL' ? '所有 API' : `${selected.apiCount} 个 API`}</div>
+                      </div>
+                      <div className="rounded-lg bg-[#f7f7f8] p-3">
+                        <div className="text-[10px] text-[#98a2b3]">有效凭证</div>
+                        <div className="mt-1 text-[13px] font-medium text-[#344054]">{selected.activeKeyCount}/{selected.keyCount}</div>
+                      </div>
+                      <div className="rounded-lg bg-[#f7f7f8] p-3">
+                        <div className="text-[10px] text-[#98a2b3]">默认限流</div>
+                        <div className="mt-1 text-[13px] font-medium text-[#344054]">{selected.defaultRateLimitPerMinute}/min</div>
+                      </div>
+                      <div className="rounded-lg bg-[#f7f7f8] p-3">
+                        <div className="text-[10px] text-[#98a2b3]">来源策略</div>
+                        <div className="mt-1 text-[13px] font-medium text-[#344054]">{ipModeLabel[selected.ipAccessMode]}</div>
+                      </div>
                     </div>
                   </section>
 
                   <div className="flex justify-end">
-                    <YakButton type="text" danger icon={<Trash2 size={14} />} onClick={() => removeConsumer(selected)}>删除调用方</YakButton>
+                    <YakButton type="text" danger icon={<Trash2 size={14} />} onClick={() => removeConsumer(selected)}>
+                      删除调用方
+                    </YakButton>
                   </div>
                 </div>
               ) : drawerTab === 'KEYS' ? (
@@ -450,32 +444,6 @@ export default function DataServiceAccessPage() {
           </div>
         ) : null}
       </Drawer>
-
-      <Modal
-        title={editing ? '编辑调用方' : '新建调用方'}
-        open={formOpen}
-        onCancel={closeForm}
-        onOk={() => form.submit()}
-        confirmLoading={saving}
-        okText={editing ? '保存' : '创建'}
-        cancelText="取消"
-        destroyOnClose
-      >
-        <Form<ConsumerFormValues> form={form} layout="vertical" onFinish={(values) => void submitConsumer(values)}>
-          <Form.Item name="name" label="调用方名称" rules={[{ required: true, message: '请输入调用方名称' }]}>
-            <Input variant="filled" placeholder="例如：BI 系统 / 数据中台 / 合作方" maxLength={128} />
-          </Form.Item>
-          <Form.Item name="description" label="说明">
-            <Input.TextArea variant="filled" rows={3} placeholder="说明调用方用途、负责人或接入系统" maxLength={500} />
-          </Form.Item>
-          <Form.Item name="defaultRateLimitPerMinute" label="新 Key 默认每分钟调用上限" rules={[{ required: true, message: '请输入调用上限' }]}>
-            <InputNumber variant="filled" min={1} max={100000} className="w-full" />
-          </Form.Item>
-          <Form.Item name="enabled" label="状态" valuePropName="checked">
-            <Switch checkedChildren="可调用" unCheckedChildren="停用" />
-          </Form.Item>
-        </Form>
-      </Modal>
     </div>
   );
 }


### PR DESCRIPTION
## Summary

Refactor the Data Service caller UI, focusing on the create/edit experience and reducing unnecessary explanatory copy.

## Changes

- Replace the caller create/edit modal with a full-page editor that follows the offline-sync editor layout:
  - centered configuration canvas
  - section cards
  - right-side quick navigation
  - sticky bottom action bar
  - filled form controls
  - YakButton actions
- Reuse the same editor for both creating and editing callers.
- Keep the existing caller-management drawer for API Key / API permission / source policy operations.
- Simplify the API 调用 list and caller overview by removing secondary descriptions that do not help the operation flow.
- Simplify API permission and source-policy panels while keeping important safety warnings, such as enabling an empty allowlist.

## Scope

Frontend only. No backend contract or database changes.

## Verification

- [x] Changes are limited to `yak-ops-ui/src/pages/data-service/access`
- [x] Existing consumer service APIs are reused unchanged
- [x] TypeScript syntax check passed; only unresolved dependency/import errors are expected outside the repository workspace
- [x] GitHub reports the PR as mergeable against current `main`
- [ ] GitHub CI / frontend build (no workflow run detected yet)
- [ ] Manual browser smoke test
