### PR TITLE
fix(ui): repair imports after page domain migration

### DIFF
--- a/yak-ops-ui/src/pages/integration/batch-link-up/BasicInfoSection.tsx
+++ b/yak-ops-ui/src/pages/integration/batch-link-up/BasicInfoSection.tsx
@@ -2,7 +2,7 @@ import Header from "@/components/Header";
 import { useIntl } from "@umijs/max";
 import { Descriptions } from "antd";
 import React from "react";
-import DatabaseIcons from "../data-source/icon/DatabaseIcons";
+import DatabaseIcons from "@/pages/data-source/icon/DatabaseIcons";
 
 import { DoubleRightOutlined } from "@ant-design/icons";
 

--- a/yak-ops-ui/src/pages/integration/batch-link-up/DataSourceSelect.tsx
+++ b/yak-ops-ui/src/pages/integration/batch-link-up/DataSourceSelect.tsx
@@ -1,12 +1,12 @@
 import { SendOutlined } from "@ant-design/icons";
 import { Select } from "antd";
 import { useMemo } from "react";
-import MysqlIcon from "../data-source/icon/MysqlIcon";
-import OracleIcon from "../data-source/icon/OracleIcon";
-import PostgreSQL from "../data-source/icon/PsSqlIcon";
-import DorisIcon from "../data-source/icon/DorisIcon";
-import KingBaseIcon from "../data-source/icon/KingBaseIcon";
-import DaMengIcon from "../data-source/icon/DamengIcon";
+import MysqlIcon from "@/pages/data-source/icon/MysqlIcon";
+import OracleIcon from "@/pages/data-source/icon/OracleIcon";
+import PostgreSQL from "@/pages/data-source/icon/PsSqlIcon";
+import DorisIcon from "@/pages/data-source/icon/DorisIcon";
+import KingBaseIcon from "@/pages/data-source/icon/KingBaseIcon";
+import DaMengIcon from "@/pages/data-source/icon/DamengIcon";
 import "./index.less";
 // 类型定义
 interface DataSourceType {

--- a/yak-ops-ui/src/pages/integration/batch-link-up/DataSourceSelector.tsx
+++ b/yak-ops-ui/src/pages/integration/batch-link-up/DataSourceSelector.tsx
@@ -1,20 +1,20 @@
-import MysqlIcon from '../data-source/icon/MysqlIcon';
-import OracleIcon from '../data-source/icon/OracleIcon';
+import MysqlIcon from '@/pages/data-source/icon/MysqlIcon';
+import OracleIcon from '@/pages/data-source/icon/OracleIcon';
 import { SendOutlined } from '@ant-design/icons';
 import { Select } from 'antd';
-import CacheIcon from '../data-source/icon/CacheIcon';
-import ClickhouseIcon from '../data-source/icon/ClickhouseIcon';
-import DaMengIcon from '../data-source/icon/DamengIcon';
-import DB2Icon from '../data-source/icon/DB2Icon';
-import DorisIcon from '../data-source/icon/DorisIcon';
-import HiveIcon from '../data-source/icon/HiveIcon';
-import MongoDBIcon from '../data-source/icon/MongoDBIcon';
-import OpenGaussIcon from '../data-source/icon/OpenGaussIcon';
-import PostgreSQL from '../data-source/icon/PsSqlIcon';
-import SQLServer from '../data-source/icon/SQLServer';
-import StarRocksIcon from '../data-source/icon/StarRocksIcon';
-import KingBaseIcon from '../data-source/icon/KingBaseIcon';
-import TiDBIcon from '../data-source/icon/TiDBIcon';
+import CacheIcon from '@/pages/data-source/icon/CacheIcon';
+import ClickhouseIcon from '@/pages/data-source/icon/ClickhouseIcon';
+import DaMengIcon from '@/pages/data-source/icon/DamengIcon';
+import DB2Icon from '@/pages/data-source/icon/DB2Icon';
+import DorisIcon from '@/pages/data-source/icon/DorisIcon';
+import HiveIcon from '@/pages/data-source/icon/HiveIcon';
+import MongoDBIcon from '@/pages/data-source/icon/MongoDBIcon';
+import OpenGaussIcon from '@/pages/data-source/icon/OpenGaussIcon';
+import PostgreSQL from '@/pages/data-source/icon/PsSqlIcon';
+import SQLServer from '@/pages/data-source/icon/SQLServer';
+import StarRocksIcon from '@/pages/data-source/icon/StarRocksIcon';
+import KingBaseIcon from '@/pages/data-source/icon/KingBaseIcon';
+import TiDBIcon from '@/pages/data-source/icon/TiDBIcon';
 
 const { Option } = Select;
 

--- a/yak-ops-ui/src/pages/integration/batch-link-up/components/SyncTaskList/components/DataSourceSyncPlan.tsx
+++ b/yak-ops-ui/src/pages/integration/batch-link-up/components/SyncTaskList/components/DataSourceSyncPlan.tsx
@@ -3,7 +3,7 @@ import { useIntl } from '@umijs/max';
 import { Empty, Popover } from 'antd';
 import type { ReactNode } from 'react';
 
-import DatabaseIcons from '../../../../data-source/icon/DatabaseIcons';
+import DatabaseIcons from '@/pages/data-source/icon/DatabaseIcons';
 
 interface DataSourceSyncPlanProps {
   record: any;


### PR DESCRIPTION
## Summary

Follow-up to merged Stage 1 page-domain migration in #1020.

The directory migration added one extra nesting level for `pages/integration/batch-link-up`, while four files still referenced the standalone `pages/data-source/icon` directory through relative paths. Umi `max setup` therefore failed to resolve those imports.

This PR keeps the Stage 1 scope unchanged and only replaces those cross-page relative imports with stable `@/pages/data-source/icon/...` aliases.

## Changed files

- `BasicInfoSection.tsx`
- `DataSourceSelect.tsx`
- `DataSourceSelector.tsx`
- `components/SyncTaskList/components/DataSourceSyncPlan.tsx`

## Validation

A branch-level validation run completed successfully with:

- `yarn install --frozen-lockfile` (including `max setup`)
- `yarn build`
- `git diff --check`

No URL, menu, RBAC, permission, or business-logic changes are included.