### PR TITLE
feat(workflow): show instance creator

### DIFF
--- a/yak-ops-business/yak-ops-business-audit/src/main/java/io/yak/ops/business/audit/AuditQueryService.java
+++ b/yak-ops-business/yak-ops-business-audit/src/main/java/io/yak/ops/business/audit/AuditQueryService.java
@@ -1,8 +1,10 @@
 package io.yak.ops.business.audit;
 
+import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 
-/** Read-side contract consumed by the administrator Audit Center. */
+/** Read-side contract consumed by Audit Center and business attribution views. */
 public interface AuditQueryService {
 
   AuditPage<AuditOperationSummary> page(AuditOperationQuery query);
@@ -10,4 +12,15 @@ public interface AuditQueryService {
   Optional<AuditOperationDetail> detail(String operationId);
 
   AuditFilterOptions options();
+
+  /**
+   * Returns the actor name from the first audit operation for each supplied resource.
+   * Later retry/recovery operations must not replace the original creator attribution.
+   */
+  default Map<String, String> firstActorNames(
+      String resourceType,
+      List<String> resourceIds,
+      Long projectId) {
+    return Map.of();
+  }
 }

--- a/yak-ops-business/yak-ops-business-audit/src/main/java/io/yak/ops/business/audit/AuditQueryService.java
+++ b/yak-ops-business/yak-ops-business-audit/src/main/java/io/yak/ops/business/audit/AuditQueryService.java
@@ -14,10 +14,11 @@ public interface AuditQueryService {
   AuditFilterOptions options();
 
   /**
-   * Returns the actor name from the first audit operation for each supplied resource.
+   * Returns the actor name from the first matching audit operation for each supplied resource.
    * Later retry/recovery operations must not replace the original creator attribution.
    */
   default Map<String, String> firstActorNames(
+      String operationType,
       String resourceType,
       List<String> resourceIds,
       Long projectId) {

--- a/yak-ops-business/yak-ops-business-audit/src/main/java/io/yak/ops/business/audit/JdbcAuditQueryService.java
+++ b/yak-ops-business/yak-ops-business-audit/src/main/java/io/yak/ops/business/audit/JdbcAuditQueryService.java
@@ -7,6 +7,7 @@ import java.sql.SQLException;
 import java.sql.Timestamp;
 import java.time.Duration;
 import java.time.LocalDateTime;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -130,6 +131,56 @@ final class JdbcAuditQueryService implements AuditQueryService {
         simpleDistinctOptions("resource_type"),
         simpleDistinctOptions("status"),
         simpleDistinctOptions("source"));
+  }
+
+  @Override
+  public Map<String, String> firstActorNames(
+      String resourceType,
+      List<String> resourceIds,
+      Long projectId) {
+    String normalizedResourceType = normalize(resourceType);
+    if (normalizedResourceType == null || resourceIds == null || resourceIds.isEmpty()) {
+      return Map.of();
+    }
+
+    List<String> normalizedIds = resourceIds.stream()
+        .map(this::normalize)
+        .filter(value -> value != null)
+        .distinct()
+        .toList();
+    if (normalizedIds.isEmpty()) return Map.of();
+
+    MapSqlParameterSource params = new MapSqlParameterSource()
+        .addValue("resourceType", normalizedResourceType)
+        .addValue("resourceIds", normalizedIds);
+    String projectPredicate = "";
+    if (projectId != null && projectId > 0L) {
+      projectPredicate = " AND project_id = :projectId";
+      params.addValue("projectId", projectId);
+    }
+
+    String sql =
+        "SELECT operation.resource_id, operation.actor_name "
+            + "FROM yak_audit_operation operation "
+            + "JOIN ("
+            + "  SELECT resource_id, MIN(id) AS first_id "
+            + "  FROM yak_audit_operation "
+            + "  WHERE resource_type = :resourceType "
+            + "    AND resource_id IN (:resourceIds)"
+            + projectPredicate
+            + "  GROUP BY resource_id"
+            + ") first_operation ON first_operation.first_id = operation.id";
+
+    Map<String, String> result = new LinkedHashMap<>();
+    jdbcTemplate.query(
+        sql,
+        params,
+        resultSet -> {
+          String resourceId = normalize(resultSet.getString("resource_id"));
+          String actorName = normalize(resultSet.getString("actor_name"));
+          if (resourceId != null && actorName != null) result.put(resourceId, actorName);
+        });
+    return Map.copyOf(result);
   }
 
   private QuerySpec operationWhere(AuditOperationQuery query) {

--- a/yak-ops-business/yak-ops-business-audit/src/main/java/io/yak/ops/business/audit/JdbcAuditQueryService.java
+++ b/yak-ops-business/yak-ops-business-audit/src/main/java/io/yak/ops/business/audit/JdbcAuditQueryService.java
@@ -135,11 +135,16 @@ final class JdbcAuditQueryService implements AuditQueryService {
 
   @Override
   public Map<String, String> firstActorNames(
+      String operationType,
       String resourceType,
       List<String> resourceIds,
       Long projectId) {
+    String normalizedOperationType = normalize(operationType);
     String normalizedResourceType = normalize(resourceType);
-    if (normalizedResourceType == null || resourceIds == null || resourceIds.isEmpty()) {
+    if (normalizedOperationType == null
+        || normalizedResourceType == null
+        || resourceIds == null
+        || resourceIds.isEmpty()) {
       return Map.of();
     }
 
@@ -151,6 +156,7 @@ final class JdbcAuditQueryService implements AuditQueryService {
     if (normalizedIds.isEmpty()) return Map.of();
 
     MapSqlParameterSource params = new MapSqlParameterSource()
+        .addValue("operationType", normalizedOperationType)
         .addValue("resourceType", normalizedResourceType)
         .addValue("resourceIds", normalizedIds);
     String projectPredicate = "";
@@ -160,16 +166,17 @@ final class JdbcAuditQueryService implements AuditQueryService {
     }
 
     String sql =
-        "SELECT operation.resource_id, operation.actor_name "
-            + "FROM yak_audit_operation operation "
+        "SELECT o.resource_id, o.actor_name "
+            + "FROM yak_audit_operation o "
             + "JOIN ("
             + "  SELECT resource_id, MIN(id) AS first_id "
             + "  FROM yak_audit_operation "
-            + "  WHERE resource_type = :resourceType "
+            + "  WHERE operation_type = :operationType "
+            + "    AND resource_type = :resourceType "
             + "    AND resource_id IN (:resourceIds)"
             + projectPredicate
             + "  GROUP BY resource_id"
-            + ") first_operation ON first_operation.first_id = operation.id";
+            + ") first_operation ON first_operation.first_id = o.id";
 
     Map<String, String> result = new LinkedHashMap<>();
     jdbcTemplate.query(

--- a/yak-ops-business/yak-ops-business-workflow/src/main/java/io/yak/ops/business/workflow/controller/v1/WorkflowController.java
+++ b/yak-ops-business/yak-ops-business-workflow/src/main/java/io/yak/ops/business/workflow/controller/v1/WorkflowController.java
@@ -178,10 +178,7 @@ public class WorkflowController {
   @GetMapping("/instances/{executionId}")
   public Result<WorkflowInstanceVO> instance(
       @PathVariable("executionId") String executionId) {
-    return Result.success(
-        workflowInstanceQueryService == null
-            ? workflowRuntimeService.getInstance(executionId)
-            : workflowInstanceQueryService.getInstance(executionId));
+    return Result.success(workflowRuntimeService.getInstance(executionId));
   }
 
   @Operation(summary = "订阅工作流实例实时状态")

--- a/yak-ops-business/yak-ops-business-workflow/src/main/java/io/yak/ops/business/workflow/controller/v1/WorkflowController.java
+++ b/yak-ops-business/yak-ops-business-workflow/src/main/java/io/yak/ops/business/workflow/controller/v1/WorkflowController.java
@@ -7,6 +7,7 @@ import io.yak.ops.business.workflow.domain.WorkflowTriggerContext;
 import io.yak.ops.business.workflow.execution.WorkflowExecutionControlAuditCoordinator;
 import io.yak.ops.business.workflow.execution.WorkflowExecutionReactivator;
 import io.yak.ops.business.workflow.execution.WorkflowLauncher;
+import io.yak.ops.business.workflow.runtime.WorkflowInstanceQueryService;
 import io.yak.ops.business.workflow.runtime.WorkflowRuntime;
 import io.yak.ops.common.bean.dto.workflow.WorkflowRunDTO;
 import io.yak.ops.common.bean.vo.workflow.WorkflowInstanceVO;
@@ -34,17 +35,34 @@ public class WorkflowController {
   private final WorkflowLauncher workflowLaunchService;
   private final WorkflowExecutionReactivator workflowReactivationService;
   private final WorkflowExecutionControlAuditCoordinator executionControlAudit;
+  private final WorkflowInstanceQueryService workflowInstanceQueryService;
 
   @Autowired
   public WorkflowController(
       WorkflowRuntime workflowRuntimeService,
       WorkflowLauncher workflowLaunchService,
       WorkflowExecutionReactivator workflowReactivationService,
-      WorkflowExecutionControlAuditCoordinator executionControlAudit) {
+      WorkflowExecutionControlAuditCoordinator executionControlAudit,
+      WorkflowInstanceQueryService workflowInstanceQueryService) {
     this.workflowRuntimeService = workflowRuntimeService;
     this.workflowLaunchService = workflowLaunchService;
     this.workflowReactivationService = workflowReactivationService;
     this.executionControlAudit = executionControlAudit;
+    this.workflowInstanceQueryService = workflowInstanceQueryService;
+  }
+
+  /** Focused compatibility constructor without query enrichment wiring. */
+  public WorkflowController(
+      WorkflowRuntime workflowRuntimeService,
+      WorkflowLauncher workflowLaunchService,
+      WorkflowExecutionReactivator workflowReactivationService,
+      WorkflowExecutionControlAuditCoordinator executionControlAudit) {
+    this(
+        workflowRuntimeService,
+        workflowLaunchService,
+        workflowReactivationService,
+        executionControlAudit,
+        null);
   }
 
   /** Focused compatibility constructor without Audit wiring. */
@@ -52,10 +70,12 @@ public class WorkflowController {
       WorkflowRuntime workflowRuntimeService,
       WorkflowLauncher workflowLaunchService,
       WorkflowExecutionReactivator workflowReactivationService) {
-    this.workflowRuntimeService = workflowRuntimeService;
-    this.workflowLaunchService = workflowLaunchService;
-    this.workflowReactivationService = workflowReactivationService;
-    this.executionControlAudit = null;
+    this(
+        workflowRuntimeService,
+        workflowLaunchService,
+        workflowReactivationService,
+        null,
+        null);
   }
 
   @Operation(summary = "创建工作流运行实例")
@@ -148,14 +168,20 @@ public class WorkflowController {
   @Operation(summary = "查询工作流实例")
   @GetMapping("/instances")
   public Result<List<WorkflowInstanceVO>> instances() {
-    return Result.success(workflowRuntimeService.listInstances());
+    return Result.success(
+        workflowInstanceQueryService == null
+            ? workflowRuntimeService.listInstances()
+            : workflowInstanceQueryService.listInstances());
   }
 
   @Operation(summary = "查询工作流实例详情")
   @GetMapping("/instances/{executionId}")
   public Result<WorkflowInstanceVO> instance(
       @PathVariable("executionId") String executionId) {
-    return Result.success(workflowRuntimeService.getInstance(executionId));
+    return Result.success(
+        workflowInstanceQueryService == null
+            ? workflowRuntimeService.getInstance(executionId)
+            : workflowInstanceQueryService.getInstance(executionId));
   }
 
   @Operation(summary = "订阅工作流实例实时状态")

--- a/yak-ops-business/yak-ops-business-workflow/src/main/java/io/yak/ops/business/workflow/runtime/WorkflowInstanceQueryService.java
+++ b/yak-ops-business/yak-ops-business-workflow/src/main/java/io/yak/ops/business/workflow/runtime/WorkflowInstanceQueryService.java
@@ -5,6 +5,8 @@ import io.yak.ops.common.bean.vo.workflow.WorkflowInstanceVO;
 import io.yak.ops.core.project.CurrentProject;
 import java.util.List;
 import java.util.Map;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.ObjectProvider;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
@@ -13,6 +15,7 @@ import org.springframework.stereotype.Service;
 @Service
 public class WorkflowInstanceQueryService {
 
+  private static final Logger log = LoggerFactory.getLogger(WorkflowInstanceQueryService.class);
   private static final String WORKFLOW_EXECUTE_OPERATION = "WORKFLOW_EXECUTE";
   private static final String WORKFLOW_EXECUTION_RESOURCE = "WORKFLOW_EXECUTION";
 
@@ -46,31 +49,49 @@ public class WorkflowInstanceQueryService {
       return instances;
     }
 
-    Map<String, String> creators =
-        auditQueryService.firstActorNames(
-            WORKFLOW_EXECUTE_OPERATION,
-            WORKFLOW_EXECUTION_RESOURCE,
-            instances.stream().map(WorkflowInstanceVO::id).toList(),
-            currentProject.requireProjectId());
-    if (creators.isEmpty()) return instances;
+    Long projectId = currentProject.requireProjectId();
+    try {
+      Map<String, String> creators =
+          auditQueryService.firstActorNames(
+              WORKFLOW_EXECUTE_OPERATION,
+              WORKFLOW_EXECUTION_RESOURCE,
+              instances.stream().map(WorkflowInstanceVO::id).toList(),
+              projectId);
+      if (creators.isEmpty()) return instances;
 
-    return instances.stream()
-        .map(instance -> withCreator(instance, creators.get(instance.id())))
-        .toList();
+      return instances.stream()
+          .map(instance -> withCreator(instance, creators.get(instance.id())))
+          .toList();
+    } catch (RuntimeException exception) {
+      log.debug(
+          "Workflow instance creator enrichment unavailable for project {}",
+          projectId,
+          exception);
+      return instances;
+    }
   }
 
   public WorkflowInstanceVO getInstance(String executionId) {
     WorkflowInstanceVO instance = workflowRuntime.getInstance(executionId);
     if (auditQueryService == null || currentProject == null) return instance;
 
-    String creatorName =
-        auditQueryService.firstActorNames(
-                WORKFLOW_EXECUTE_OPERATION,
-                WORKFLOW_EXECUTION_RESOURCE,
-                List.of(instance.id()),
-                currentProject.requireProjectId())
-            .get(instance.id());
-    return withCreator(instance, creatorName);
+    Long projectId = currentProject.requireProjectId();
+    try {
+      String creatorName =
+          auditQueryService.firstActorNames(
+                  WORKFLOW_EXECUTE_OPERATION,
+                  WORKFLOW_EXECUTION_RESOURCE,
+                  List.of(instance.id()),
+                  projectId)
+              .get(instance.id());
+      return withCreator(instance, creatorName);
+    } catch (RuntimeException exception) {
+      log.debug(
+          "Workflow instance creator enrichment unavailable for execution {}",
+          instance.id(),
+          exception);
+      return instance;
+    }
   }
 
   private WorkflowInstanceVO withCreator(WorkflowInstanceVO instance, String creatorName) {

--- a/yak-ops-business/yak-ops-business-workflow/src/main/java/io/yak/ops/business/workflow/runtime/WorkflowInstanceQueryService.java
+++ b/yak-ops-business/yak-ops-business-workflow/src/main/java/io/yak/ops/business/workflow/runtime/WorkflowInstanceQueryService.java
@@ -1,0 +1,79 @@
+package io.yak.ops.business.workflow.runtime;
+
+import io.yak.ops.business.audit.AuditQueryService;
+import io.yak.ops.common.bean.vo.workflow.WorkflowInstanceVO;
+import io.yak.ops.core.project.CurrentProject;
+import java.util.List;
+import java.util.Map;
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.ObjectProvider;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+
+/** Read-side enrichment for Workflow instances that must not mutate runtime execution truth. */
+@Service
+public class WorkflowInstanceQueryService {
+
+  private static final String WORKFLOW_EXECUTION_RESOURCE = "WORKFLOW_EXECUTION";
+
+  private final WorkflowRuntime workflowRuntime;
+  private final AuditQueryService auditQueryService;
+  private final CurrentProject currentProject;
+
+  @Autowired
+  public WorkflowInstanceQueryService(
+      WorkflowRuntime workflowRuntime,
+      ObjectProvider<AuditQueryService> auditQueryServiceProvider,
+      CurrentProject currentProject) {
+    this(
+        workflowRuntime,
+        auditQueryServiceProvider == null ? null : auditQueryServiceProvider.getIfAvailable(),
+        currentProject);
+  }
+
+  WorkflowInstanceQueryService(
+      WorkflowRuntime workflowRuntime,
+      AuditQueryService auditQueryService,
+      CurrentProject currentProject) {
+    this.workflowRuntime = workflowRuntime;
+    this.auditQueryService = auditQueryService;
+    this.currentProject = currentProject;
+  }
+
+  public List<WorkflowInstanceVO> listInstances() {
+    List<WorkflowInstanceVO> instances = workflowRuntime.listInstances();
+    if (instances.isEmpty() || auditQueryService == null || currentProject == null) {
+      return instances;
+    }
+
+    Map<String, String> creators =
+        auditQueryService.firstActorNames(
+            WORKFLOW_EXECUTION_RESOURCE,
+            instances.stream().map(WorkflowInstanceVO::id).toList(),
+            currentProject.requireProjectId());
+    if (creators.isEmpty()) return instances;
+
+    return instances.stream()
+        .map(instance -> withCreator(instance, creators.get(instance.id())))
+        .toList();
+  }
+
+  public WorkflowInstanceVO getInstance(String executionId) {
+    WorkflowInstanceVO instance = workflowRuntime.getInstance(executionId);
+    if (auditQueryService == null || currentProject == null) return instance;
+
+    String creatorName =
+        auditQueryService.firstActorNames(
+                WORKFLOW_EXECUTION_RESOURCE,
+                List.of(instance.id()),
+                currentProject.requireProjectId())
+            .get(instance.id());
+    return withCreator(instance, creatorName);
+  }
+
+  private WorkflowInstanceVO withCreator(WorkflowInstanceVO instance, String creatorName) {
+    return creatorName == null || creatorName.isBlank()
+        ? instance
+        : instance.withCreatorName(creatorName.trim());
+  }
+}

--- a/yak-ops-business/yak-ops-business-workflow/src/main/java/io/yak/ops/business/workflow/runtime/WorkflowInstanceQueryService.java
+++ b/yak-ops-business/yak-ops-business-workflow/src/main/java/io/yak/ops/business/workflow/runtime/WorkflowInstanceQueryService.java
@@ -11,7 +11,7 @@ import org.springframework.beans.factory.ObjectProvider;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 
-/** Read-side enrichment for Workflow instances that must not mutate runtime execution truth. */
+/** Read-side enrichment for Workflow instance list views. */
 @Service
 public class WorkflowInstanceQueryService {
 
@@ -68,29 +68,6 @@ public class WorkflowInstanceQueryService {
           projectId,
           exception);
       return instances;
-    }
-  }
-
-  public WorkflowInstanceVO getInstance(String executionId) {
-    WorkflowInstanceVO instance = workflowRuntime.getInstance(executionId);
-    if (auditQueryService == null || currentProject == null) return instance;
-
-    Long projectId = currentProject.requireProjectId();
-    try {
-      String creatorName =
-          auditQueryService.firstActorNames(
-                  WORKFLOW_EXECUTE_OPERATION,
-                  WORKFLOW_EXECUTION_RESOURCE,
-                  List.of(instance.id()),
-                  projectId)
-              .get(instance.id());
-      return withCreator(instance, creatorName);
-    } catch (RuntimeException exception) {
-      log.debug(
-          "Workflow instance creator enrichment unavailable for execution {}",
-          instance.id(),
-          exception);
-      return instance;
     }
   }
 

--- a/yak-ops-business/yak-ops-business-workflow/src/main/java/io/yak/ops/business/workflow/runtime/WorkflowInstanceQueryService.java
+++ b/yak-ops-business/yak-ops-business-workflow/src/main/java/io/yak/ops/business/workflow/runtime/WorkflowInstanceQueryService.java
@@ -5,7 +5,6 @@ import io.yak.ops.common.bean.vo.workflow.WorkflowInstanceVO;
 import io.yak.ops.core.project.CurrentProject;
 import java.util.List;
 import java.util.Map;
-import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.ObjectProvider;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
@@ -14,6 +13,7 @@ import org.springframework.stereotype.Service;
 @Service
 public class WorkflowInstanceQueryService {
 
+  private static final String WORKFLOW_EXECUTE_OPERATION = "WORKFLOW_EXECUTE";
   private static final String WORKFLOW_EXECUTION_RESOURCE = "WORKFLOW_EXECUTION";
 
   private final WorkflowRuntime workflowRuntime;
@@ -48,6 +48,7 @@ public class WorkflowInstanceQueryService {
 
     Map<String, String> creators =
         auditQueryService.firstActorNames(
+            WORKFLOW_EXECUTE_OPERATION,
             WORKFLOW_EXECUTION_RESOURCE,
             instances.stream().map(WorkflowInstanceVO::id).toList(),
             currentProject.requireProjectId());
@@ -64,6 +65,7 @@ public class WorkflowInstanceQueryService {
 
     String creatorName =
         auditQueryService.firstActorNames(
+                WORKFLOW_EXECUTE_OPERATION,
                 WORKFLOW_EXECUTION_RESOURCE,
                 List.of(instance.id()),
                 currentProject.requireProjectId())

--- a/yak-ops-business/yak-ops-business-workflow/src/test/java/io/yak/ops/business/workflow/runtime/WorkflowInstanceQueryServiceTest.java
+++ b/yak-ops-business/yak-ops-business-workflow/src/test/java/io/yak/ops/business/workflow/runtime/WorkflowInstanceQueryServiceTest.java
@@ -1,0 +1,94 @@
+package io.yak.ops.business.workflow.runtime;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import io.yak.ops.business.audit.AuditQueryService;
+import io.yak.ops.common.bean.vo.workflow.WorkflowInstanceVO;
+import io.yak.ops.core.project.CurrentProject;
+import java.time.Instant;
+import java.util.List;
+import java.util.Map;
+import org.junit.jupiter.api.Test;
+
+class WorkflowInstanceQueryServiceTest {
+
+  @Test
+  void enrichesInstancesWithTheFirstExecuteActorName() {
+    WorkflowRuntime runtime = mock(WorkflowRuntime.class);
+    AuditQueryService auditQueryService = mock(AuditQueryService.class);
+    CurrentProject currentProject = mock(CurrentProject.class);
+    WorkflowInstanceVO instance = instance("execution-1");
+
+    when(runtime.listInstances()).thenReturn(List.of(instance));
+    when(currentProject.requireProjectId()).thenReturn(42L);
+    when(auditQueryService.firstActorNames(
+            "WORKFLOW_EXECUTE",
+            "WORKFLOW_EXECUTION",
+            List.of("execution-1"),
+            42L))
+        .thenReturn(Map.of("execution-1", "alice"));
+
+    WorkflowInstanceQueryService service =
+        new WorkflowInstanceQueryService(runtime, auditQueryService, currentProject);
+
+    List<WorkflowInstanceVO> result = service.listInstances();
+
+    assertEquals(1, result.size());
+    assertEquals("alice", result.get(0).creatorName());
+    verify(auditQueryService)
+        .firstActorNames(
+            "WORKFLOW_EXECUTE",
+            "WORKFLOW_EXECUTION",
+            List.of("execution-1"),
+            42L);
+  }
+
+  @Test
+  void keepsCreatorEmptyWhenNoLaunchAuditExists() {
+    WorkflowRuntime runtime = mock(WorkflowRuntime.class);
+    AuditQueryService auditQueryService = mock(AuditQueryService.class);
+    CurrentProject currentProject = mock(CurrentProject.class);
+    WorkflowInstanceVO instance = instance("execution-legacy");
+
+    when(runtime.listInstances()).thenReturn(List.of(instance));
+    when(currentProject.requireProjectId()).thenReturn(7L);
+    when(auditQueryService.firstActorNames(
+            "WORKFLOW_EXECUTE",
+            "WORKFLOW_EXECUTION",
+            List.of("execution-legacy"),
+            7L))
+        .thenReturn(Map.of());
+
+    WorkflowInstanceQueryService service =
+        new WorkflowInstanceQueryService(runtime, auditQueryService, currentProject);
+
+    WorkflowInstanceVO result = service.listInstances().get(0);
+
+    assertNull(result.creatorName());
+  }
+
+  private WorkflowInstanceVO instance(String id) {
+    return new WorkflowInstanceVO(
+        id,
+        "definition-1",
+        null,
+        "Example workflow",
+        "SUCCESS",
+        "FAIL_FAST",
+        Instant.parse("2026-09-03T00:00:00Z"),
+        Instant.parse("2026-09-03T00:00:00Z"),
+        Instant.parse("2026-09-03T00:00:01Z"),
+        3600L,
+        Map.of(),
+        1,
+        0,
+        List.of(),
+        "version-1",
+        1,
+        false);
+  }
+}

--- a/yak-ops-common/src/main/java/io/yak/ops/common/bean/vo/workflow/WorkflowInstanceVO.java
+++ b/yak-ops-common/src/main/java/io/yak/ops/common/bean/vo/workflow/WorkflowInstanceVO.java
@@ -22,7 +22,33 @@ public record WorkflowInstanceVO(
     List<NodeInstanceVO> nodes,
     String workflowVersionId,
     Integer workflowVersionNo,
-    boolean testRun) {
+    boolean testRun,
+    String creatorName) {
+
+  /** Compatibility constructor for existing runtime projections. */
+  public WorkflowInstanceVO(
+      String id,
+      String definitionId,
+      String sourceExecutionId,
+      String name,
+      String status,
+      String failureStrategy,
+      Instant startedAt,
+      Instant runStartedAt,
+      Instant endedAt,
+      long workflowTimeoutSeconds,
+      Map<String, Object> input,
+      int nodeCount,
+      int edgeCount,
+      List<NodeInstanceVO> nodes,
+      String workflowVersionId,
+      Integer workflowVersionNo,
+      boolean testRun) {
+    this(
+        id, definitionId, sourceExecutionId, name, status, failureStrategy,
+        startedAt, runStartedAt, endedAt, workflowTimeoutSeconds, input,
+        nodeCount, edgeCount, nodes, workflowVersionId, workflowVersionNo, testRun, null);
+  }
 
   public WorkflowInstanceVO(
       String id,
@@ -42,7 +68,14 @@ public record WorkflowInstanceVO(
     this(
         id, definitionId, sourceExecutionId, name, status, failureStrategy,
         startedAt, runStartedAt, endedAt, workflowTimeoutSeconds, input,
-        nodeCount, edgeCount, nodes, null, null, false);
+        nodeCount, edgeCount, nodes, null, null, false, null);
+  }
+
+  public WorkflowInstanceVO withCreatorName(String value) {
+    return new WorkflowInstanceVO(
+        id, definitionId, sourceExecutionId, name, status, failureStrategy,
+        startedAt, runStartedAt, endedAt, workflowTimeoutSeconds, input,
+        nodeCount, edgeCount, nodes, workflowVersionId, workflowVersionNo, testRun, value);
   }
 
   public record NodeInstanceVO(

--- a/yak-ops-ui/src/pages/workflow/instances/components/WorkflowInstanceList.tsx
+++ b/yak-ops-ui/src/pages/workflow/instances/components/WorkflowInstanceList.tsx
@@ -333,6 +333,19 @@ const WorkflowInstancesPage = () => {
         ),
       },
       {
+        title: '创建用户',
+        dataIndex: 'creatorName',
+        width: 160,
+        render: (value?: string) => (
+          <span
+            className="block truncate text-[12px] text-[#667085]"
+            title={value || undefined}
+          >
+            {value || '-'}
+          </span>
+        ),
+      },
+      {
         title: '状态',
         dataIndex: 'status',
         width: 150,
@@ -620,7 +633,7 @@ const WorkflowInstancesPage = () => {
                     : '当前实例没有可批量恢复的失败/阻断节点',
                 }),
               }}
-              scroll={{ x: 1050 }}
+              scroll={{ x: 1320 }}
               locale={{
                 emptyText: (
                   <Empty

--- a/yak-ops-ui/src/services/workflow/instances.ts
+++ b/yak-ops-ui/src/services/workflow/instances.ts
@@ -102,6 +102,7 @@ export interface WorkflowInstance {
   definitionId: string;
   sourceExecutionId?: string;
   name: string;
+  creatorName?: string;
   status: string;
   failureStrategy: WorkflowFailureStrategy;
   startedAt: string;


### PR DESCRIPTION
## Summary

Add a `创建用户` column to the Workflow Instance list while keeping creator attribution stable across later retry/recovery operations.

## Changes

- Add `creatorName` to `WorkflowInstanceVO` and the frontend `WorkflowInstance` type
- Add a compact `创建用户` column after the instance name
- Keep the row visually lightweight: creator is plain text only, with `-` when no trustworthy creator snapshot is available
- Resolve creator from the Audit read model instead of querying the user directory per row
- Batch creator lookup for the whole instance list, avoiding N+1 user queries
- Scope attribution to:
  - operation type: `WORKFLOW_EXECUTE`
  - resource type: `WORKFLOW_EXECUTION`
  - current Project Space
- Use the first matching execute audit operation for each execution so later Retry / recovery operations do not replace the original creator attribution
- Keep Audit enrichment fail-open: if Audit storage is unavailable, the Workflow Instance list still loads and creator simply remains empty
- Keep instance detail / SSE behavior unchanged; enrichment is list-only
- Add focused unit coverage for creator enrichment and legacy instances without a matching launch audit

## Why Audit instead of a new execution column

Workflow execution already records actor snapshots in the shared Audit store. Reusing that source avoids another user lookup and avoids duplicating creator state into the workflow execution schema. It also means existing instances with a matching launch audit can show the creator without a new Flyway migration.

The mutable `audit_carrier_json.actorName` is intentionally not used directly because retry/recovery can replace the current carrier with the later operator. The list needs the original instance creator, not the latest operator.

## Scope

No workflow execution schema migration, no user-directory join, no change to workflow execution/retry semantics, and no change to the instance detail/SSE contract.

## Validation

- Branch is based on current `main` after #1000 was merged
- Added `WorkflowInstanceQueryServiceTest` for creator mapping and missing historical audit fallback
- Final diff reviewed for project scoping, batch lookup, stable creator semantics, and fail-open behavior
- Full Maven/frontend lint/test could not be executed in the connector environment; CI should provide repository-level validation
