### PR TITLE
fix: load external JDBC drivers from jdbc-drivers

### DIFF
--- a/yak-ops-boot/pom.xml
+++ b/yak-ops-boot/pom.xml
@@ -149,6 +149,8 @@
                 <artifactId>spring-boot-maven-plugin</artifactId>
                 <configuration>
                     <mainClass>io.yak.ops.boot.YakOpsApplication</mainClass>
+                    <!-- Use PropertiesLauncher so the distribution can extend its runtime classpath with jdbc-drivers/. -->
+                    <layout>ZIP</layout>
                 </configuration>
             </plugin>
         </plugins>

--- a/yak-ops-dist/src/main/bin/run-yak-ops.sh
+++ b/yak-ops-dist/src/main/bin/run-yak-ops.sh
@@ -43,6 +43,7 @@ fi
 exec "${JAVA_BIN}" \
   "${JAVA_ARGS[@]}" \
   -Dyak.ops.home="${YAK_OPS_HOME}" \
+  -Dloader.path="${DRIVER_DIR}" \
   -Dlogging.config="${CONF_DIR}/logback-spring.xml" \
   -jar "${YAK_OPS_HOME}/libs/yak-ops-api.jar" \
   --spring.config.location="${CONF_DIR}/application.yml" \

--- a/yak-ops-dist/src/main/jdbc-drivers/README.md
+++ b/yak-ops-dist/src/main/jdbc-drivers/README.md
@@ -1,9 +1,17 @@
 # JDBC drivers
 
-Place JDBC driver JAR files in this directory.
+Place trusted vendor JDBC driver JAR files in this directory before starting Yak Ops.
 
-Examples:
+The distribution starts the Spring Boot application with `PropertiesLauncher` and adds this directory through `loader.path`. All JAR/ZIP files below `jdbc-drivers/` are therefore available to datasource plugins at runtime.
 
-- mysql-connector-java-8.0.29.jar
-- postgresql-42.x.x.jar
-- ojdbc11.jar
+MySQL and PostgreSQL drivers are bundled with Yak Ops and do not need to be copied here. This directory is mainly intended for drivers that cannot be redistributed with Yak Ops, for example:
+
+- Oracle: `ojdbc11.jar`
+- KingbaseES: the Kingbase JDBC driver JAR that provides `com.kingbase8.Driver`
+- Dameng: the Dameng JDBC driver JAR that provides `dm.jdbc.driver.DmDriver`
+
+After adding, replacing, or removing a driver, restart Yak Ops so the runtime classpath is rebuilt.
+
+For Docker deployments, mount the driver files into `/opt/yak-ops/jdbc-drivers` (the backend image already declares that path as a volume).
+
+Only install JDBC drivers from sources you trust. Driver JARs are executable code and run with the same permissions as the Yak Ops backend process.


### PR DESCRIPTION
## What changed

- package `yak-ops-boot` with Spring Boot `ZIP` layout so the executable JAR uses `PropertiesLauncher`
- add `${YAK_OPS_HOME}/jdbc-drivers` to `loader.path` in the distribution launcher
- document how to install Oracle, KingbaseES, and Dameng vendor JDBC drivers, including Docker mounting and restart/security notes

## Why

Datasource plugins for Oracle, KingbaseES, and Dameng already exist, but their vendor JDBC drivers are intentionally not bundled. The distribution already creates and exposes a `jdbc-drivers/` directory, but the directory was not part of the application runtime classpath, so copying a driver JAR there did not make it loadable by `Class.forName(...)`.

Using Spring Boot's `PropertiesLauncher` keeps the existing `java -jar` distribution model while allowing external runtime dependencies through `loader.path`.

## Result

After placing a trusted vendor JDBC JAR in `jdbc-drivers/` and restarting Yak Ops, the existing datasource connection test and JDBC catalog/SQL execution paths can load that driver. MySQL/PostgreSQL remain bundled, and Doris continues to reuse the bundled MySQL driver.

## Validation

- `bash -n yak-ops-dist/src/main/bin/run-yak-ops.sh`
- simulated the launcher with a fake Java executable and verified `-Dloader.path=<yak-ops-home>/jdbc-drivers` is passed before `-jar`
- reviewed the branch diff against `main`; only boot packaging, launcher wiring, and JDBC-driver documentation are changed
- repository CI will perform the full release distribution package build when the private yak-framework token is available
