### PR TITLE
feat(ui): add YakStatusIcon semantic SVG status system

### DIFF
--- a/yak-ops-ui/src/components/YakStatusIcon/index.less
+++ b/yak-ops-ui/src/components/YakStatusIcon/index.less
@@ -59,11 +59,6 @@
     opacity: 0.94;
   }
 
-  .yak-status-icon__core-glint {
-    fill: #fff;
-    opacity: 0.42;
-  }
-
   .yak-status-icon__dot {
     opacity: 0.5;
   }

--- a/yak-ops-ui/src/components/YakStatusIcon/index.less
+++ b/yak-ops-ui/src/components/YakStatusIcon/index.less
@@ -1,0 +1,151 @@
+.yak-status-icon {
+  display: inline-block;
+  flex: none;
+  overflow: visible;
+  vertical-align: -0.125em;
+
+  color: var(--yak-status-color, #98a2b3);
+
+  .yak-status-icon__surface {
+    fill: currentColor;
+    fill-opacity: 0.075;
+    stroke: currentColor;
+    stroke-opacity: 0.34;
+    stroke-width: 1.15;
+  }
+
+  .yak-status-icon__surface--soft {
+    fill-opacity: 0.055;
+    stroke-opacity: 0.2;
+  }
+
+  .yak-status-icon__symbol,
+  .yak-status-icon__orbit-line {
+    fill: none;
+    stroke: currentColor;
+    stroke-linecap: round;
+    stroke-linejoin: round;
+  }
+
+  .yak-status-icon__symbol {
+    stroke-width: 1.85;
+  }
+
+  .yak-status-icon__symbol-dot,
+  .yak-status-icon__dot,
+  .yak-status-icon__orbit-node,
+  .yak-status-icon__core {
+    fill: currentColor;
+  }
+
+  .yak-status-icon__orbit {
+    transform-origin: 12px 12px;
+  }
+
+  .yak-status-icon__orbit-line {
+    stroke-width: 1.25;
+    stroke-opacity: 0.72;
+  }
+
+  .yak-status-icon__orbit-node {
+    opacity: 0.92;
+  }
+
+  .yak-status-icon__orbit-node--minor {
+    opacity: 0.58;
+  }
+
+  .yak-status-icon__core {
+    opacity: 0.94;
+  }
+
+  .yak-status-icon__core-glint {
+    fill: #fff;
+    opacity: 0.42;
+  }
+
+  .yak-status-icon__dot {
+    opacity: 0.5;
+  }
+}
+
+.yak-status-icon--success {
+  --yak-status-color: var(--yak-status-success-color, #16a34a);
+}
+
+.yak-status-icon--failed {
+  --yak-status-color: var(--yak-status-failed-color, #d92d20);
+}
+
+.yak-status-icon--running {
+  --yak-status-color: var(--yak-status-running-color, #6675f5);
+}
+
+.yak-status-icon--pending {
+  --yak-status-color: var(--yak-status-pending-color, #7c8494);
+}
+
+.yak-status-icon--warning {
+  --yak-status-color: var(--yak-status-warning-color, #d97706);
+}
+
+.yak-status-icon--paused {
+  --yak-status-color: var(--yak-status-paused-color, #667085);
+}
+
+.yak-status-icon--canceled {
+  --yak-status-color: var(--yak-status-canceled-color, #8b93a1);
+}
+
+.yak-status-icon--unknown {
+  --yak-status-color: var(--yak-status-unknown-color, #98a2b3);
+}
+
+.yak-status-icon--animated {
+  .yak-status-icon__orbit {
+    animation: yak-status-orbit 1.8s linear infinite;
+  }
+
+  .yak-status-icon__dot {
+    animation: yak-status-dot 1.35s ease-in-out infinite;
+  }
+
+  .yak-status-icon__dot--2 {
+    animation-delay: 140ms;
+  }
+
+  .yak-status-icon__dot--3 {
+    animation-delay: 280ms;
+  }
+}
+
+@keyframes yak-status-orbit {
+  from {
+    transform: rotate(0deg);
+  }
+
+  to {
+    transform: rotate(360deg);
+  }
+}
+
+@keyframes yak-status-dot {
+  0%,
+  70%,
+  100% {
+    opacity: 0.35;
+  }
+
+  35% {
+    opacity: 1;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .yak-status-icon--animated {
+    .yak-status-icon__orbit,
+    .yak-status-icon__dot {
+      animation: none;
+    }
+  }
+}

--- a/yak-ops-ui/src/components/YakStatusIcon/index.test.tsx
+++ b/yak-ops-ui/src/components/YakStatusIcon/index.test.tsx
@@ -1,0 +1,52 @@
+import { render, screen } from '@testing-library/react';
+
+import YakStatusIcon, { type YakStatus, YAK_STATUS_VALUES } from './index';
+
+describe('YakStatusIcon', () => {
+  it.each(YAK_STATUS_VALUES)('renders the %s semantic status', (status) => {
+    const { container } = render(<YakStatusIcon status={status} />);
+    const icon = container.querySelector('svg');
+
+    expect(icon).toHaveClass(
+      'yak-status-icon',
+      `yak-status-icon--${status}`,
+      'yak-status-icon--animated',
+    );
+    expect(icon).toHaveAttribute('data-status', status);
+    expect(icon).toHaveAttribute('width', '18');
+    expect(icon).toHaveAttribute('height', '18');
+    expect(icon).toHaveAttribute('aria-hidden', 'true');
+  });
+
+  it('supports size, className and disabling motion', () => {
+    const { container } = render(
+      <YakStatusIcon
+        status="running"
+        size={24}
+        animated={false}
+        className="workflow-status-icon"
+      />,
+    );
+    const icon = container.querySelector('svg');
+
+    expect(icon).toHaveClass('workflow-status-icon');
+    expect(icon).not.toHaveClass('yak-status-icon--animated');
+    expect(icon).toHaveAttribute('data-animated', 'false');
+    expect(icon).toHaveAttribute('width', '24');
+    expect(icon).toHaveAttribute('height', '24');
+  });
+
+  it('exposes an accessible name when title is provided', () => {
+    render(<YakStatusIcon status="failed" title="任务执行失败" />);
+
+    expect(screen.getByRole('img', { name: '任务执行失败' })).toBeInTheDocument();
+  });
+
+  it('keeps the public status type business-agnostic', () => {
+    const status: YakStatus = 'success';
+
+    expect(status).toBe('success');
+    expect(YAK_STATUS_VALUES).not.toContain('COMPLETED');
+    expect(YAK_STATUS_VALUES).not.toContain('SYNC_SUCCESS');
+  });
+});

--- a/yak-ops-ui/src/components/YakStatusIcon/index.tsx
+++ b/yak-ops-ui/src/components/YakStatusIcon/index.tsx
@@ -1,0 +1,168 @@
+import type { SVGProps } from 'react';
+
+import './index.less';
+
+export const YAK_STATUS_VALUES = [
+  'success',
+  'failed',
+  'running',
+  'pending',
+  'warning',
+  'paused',
+  'canceled',
+  'unknown',
+] as const;
+
+export type YakStatus = (typeof YAK_STATUS_VALUES)[number];
+
+export type YakStatusIconProps = Omit<
+  SVGProps<SVGSVGElement>,
+  'children' | 'height' | 'width'
+> & {
+  /** Business-agnostic semantic status rendered by the icon. */
+  status: YakStatus;
+  /** Icon size in pixels. */
+  size?: number;
+  /** Enables subtle motion for active states such as running and pending. */
+  animated?: boolean;
+  /** Optional accessible title. Decorative icons are hidden from assistive tech. */
+  title?: string;
+};
+
+const BLOB_PATH =
+  'M12.08 4.25c4.55 0 7.67 2.58 7.67 6.92 0 4.93-2.89 8.58-7.9 8.58-4.69 0-7.6-3.04-7.6-7.62 0-4.61 2.87-7.88 7.83-7.88Z';
+
+function StaticSurface() {
+  return <path className="yak-status-icon__surface" d={BLOB_PATH} />;
+}
+
+function StatusGlyph({ status }: { status: YakStatus }) {
+  switch (status) {
+    case 'success':
+      return (
+        <>
+          <StaticSurface />
+          <path
+            className="yak-status-icon__symbol"
+            d="m8.15 12.1 2.38 2.4 5.36-5.55"
+          />
+        </>
+      );
+    case 'failed':
+      return (
+        <>
+          <StaticSurface />
+          <path
+            className="yak-status-icon__symbol"
+            d="m9.08 9.08 5.84 5.84m0-5.84-5.84 5.84"
+          />
+        </>
+      );
+    case 'running':
+      return (
+        <>
+          <path className="yak-status-icon__surface yak-status-icon__surface--soft" d={BLOB_PATH} />
+          <g className="yak-status-icon__orbit">
+            <path
+              className="yak-status-icon__orbit-line"
+              d="M4.55 10.55c.6-3.23 3.19-5.72 6.45-6.1"
+            />
+            <path
+              className="yak-status-icon__orbit-line"
+              d="M19.45 13.45c-.6 3.23-3.19 5.72-6.45 6.1"
+            />
+            <circle className="yak-status-icon__orbit-node" cx="17.45" cy="7.15" r="1.05" />
+            <circle className="yak-status-icon__orbit-node yak-status-icon__orbit-node--minor" cx="6.35" cy="16.9" r="0.72" />
+          </g>
+          <circle className="yak-status-icon__core" cx="12" cy="12" r="3.15" />
+          <circle className="yak-status-icon__core-glint" cx="11.15" cy="11.05" r="0.72" />
+        </>
+      );
+    case 'pending':
+      return (
+        <>
+          <StaticSurface />
+          <g className="yak-status-icon__dots">
+            <circle className="yak-status-icon__dot yak-status-icon__dot--1" cx="8.7" cy="12" r="1" />
+            <circle className="yak-status-icon__dot yak-status-icon__dot--2" cx="12" cy="12" r="1" />
+            <circle className="yak-status-icon__dot yak-status-icon__dot--3" cx="15.3" cy="12" r="1" />
+          </g>
+        </>
+      );
+    case 'warning':
+      return (
+        <>
+          <StaticSurface />
+          <path className="yak-status-icon__symbol" d="M12 8.35v4.75" />
+          <circle className="yak-status-icon__symbol-dot" cx="12" cy="15.75" r="1" />
+        </>
+      );
+    case 'paused':
+      return (
+        <>
+          <StaticSurface />
+          <path className="yak-status-icon__symbol" d="M10 9.05v5.9m4-5.9v5.9" />
+        </>
+      );
+    case 'canceled':
+      return (
+        <>
+          <StaticSurface />
+          <path className="yak-status-icon__symbol" d="m8.2 15.8 7.6-7.6" />
+        </>
+      );
+    case 'unknown':
+      return (
+        <>
+          <StaticSurface />
+          <path
+            className="yak-status-icon__symbol"
+            d="M9.65 9.7a2.55 2.55 0 0 1 4.91.95c0 1.85-2.56 1.94-2.56 3.18"
+          />
+          <circle className="yak-status-icon__symbol-dot" cx="12" cy="16.15" r="0.9" />
+        </>
+      );
+  }
+}
+
+export default function YakStatusIcon({
+  status,
+  size = 18,
+  animated = true,
+  className,
+  title,
+  'aria-label': ariaLabel,
+  'aria-labelledby': ariaLabelledby,
+  ...svgProps
+}: YakStatusIconProps) {
+  const accessibleLabel = ariaLabel ?? (ariaLabelledby ? undefined : title);
+  const isAccessible = Boolean(accessibleLabel || ariaLabelledby);
+
+  return (
+    <svg
+      {...svgProps}
+      className={[
+        'yak-status-icon',
+        `yak-status-icon--${status}`,
+        animated ? 'yak-status-icon--animated' : '',
+        className,
+      ]
+        .filter(Boolean)
+        .join(' ')}
+      width={size}
+      height={size}
+      viewBox="0 0 24 24"
+      fill="none"
+      focusable="false"
+      data-status={status}
+      data-animated={animated ? 'true' : 'false'}
+      role={isAccessible ? 'img' : undefined}
+      aria-label={accessibleLabel}
+      aria-labelledby={ariaLabelledby}
+      aria-hidden={isAccessible ? undefined : true}
+    >
+      {title ? <title>{title}</title> : null}
+      <StatusGlyph status={status} />
+    </svg>
+  );
+}

--- a/yak-ops-ui/src/components/YakStatusIcon/index.tsx
+++ b/yak-ops-ui/src/components/YakStatusIcon/index.tsx
@@ -75,7 +75,6 @@ function StatusGlyph({ status }: { status: YakStatus }) {
             <circle className="yak-status-icon__orbit-node yak-status-icon__orbit-node--minor" cx="6.35" cy="16.9" r="0.72" />
           </g>
           <circle className="yak-status-icon__core" cx="12" cy="12" r="3.15" />
-          <circle className="yak-status-icon__core-glint" cx="11.15" cy="11.05" r="0.72" />
         </>
       );
     case 'pending':

--- a/yak-ops-ui/src/components/ui/index.ts
+++ b/yak-ops-ui/src/components/ui/index.ts
@@ -6,5 +6,7 @@ export type {
   YakFilterSwitchOption,
   YakFilterSwitchProps,
 } from '../YakFilterSwitch';
+export { default as YakStatusIcon, YAK_STATUS_VALUES } from '../YakStatusIcon';
+export type { YakStatus, YakStatusIconProps } from '../YakStatusIcon';
 export { default as YakTab } from '../YakTab';
 export type { YakTabProps } from '../YakTab';


### PR DESCRIPTION
## Summary

Add a reusable `YakStatusIcon` to establish a consistent Yak Ops status visual language before migrating existing business pages.

### Included

- Add 8 business-agnostic semantic statuses: `success`, `failed`, `running`, `pending`, `warning`, `paused`, `canceled`, `unknown`
- Use original Yak SVG geometry with a soft organic core instead of depending on Lucide/Ant status glyphs
- Add restrained active-state motion:
  - `running`: incomplete orbit rotates around the status core
  - `pending`: three dots pulse with a small stagger
- Keep terminal states static to avoid excessive motion
- Use `currentColor` for SVG rendering with centralized CSS custom-property fallbacks for semantic colors
- Respect `prefers-reduced-motion`
- Support decorative and accessible usage (`title` / ARIA)
- Export through the stable `@/components/ui` Yak Design System entry
- Add Jest coverage for all semantic statuses, sizing, animation opt-out, and accessibility

## Design note

The state-driven SVG/motion approach is inspired by `jeremy-prt/bloub`, but this implementation does **not** copy upstream SVG paths/assets. The geometry and Yak status semantics are original so Yak Ops can build its own visual identity.

## Scope

This PR intentionally **does not replace status icons in existing business pages yet**. It only lands the shared primitive so page migrations can be reviewed incrementally afterward.

## Validation

- Added focused Jest tests for `YakStatusIcon`
- Diff is limited to the new component and the `components/ui` export
- Local full `npm test` / `npm run lint` could not be executed in the current connector environment; CI can provide the repository-level validation
