### PR TITLE
feat(docker): package and orchestrate Yak Ops stack

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -16,30 +16,28 @@ YAK_OPS_PORT=9001
 # MySQL
 # =========================
 
-MYSQL_ROOT_PASSWORD=linkup_root_password
+MYSQL_ROOT_PASSWORD=yak_ops_root_password
 MYSQL_DATABASE=yak_ops
-MYSQL_USER=linkup
-MYSQL_PASSWORD=linkup_password
+MYSQL_USER=yak_ops
+MYSQL_PASSWORD=yak_ops_password
 
 # MySQL address used inside the Docker network.
-# Do not change this to localhost.
+# Do not change this to localhost for the bundled Compose stack.
 MYSQL_HOST=mysql
 MYSQL_PORT=3306
 
-# MySQL port exposed on the host.
-# Use 3306 because the local 3306 port is already occupied.
+# MySQL port exposed on the host. Change it if local 3306 is already occupied.
 MYSQL_HOST_PORT=3306
 
 
 # =========================
-# Database Connection (shared by Security & Business)
+# Database Connection
 # =========================
 
-# Set YAK_DATASOURCE_* to configure both yak.security.datasource and yak.database at once.
-# Override with YAK_SECURITY_DATASOURCE_* or YAK_DATABASE_* to point them to different databases.
-#YAK_DATASOURCE_URL=jdbc:mysql://127.0.0.1:3306/yak_security?useUnicode=true&allowPublicKeyRetrieval=true&characterEncoding=UTF-8&useSSL=false&serverTimezone=Asia/Shanghai
-#YAK_DATASOURCE_USERNAME=root
-#YAK_DATASOURCE_PASSWORD=123456
+# The default Compose stack derives YAK_DATASOURCE_* from the MySQL values
+# above so Yak Security and Yak Ops business modules share one database.
+# Override YAK_SECURITY_DATASOURCE_* or YAK_DATABASE_* only when you need
+# separate databases.
 
 
 # =========================
@@ -53,9 +51,17 @@ APP_OPTS=
 
 
 # =========================
+# Bootstrap account
+# =========================
+
+YAK_SECURITY_BOOTSTRAP_USERNAME=root
+YAK_SECURITY_BOOTSTRAP_PASSWORD=Root@123456
+
+
+# =========================
 # Security
 # =========================
 
 # Used to encrypt datasource passwords with AES-GCM.
-# Generate a new value before production deployment.
+# Generate a new random value before any non-local deployment.
 YAK_OPS_DATASOURCE_MASTER_KEY=replace_with_a_random_32_byte_secret_key

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,10 +1,15 @@
+# syntax=docker/dockerfile:1
+
+# The Docker images package the release distribution produced by the normal
+# Yak Ops build. CI builds yak-framework, the frontend, and the Maven reactor
+# before invoking these runtime targets.
+
 # =========================
 # Distribution artifact
 # =========================
 FROM scratch AS dist-artifact
 
-COPY yak-ops-dist/target/yak-ops-*.tar.gz \
-     /yak-ops.tar.gz
+COPY yak-ops-dist/target/yak-ops-*.tar.gz /yak-ops.tar.gz
 
 
 # =========================
@@ -16,8 +21,8 @@ ARG VERSION=dev
 ARG VCS_REF=unknown
 ARG BUILD_DATE=unknown
 
-LABEL org.opencontainers.image.title="Yak Ops API" \
-      org.opencontainers.image.description="Yak Ops backend service" \
+LABEL org.opencontainers.image.title="Yak Ops Backend" \
+      org.opencontainers.image.description="Yak Ops Spring Boot backend service" \
       org.opencontainers.image.licenses="Apache-2.0" \
       org.opencontainers.image.version="${VERSION}" \
       org.opencontainers.image.revision="${VCS_REF}" \
@@ -27,20 +32,11 @@ ENV YAK_OPS_HOME=/opt/yak-ops \
     JAVA_OPTS="" \
     APP_OPTS="" \
     SERVER_PORT=9527 \
-    SPRING_PROFILES_ACTIVE=mysql \
-    YAK_OPS_DATABASE_TYPE=mysql \
-    YAK_OPS_DATABASE_HOST=mysql \
-    YAK_OPS_DATABASE_PORT=3306 \
-    YAK_OPS_DATABASE_NAME=yak_ops \
-    SPRING_DATASOURCE_URL="jdbc:mysql://mysql:3306/yak_ops?useUnicode=true&characterEncoding=utf8&useSSL=false&serverTimezone=GMT%2B8&allowPublicKeyRetrieval=true" \
-    SPRING_DATASOURCE_USERNAME=linkup \
-    SPRING_DATASOURCE_PASSWORD=linkup
+    SPRING_PROFILES_ACTIVE=mysql
 
 WORKDIR ${YAK_OPS_HOME}
 
-COPY --from=dist-artifact \
-     /yak-ops.tar.gz \
-     /tmp/yak-ops.tar.gz
+COPY --from=dist-artifact /yak-ops.tar.gz /tmp/yak-ops.tar.gz
 
 RUN set -eux; \
     mkdir -p "${YAK_OPS_HOME}"; \
@@ -50,13 +46,22 @@ RUN set -eux; \
     rm -f /tmp/yak-ops.tar.gz; \
     chmod +x "${YAK_OPS_HOME}"/bin/*.sh; \
     mkdir -p \
+        "${YAK_OPS_HOME}/data" \
         "${YAK_OPS_HOME}/logs" \
         "${YAK_OPS_HOME}/jdbc-drivers"; \
-    test -f "${YAK_OPS_HOME}/libs/yak-ops-api.jar"
+    test -f "${YAK_OPS_HOME}/libs/yak-ops-api.jar"; \
+    test -f "${YAK_OPS_HOME}/conf/application.yml"
 
 EXPOSE 9527
 
-VOLUME ["/opt/yak-ops/logs","/opt/yak-ops/jdbc-drivers"]
+VOLUME ["/opt/yak-ops/data", "/opt/yak-ops/logs", "/opt/yak-ops/jdbc-drivers"]
+
+HEALTHCHECK \
+    --interval=10s \
+    --timeout=5s \
+    --start-period=30s \
+    --retries=12 \
+    CMD bash -c '</dev/tcp/127.0.0.1/9527' || exit 1
 
 ENTRYPOINT ["/opt/yak-ops/bin/run-yak-ops.sh"]
 
@@ -70,16 +75,15 @@ ARG VERSION=dev
 ARG VCS_REF=unknown
 ARG BUILD_DATE=unknown
 
-LABEL org.opencontainers.image.title="Yak Ops" \
-      org.opencontainers.image.description="Yak Ops frontend and reverse proxy" \
+LABEL org.opencontainers.image.title="Yak Ops Frontend" \
+      org.opencontainers.image.description="Yak Ops web UI and reverse proxy" \
       org.opencontainers.image.licenses="Apache-2.0" \
       org.opencontainers.image.version="${VERSION}" \
       org.opencontainers.image.revision="${VCS_REF}" \
       org.opencontainers.image.created="${BUILD_DATE}"
 
-COPY --from=dist-artifact \
-     /yak-ops.tar.gz \
-     /tmp/yak-ops.tar.gz
+COPY --from=dist-artifact /yak-ops.tar.gz /tmp/yak-ops.tar.gz
+COPY docker/nginx/default.conf /etc/nginx/conf.d/default.conf
 
 RUN set -eux; \
     mkdir -p /tmp/yak-ops; \
@@ -87,14 +91,9 @@ RUN set -eux; \
         --strip-components=1 \
         -C /tmp/yak-ops; \
     test -f /tmp/yak-ops/web/index.html; \
-    test -f /tmp/yak-ops/conf/nginx/default.conf; \
     rm -rf /usr/share/nginx/html/*; \
     cp -r /tmp/yak-ops/web/. /usr/share/nginx/html/; \
-    cp /tmp/yak-ops/conf/nginx/default.conf \
-       /etc/nginx/conf.d/default.conf; \
-    rm -rf \
-        /tmp/yak-ops \
-        /tmp/yak-ops.tar.gz
+    rm -rf /tmp/yak-ops /tmp/yak-ops.tar.gz
 
 EXPOSE 80
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -102,6 +102,6 @@ HEALTHCHECK \
     --timeout=3s \
     --start-period=10s \
     --retries=6 \
-    CMD wget -q -O /dev/null http://127.0.0.1/ || exit 1
+    CMD nginx -t || exit 1
 
 CMD ["nginx", "-g", "daemon off;"]

--- a/compose.without-mysql.yaml
+++ b/compose.without-mysql.yaml
@@ -1,74 +1,64 @@
 services:
-  yak-ops-api:
-    image: ${YAK_OPS_API_IMAGE:-yak-ops-api:latest}
-    container_name: yak-ops-api
+  yak-ops-backend:
+    image: ${YAK_OPS_API_IMAGE:-weifuwan/yak-ops-api:0.1.0}
+    container_name: yak-ops-backend
     restart: unless-stopped
-
     build:
       context: .
       dockerfile: Dockerfile
       target: backend-runtime
-
     environment:
       TZ: Asia/Shanghai
       JAVA_OPTS: ${JAVA_OPTS:--Xms512m -Xmx1024m}
       APP_OPTS: ${APP_OPTS:-}
-
       SERVER_PORT: 9527
       SPRING_PROFILES_ACTIVE: mysql
 
-      YAK_OPS_DATABASE_TYPE: mysql
-      YAK_OPS_DATABASE_HOST: ${MYSQL_HOST:-host.docker.internal}
-      YAK_OPS_DATABASE_PORT: ${MYSQL_PORT:-3306}
-      YAK_OPS_DATABASE_NAME: ${MYSQL_DATABASE:-yak_ops}
+      YAK_DATASOURCE_URL: "jdbc:mysql://${MYSQL_HOST:-host.docker.internal}:${MYSQL_PORT:-3306}/${MYSQL_DATABASE:-yak_ops}?useUnicode=true&allowPublicKeyRetrieval=true&characterEncoding=UTF-8&useSSL=false&serverTimezone=Asia/Shanghai"
+      YAK_DATASOURCE_USERNAME: ${MYSQL_USER:?set MYSQL_USER}
+      YAK_DATASOURCE_PASSWORD: ${MYSQL_PASSWORD:?set MYSQL_PASSWORD}
 
-      SPRING_DATASOURCE_URL: "jdbc:mysql://${MYSQL_HOST:-host.docker.internal}:${MYSQL_PORT:-3306}/${MYSQL_DATABASE:-yak_ops}?useUnicode=true&characterEncoding=utf8&useSSL=false&serverTimezone=GMT%2B8&allowPublicKeyRetrieval=true"
-      SPRING_DATASOURCE_USERNAME: ${MYSQL_USER:?set MYSQL_USER}
-      SPRING_DATASOURCE_PASSWORD: ${MYSQL_PASSWORD:?set MYSQL_PASSWORD}
-
-      SPRING_FLYWAY_ENABLED: "true"
+      YAK_SECURITY_BOOTSTRAP_USERNAME: ${YAK_SECURITY_BOOTSTRAP_USERNAME:-root}
+      YAK_SECURITY_BOOTSTRAP_PASSWORD: ${YAK_SECURITY_BOOTSTRAP_PASSWORD:-Root@123456}
 
       YAK_OPS_DATASOURCE_MASTER_KEY: ${YAK_OPS_DATASOURCE_MASTER_KEY:?set YAK_OPS_DATASOURCE_MASTER_KEY}
-
+      YAK_RESOURCE_LOCAL_BASE_DIRECTORY: /opt/yak-ops/data/resources
     extra_hosts:
       - "host.docker.internal:host-gateway"
-
     expose:
       - "9527"
-
     volumes:
+      - yak-ops-data:/opt/yak-ops/data
       - yak-ops-logs:/opt/yak-ops/logs
       - yak-ops-jdbc-drivers:/opt/yak-ops/jdbc-drivers
+    networks:
+      - yak-ops-network
 
-    healthcheck:
-      test:
-        - CMD-SHELL
-        - curl -fsS http://127.0.0.1:9527/actuator/health || exit 1
-      interval: 10s
-      timeout: 5s
-      retries: 12
-      start_period: 30s
-
-  yak-ops:
-    image: ${YAK_OPS_IMAGE:-yak-ops:latest}
-    container_name: yak-ops
+  yak-ops-frontend:
+    image: ${YAK_OPS_IMAGE:-weifuwan/yak-ops:0.1.0}
+    container_name: yak-ops-frontend
     restart: unless-stopped
-
     build:
       context: .
       dockerfile: Dockerfile
       target: frontend-runtime
-
-    healthcheck:
-      disable: true
-
     depends_on:
-      yak-ops-api:
+      yak-ops-backend:
         condition: service_healthy
-
     ports:
       - "${YAK_OPS_PORT:-9001}:80"
+    networks:
+      - yak-ops-network
 
 volumes:
+  yak-ops-data:
+    name: yak-ops-data
   yak-ops-logs:
+    name: yak-ops-logs
   yak-ops-jdbc-drivers:
+    name: yak-ops-jdbc-drivers
+
+networks:
+  yak-ops-network:
+    name: yak-ops-network
+    driver: bridge

--- a/compose.yaml
+++ b/compose.yaml
@@ -4,10 +4,10 @@ services:
     container_name: yak-ops-mysql
     restart: unless-stopped
     environment:
-      MYSQL_ROOT_PASSWORD: ${MYSQL_ROOT_PASSWORD:-change_me}
+      MYSQL_ROOT_PASSWORD: ${MYSQL_ROOT_PASSWORD:-yak_ops_root_password}
       MYSQL_DATABASE: ${MYSQL_DATABASE:-yak_ops}
-      MYSQL_USER: ${MYSQL_USER:-linkup}
-      MYSQL_PASSWORD: ${MYSQL_PASSWORD:-change_me}
+      MYSQL_USER: ${MYSQL_USER:-yak_ops}
+      MYSQL_PASSWORD: ${MYSQL_PASSWORD:-yak_ops_password}
       TZ: Asia/Shanghai
     command:
       - --character-set-server=utf8mb4
@@ -49,8 +49,8 @@ services:
       # Yak Security and Yak Ops business modules share this datasource by
       # default. The MySQL application user owns MYSQL_DATABASE.
       YAK_DATASOURCE_URL: "jdbc:mysql://mysql:3306/${MYSQL_DATABASE:-yak_ops}?useUnicode=true&allowPublicKeyRetrieval=true&characterEncoding=UTF-8&useSSL=false&serverTimezone=Asia/Shanghai"
-      YAK_DATASOURCE_USERNAME: ${MYSQL_USER:-linkup}
-      YAK_DATASOURCE_PASSWORD: ${MYSQL_PASSWORD:-change_me}
+      YAK_DATASOURCE_USERNAME: ${MYSQL_USER:-yak_ops}
+      YAK_DATASOURCE_PASSWORD: ${MYSQL_PASSWORD:-yak_ops_password}
 
       YAK_SECURITY_BOOTSTRAP_USERNAME: ${YAK_SECURITY_BOOTSTRAP_USERNAME:-root}
       YAK_SECURITY_BOOTSTRAP_PASSWORD: ${YAK_SECURITY_BOOTSTRAP_PASSWORD:-Root@123456}

--- a/compose.yaml
+++ b/compose.yaml
@@ -3,25 +3,20 @@ services:
     image: mysql:8.0.39
     container_name: yak-ops-mysql
     restart: unless-stopped
-
     environment:
       MYSQL_ROOT_PASSWORD: ${MYSQL_ROOT_PASSWORD:-change_me}
       MYSQL_DATABASE: ${MYSQL_DATABASE:-yak_ops}
       MYSQL_USER: ${MYSQL_USER:-linkup}
       MYSQL_PASSWORD: ${MYSQL_PASSWORD:-change_me}
       TZ: Asia/Shanghai
-
     command:
       - --character-set-server=utf8mb4
       - --collation-server=utf8mb4_unicode_ci
       - --default-time-zone=+08:00
-
     ports:
       - "${MYSQL_HOST_PORT:-3306}:3306"
-
     volumes:
       - mysql-data:/var/lib/mysql
-
     healthcheck:
       test:
         - CMD-SHELL
@@ -30,105 +25,72 @@ services:
       timeout: 5s
       retries: 10
       start_period: 30s
-
     networks:
       - yak-ops-network
 
-
-  yak-ops-api:
-    image: ${YAK_OPS_API_IMAGE:-yak-ops-api:latest}
-    container_name: yak-ops-api
+  yak-ops-backend:
+    image: ${YAK_OPS_API_IMAGE:-weifuwan/yak-ops-api:0.1.0}
+    container_name: yak-ops-backend
     restart: unless-stopped
-
     build:
       context: .
       dockerfile: Dockerfile
       target: backend-runtime
-
     depends_on:
       mysql:
         condition: service_healthy
-
     environment:
       TZ: Asia/Shanghai
-
       JAVA_OPTS: ${JAVA_OPTS:--Xms512m -Xmx1024m}
-
       APP_OPTS: ${APP_OPTS:-}
-
       SERVER_PORT: 9527
-
       SPRING_PROFILES_ACTIVE: mysql
 
-      YAK_OPS_DATABASE_TYPE: mysql
-      YAK_OPS_DATABASE_HOST: mysql
-      YAK_OPS_DATABASE_PORT: 3306
-      YAK_OPS_DATABASE_NAME: ${MYSQL_DATABASE:-yak_ops}
-
-      # Shared datasource – both yak.security.datasource and yak.database read these.
-      # Override with YAK_SECURITY_DATASOURCE_* or YAK_DATABASE_* to split databases.
+      # Yak Security and Yak Ops business modules share this datasource by
+      # default. The MySQL application user owns MYSQL_DATABASE.
       YAK_DATASOURCE_URL: "jdbc:mysql://mysql:3306/${MYSQL_DATABASE:-yak_ops}?useUnicode=true&allowPublicKeyRetrieval=true&characterEncoding=UTF-8&useSSL=false&serverTimezone=Asia/Shanghai"
-      YAK_DATASOURCE_USERNAME: ${MYSQL_ROOT_PASSWORD:+root}
-      YAK_DATASOURCE_PASSWORD: ${MYSQL_ROOT_PASSWORD:-change_me}
+      YAK_DATASOURCE_USERNAME: ${MYSQL_USER:-linkup}
+      YAK_DATASOURCE_PASSWORD: ${MYSQL_PASSWORD:-change_me}
 
-      SPRING_FLYWAY_ENABLED: "true"
+      YAK_SECURITY_BOOTSTRAP_USERNAME: ${YAK_SECURITY_BOOTSTRAP_USERNAME:-root}
+      YAK_SECURITY_BOOTSTRAP_PASSWORD: ${YAK_SECURITY_BOOTSTRAP_PASSWORD:-Root@123456}
 
       YAK_OPS_DATASOURCE_MASTER_KEY: ${YAK_OPS_DATASOURCE_MASTER_KEY:?Please set YAK_OPS_DATASOURCE_MASTER_KEY in .env}
-
+      YAK_RESOURCE_LOCAL_BASE_DIRECTORY: /opt/yak-ops/data/resources
     expose:
       - "9527"
-
     volumes:
+      - yak-ops-data:/opt/yak-ops/data
       - yak-ops-logs:/opt/yak-ops/logs
       - yak-ops-jdbc-drivers:/opt/yak-ops/jdbc-drivers
-
-    healthcheck:
-      test:
-        - CMD-SHELL
-        - 'bash -c "</dev/tcp/127.0.0.1/9527"'
-      interval: 10s
-      timeout: 5s
-      retries: 12
-      start_period: 30s
-
     networks:
       - yak-ops-network
 
-
-  yak-ops:
-    image: ${YAK_OPS_IMAGE:-yak-ops:latest}
-    container_name: yak-ops
+  yak-ops-frontend:
+    image: ${YAK_OPS_IMAGE:-weifuwan/yak-ops:0.1.0}
+    container_name: yak-ops-frontend
     restart: unless-stopped
-
     build:
       context: .
       dockerfile: Dockerfile
       target: frontend-runtime
-
-    healthcheck:
-      disable: true
-
     depends_on:
-      yak-ops-api:
+      yak-ops-backend:
         condition: service_healthy
-
     ports:
-      - "${YAK_OPS_PORT:-9527}:80"
-
+      - "${YAK_OPS_PORT:-9001}:80"
     networks:
       - yak-ops-network
-
 
 volumes:
   mysql-data:
     name: yak-ops-mysql-data
-
+  yak-ops-data:
+    name: yak-ops-data
   yak-ops-logs:
     name: yak-ops-logs
-
   yak-ops-jdbc-drivers:
     name: yak-ops-jdbc-drivers
-
 
 networks:
   yak-ops-network:

--- a/docker/nginx/default.conf
+++ b/docker/nginx/default.conf
@@ -1,0 +1,85 @@
+server {
+    listen 80;
+    server_name _;
+
+    absolute_redirect off;
+
+    root /usr/share/nginx/html;
+    index index.html;
+
+    charset utf-8;
+    client_max_body_size 1024m;
+
+    # React / Umi SPA routes.
+    location / {
+        try_files $uri /index.html;
+    }
+
+    # Yak Ops business API.
+    location /api/ {
+        proxy_pass http://yak-ops-backend:9527;
+        proxy_http_version 1.1;
+
+        proxy_set_header Host $http_host;
+        proxy_set_header X-Forwarded-Host $http_host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+
+        proxy_connect_timeout 60s;
+        proxy_send_timeout 3600s;
+        proxy_read_timeout 3600s;
+        proxy_buffering off;
+        proxy_redirect off;
+    }
+
+    # Yak Security ingress. Keep the existing prefix handling used by the
+    # distribution nginx configuration while routing to the Compose backend.
+    location /yak-security/ {
+        proxy_pass http://yak-ops-backend:9527/;
+        proxy_http_version 1.1;
+
+        proxy_set_header Host $http_host;
+        proxy_set_header X-Forwarded-Host $http_host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+
+        proxy_cookie_domain ~.+ $host;
+        proxy_cookie_path / /yak-security/;
+        proxy_cookie_flags ~ samesite=lax;
+
+        proxy_connect_timeout 60s;
+        proxy_send_timeout 3600s;
+        proxy_read_timeout 3600s;
+        proxy_buffering off;
+        proxy_redirect off;
+    }
+
+    # STOMP / SockJS / WebSocket.
+    location /ws {
+        proxy_pass http://yak-ops-backend:9527;
+        proxy_http_version 1.1;
+
+        proxy_set_header Upgrade $http_upgrade;
+        proxy_set_header Connection "upgrade";
+        proxy_set_header Host $http_host;
+        proxy_set_header X-Forwarded-Host $http_host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+
+        proxy_connect_timeout 60s;
+        proxy_send_timeout 3600s;
+        proxy_read_timeout 3600s;
+        proxy_buffering off;
+        proxy_redirect off;
+    }
+
+    # Hashed frontend assets are safe to cache aggressively.
+    location ~* \.(js|css|png|jpg|jpeg|gif|svg|ico|woff|woff2|ttf)$ {
+        expires 7d;
+        add_header Cache-Control "public, max-age=604800, immutable";
+        try_files $uri =404;
+    }
+}

--- a/yak-ops-dist/src/main/assembly/assembly.xml
+++ b/yak-ops-dist/src/main/assembly/assembly.xml
@@ -16,7 +16,7 @@
             <includes>
                 <include>io.yak.ops:yak-ops-boot</include>
             </includes>
-            <outputFileNameMapping>yak-ops-boot.jar</outputFileNameMapping>
+            <outputFileNameMapping>yak-ops-api.jar</outputFileNameMapping>
         </dependencySet>
     </dependencySets>
 


### PR DESCRIPTION
## What changed

- Harden the existing multi-target `Dockerfile` so it packages two production runtime images:
  - `backend-runtime`: Java 21 + Yak Ops Spring Boot distribution
  - `frontend-runtime`: Nginx + built Umi frontend
- Add a Docker-specific Nginx configuration that proxies API, Yak Security, and WebSocket traffic to `yak-ops-backend`.
- Rework `compose.yaml` into the requested three-service stack:
  - `mysql`
  - `yak-ops-backend`
  - `yak-ops-frontend`
- Keep MySQL, application data, logs, and external JDBC drivers on named volumes.
- Make the backend use the dedicated MySQL application user instead of connecting as `root`.
- Add health-based startup ordering: MySQL -> backend -> frontend.
- Keep `compose.without-mysql.yaml` compatible with the new backend/frontend service naming.
- Refresh `.env.example` with consistent Yak Ops database credentials and bootstrap-account settings.

## Important fix

The distribution assembly previously emitted `libs/yak-ops-boot.jar`, while both `run-yak-ops.sh` and the Docker runtime expected `libs/yak-ops-api.jar`. That mismatch meant the backend Docker target could not pass its own artifact check. This PR aligns the distribution output with the runtime contract.

## Image build model

Yak Ops currently depends on the private `yak-framework` reactor. To avoid putting private GitHub credentials or source into Docker layers, the Dockerfile is intentionally a runtime-image packager rather than a private-dependency source builder.

The existing CI/release flow remains the build boundary:

```bash
cd yak-ops-ui
yarn install --frozen-lockfile
yarn build
cd ..

# yak-framework must already be available in the Maven repository
./mvnw clean package -DskipTests

docker compose build yak-ops-backend yak-ops-frontend
```

For released images, deployment stays simple:

```bash
cp .env.example .env
# replace passwords/master key for non-local use
docker compose pull
docker compose up -d
```

Then open `http://localhost:9001` with the current example configuration.

## Compose topology

```text
Browser
  |
  v
 yak-ops-frontend :80
  |  Nginx reverse proxy
  v
 yak-ops-backend :9527
  |
  v
 mysql :3306
```

## Security / persistence

- Backend uses `MYSQL_USER` / `MYSQL_PASSWORD`, not MySQL root credentials.
- `YAK_OPS_DATASOURCE_MASTER_KEY` remains mandatory.
- Persistent volumes are provided for MySQL data, Yak Ops application data, logs, and JDBC drivers.
- Bootstrap credentials remain configurable through `.env`.

## Scope

- Docker image packaging and Compose deployment only
- No business/API behavior changes
- No private `yak-framework` source or credentials are added to the image/build context