### PR TITLE
refactor(sync): centralize offline connector profiles

### DIFF
--- a/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-offline/src/main/java/io/yak/ops/business/sync/offline/connector/OfflineSyncConnectorProfile.java
+++ b/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-offline/src/main/java/io/yak/ops/business/sync/offline/connector/OfflineSyncConnectorProfile.java
@@ -1,0 +1,43 @@
+package io.yak.ops.business.sync.offline.connector;
+
+import io.yak.ops.common.enums.datasource.DataSourceDbType;
+import java.util.Objects;
+import org.springframework.util.StringUtils;
+
+/**
+ * Yak Ops 离线同步产品数据源与 Link-Up 执行 Connector 的稳定映射。
+ *
+ * <p>Profile 描述控制面默认选择，不代表 Worker 当前一定已加载对应 Connector；
+ * Worker 运行时能力与可用性由后续 Connector Schema / runtime discovery 阶段负责。</p>
+ *
+ * @author weifuwan
+ */
+public record OfflineSyncConnectorProfile(
+    String profileId,
+    DataSourceDbType dbType,
+    String sourceConnectorId,
+    String sinkConnectorId,
+    String pluginName,
+    boolean defaultProfile) {
+
+  public OfflineSyncConnectorProfile {
+    if (!StringUtils.hasText(profileId)) {
+      throw new IllegalArgumentException("profileId 不能为空");
+    }
+    dbType = Objects.requireNonNull(dbType, "dbType");
+    if (!StringUtils.hasText(sourceConnectorId)) {
+      throw new IllegalArgumentException("sourceConnectorId 不能为空");
+    }
+    if (!StringUtils.hasText(sinkConnectorId)) {
+      throw new IllegalArgumentException("sinkConnectorId 不能为空");
+    }
+    if (!StringUtils.hasText(pluginName)) {
+      throw new IllegalArgumentException("pluginName 不能为空");
+    }
+
+    profileId = profileId.trim();
+    sourceConnectorId = sourceConnectorId.trim().toLowerCase(java.util.Locale.ROOT);
+    sinkConnectorId = sinkConnectorId.trim().toLowerCase(java.util.Locale.ROOT);
+    pluginName = pluginName.trim();
+  }
+}

--- a/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-offline/src/main/java/io/yak/ops/business/sync/offline/connector/OfflineSyncConnectorRegistry.java
+++ b/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-offline/src/main/java/io/yak/ops/business/sync/offline/connector/OfflineSyncConnectorRegistry.java
@@ -1,0 +1,158 @@
+package io.yak.ops.business.sync.offline.connector;
+
+import io.yak.ops.common.enums.datasource.DataSourceDbType;
+import java.util.EnumMap;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+
+/**
+ * 离线同步 Connector Profile 注册表。
+ *
+ * <p>这里是 Yak Ops 控制面默认 {@code dbType -> connectorId} 关系的单一后端来源。
+ * 旧版本曾由 {@code ConnectorIdResolver} 自己维护 JDBC 类型集合；Registry 建立后，
+ * Resolver 只负责兼容输入优先级与标识规范化。</p>
+ *
+ * <p>当前阶段严格保持历史执行语义：现有六类产品数据源默认仍走 JDBC。
+ * StarRocks / ClickHouse / DB2 等尚未进入 Yak Ops 数据源类型模型的历史标签也继续按
+ * 旧行为解析为 JDBC，避免本次重构偷偷改变存量定义。</p>
+ *
+ * @author weifuwan
+ */
+public final class OfflineSyncConnectorRegistry {
+
+  private static final String JDBC = "jdbc";
+
+  private static final List<OfflineSyncConnectorProfile> PROFILES = List.of(
+      profile("mysql-jdbc", DataSourceDbType.MYSQL, "JDBC-MYSQL"),
+      profile("oracle-jdbc", DataSourceDbType.ORACLE, "JDBC-ORACLE"),
+      profile("postgresql-jdbc", DataSourceDbType.POSTGRE_SQL, "JDBC-POSTGRESQL"),
+      profile("doris-jdbc", DataSourceDbType.DORIS, "DORIS"),
+      profile("kingbase-jdbc", DataSourceDbType.KINGBASE, "JDBC-KINGBASE"),
+      profile("dameng-jdbc", DataSourceDbType.DAMENG, "JDBC-DAMENG"));
+
+  /**
+   * Compatibility labels accepted by the old front/back resolver although Yak Ops currently does
+   * not expose all of them as DataSourceDbType values.
+   */
+  private static final Set<String> LEGACY_JDBC_LABELS = Set.of(
+      "JDBC",
+      "MARIADB",
+      "SQLSERVER",
+      "SQL_SERVER",
+      "STARROCKS",
+      "CLICKHOUSE",
+      "DB2",
+      "HIVE",
+      "DM");
+
+  private static final Map<String, DataSourceDbType> DATA_SOURCE_ALIASES = Map.of(
+      "POSTGRESQL", DataSourceDbType.POSTGRE_SQL,
+      "POSTGRES", DataSourceDbType.POSTGRE_SQL);
+
+  private static final Map<DataSourceDbType, OfflineSyncConnectorProfile> DEFAULTS =
+      buildDefaults();
+
+  private OfflineSyncConnectorRegistry() {
+  }
+
+  public static List<OfflineSyncConnectorProfile> profiles() {
+    return PROFILES;
+  }
+
+  public static Optional<OfflineSyncConnectorProfile> defaultProfile(String value) {
+    DataSourceDbType dbType = parseDbType(value);
+    return dbType == null ? Optional.empty() : Optional.ofNullable(DEFAULTS.get(dbType));
+  }
+
+  /**
+   * Resolves a product/legacy datasource label to its historical default Connector ID.
+   * Unknown labels stay empty so framework-neutral connector identifiers can pass through.
+   */
+  public static Optional<String> defaultConnectorId(String value) {
+    String normalized = normalize(value);
+    if (normalized == null) {
+      return Optional.empty();
+    }
+
+    Optional<OfflineSyncConnectorProfile> profile = defaultProfile(normalized);
+    if (profile.isPresent()) {
+      OfflineSyncConnectorProfile selected = profile.get();
+      if (!selected.sourceConnectorId().equals(selected.sinkConnectorId())) {
+        throw new IllegalStateException(
+            "当前兼容解析需要 Source/Sink 默认 Connector 一致：" + selected.profileId());
+      }
+      return Optional.of(selected.sourceConnectorId());
+    }
+
+    return LEGACY_JDBC_LABELS.contains(normalized)
+        ? Optional.of(JDBC)
+        : Optional.empty();
+  }
+
+  public static boolean isLegacyDatasourceLabel(String value) {
+    return defaultConnectorId(value).isPresent();
+  }
+
+  private static OfflineSyncConnectorProfile profile(
+      String profileId,
+      DataSourceDbType dbType,
+      String pluginName) {
+    return new OfflineSyncConnectorProfile(
+        profileId,
+        dbType,
+        JDBC,
+        JDBC,
+        pluginName,
+        true);
+  }
+
+  private static Map<DataSourceDbType, OfflineSyncConnectorProfile> buildDefaults() {
+    Map<DataSourceDbType, OfflineSyncConnectorProfile> result =
+        new EnumMap<>(DataSourceDbType.class);
+    Map<String, OfflineSyncConnectorProfile> profileIds = new LinkedHashMap<>();
+
+    for (OfflineSyncConnectorProfile profile : PROFILES) {
+      OfflineSyncConnectorProfile duplicateId = profileIds.put(profile.profileId(), profile);
+      if (duplicateId != null) {
+        throw new IllegalStateException("重复的离线同步 profileId：" + profile.profileId());
+      }
+      if (!profile.defaultProfile()) {
+        continue;
+      }
+      OfflineSyncConnectorProfile duplicateDefault = result.put(profile.dbType(), profile);
+      if (duplicateDefault != null) {
+        throw new IllegalStateException(
+            "数据源存在多个默认离线同步 Profile：" + profile.dbType());
+      }
+    }
+
+    return Map.copyOf(result);
+  }
+
+  private static DataSourceDbType parseDbType(String value) {
+    String normalized = normalize(value);
+    if (normalized == null) {
+      return null;
+    }
+    DataSourceDbType alias = DATA_SOURCE_ALIASES.get(normalized);
+    if (alias != null) {
+      return alias;
+    }
+    try {
+      return DataSourceDbType.valueOf(normalized);
+    } catch (IllegalArgumentException ignored) {
+      return null;
+    }
+  }
+
+  private static String normalize(String value) {
+    if (value == null || value.trim().isEmpty()) {
+      return null;
+    }
+    return value.trim().toUpperCase(Locale.ROOT).replace('-', '_');
+  }
+}

--- a/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-offline/src/main/java/io/yak/ops/business/sync/offline/engine/ConnectorIdResolver.java
+++ b/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-offline/src/main/java/io/yak/ops/business/sync/offline/engine/ConnectorIdResolver.java
@@ -1,55 +1,57 @@
 package io.yak.ops.business.sync.offline.engine;
 
+import io.yak.ops.business.sync.offline.connector.OfflineSyncConnectorRegistry;
 import java.util.Locale;
-import java.util.Set;
 import org.springframework.util.StringUtils;
 
 /**
  * 数据源类型与 Link-Up Connector 标识转换工具。
  *
- * Normalizes product datasource types and legacy connector labels to Link-Up connector IDs.
+ * <p>默认产品映射由 {@link OfflineSyncConnectorRegistry} 统一维护。这里仅保留历史输入
+ * 优先级与 Connector ID 规范化，避免前后续执行链路继续复制 datasource 类型集合。</p>
  *
  * @author weifuwan
  */
 public final class ConnectorIdResolver {
-
-  private static final Set<String> JDBC_TYPES = Set.of(
-      "JDBC",
-      "MYSQL",
-      "MARIADB",
-      "POSTGRE_SQL",
-      "POSTGRESQL",
-      "POSTGRES",
-      "ORACLE",
-      "SQLSERVER",
-      "SQL_SERVER",
-      "DORIS",
-      "STARROCKS",
-      "CLICKHOUSE",
-      "DB2",
-      "HIVE",
-      "KINGBASE",
-      "DAMENG",
-      "DM");
 
   private ConnectorIdResolver() {
   }
 
   public static String resolve(String connectorId, String connectorType, String dbType,
       String fallback) {
-    String value = firstText(connectorId, connectorType, dbType, fallback);
+    if (StringUtils.hasText(connectorId)) {
+      String explicit = connectorId.trim();
+      // Historical definitions sometimes stored product labels such as "Doris" in connectorId.
+      // Preserve those mixed/upper-case aliases, while a canonical lower-case connectorId such as
+      // "doris" is treated as an explicit engine identifier and must not be rewritten to JDBC.
+      if (hasUpperCase(explicit)) {
+        String legacy = OfflineSyncConnectorRegistry.defaultConnectorId(explicit).orElse(null);
+        if (StringUtils.hasText(legacy)) {
+          return legacy;
+        }
+      }
+      return normalizeConnectorId(explicit);
+    }
+
+    String value = firstText(connectorType, dbType, fallback);
     if (!StringUtils.hasText(value)) {
       throw new IllegalArgumentException("Connector 类型不能为空");
     }
-    String normalized = value.trim().toUpperCase(Locale.ROOT).replace('-', '_');
-    if (JDBC_TYPES.contains(normalized)) {
-      return "jdbc";
-    }
-    return normalized.toLowerCase(Locale.ROOT);
+
+    String registered = OfflineSyncConnectorRegistry.defaultConnectorId(value).orElse(null);
+    return StringUtils.hasText(registered) ? registered : normalizeConnectorId(value);
   }
 
   public static boolean isJdbc(String connectorId) {
     return "jdbc".equalsIgnoreCase(connectorId);
+  }
+
+  private static String normalizeConnectorId(String value) {
+    return value.trim().toLowerCase(Locale.ROOT).replace('-', '_');
+  }
+
+  private static boolean hasUpperCase(String value) {
+    return value.chars().anyMatch(Character::isUpperCase);
   }
 
   private static String firstText(String... values) {

--- a/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-offline/src/test/java/io/yak/ops/business/sync/offline/connector/OfflineSyncConnectorRegistryTest.java
+++ b/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-offline/src/test/java/io/yak/ops/business/sync/offline/connector/OfflineSyncConnectorRegistryTest.java
@@ -1,0 +1,38 @@
+package io.yak.ops.business.sync.offline.connector;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.yak.ops.common.enums.datasource.DataSourceDbType;
+import java.util.Map;
+import java.util.stream.Collectors;
+import org.junit.jupiter.api.Test;
+
+class OfflineSyncConnectorRegistryTest {
+
+  @Test
+  void shouldExposeOneDefaultProfileForEveryCurrentDatasourceType() {
+    Map<DataSourceDbType, OfflineSyncConnectorProfile> profiles =
+        OfflineSyncConnectorRegistry.profiles().stream()
+            .filter(OfflineSyncConnectorProfile::defaultProfile)
+            .collect(Collectors.toMap(OfflineSyncConnectorProfile::dbType, value -> value));
+
+    assertThat(profiles).containsOnlyKeys(DataSourceDbType.values());
+    assertThat(profiles.values())
+        .allSatisfy(profile -> {
+          assertThat(profile.sourceConnectorId()).isEqualTo("jdbc");
+          assertThat(profile.sinkConnectorId()).isEqualTo("jdbc");
+        });
+  }
+
+  @Test
+  void shouldKeepHistoricalAliasesOnJdbcWithoutTurningCanonicalIdsIntoAliases() {
+    assertThat(OfflineSyncConnectorRegistry.defaultConnectorId("POSTGRESQL"))
+        .contains("jdbc");
+    assertThat(OfflineSyncConnectorRegistry.defaultConnectorId("DB2"))
+        .contains("jdbc");
+    assertThat(OfflineSyncConnectorRegistry.defaultConnectorId("STARROCKS"))
+        .contains("jdbc");
+    assertThat(OfflineSyncConnectorRegistry.defaultConnectorId("HTTP"))
+        .isEmpty();
+  }
+}

--- a/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-offline/src/test/java/io/yak/ops/business/sync/offline/engine/ConnectorIdResolverTest.java
+++ b/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-offline/src/test/java/io/yak/ops/business/sync/offline/engine/ConnectorIdResolverTest.java
@@ -12,11 +12,15 @@ class ConnectorIdResolverTest {
     assertThat(ConnectorIdResolver.resolve(null, null, "POSTGRE_SQL", null)).isEqualTo("jdbc");
     assertThat(ConnectorIdResolver.resolve("Doris", null, null, null)).isEqualTo("jdbc");
     assertThat(ConnectorIdResolver.resolve(null, "Jdbc", null, null)).isEqualTo("jdbc");
+    assertThat(ConnectorIdResolver.resolve(null, null, "DB2", null)).isEqualTo("jdbc");
   }
 
   @Test
-  void shouldKeepFutureConnectorIdsFrameworkNeutral() {
+  void shouldKeepCanonicalConnectorIdsFrameworkNeutral() {
+    assertThat(ConnectorIdResolver.resolve("doris", null, null, null)).isEqualTo("doris");
+    assertThat(ConnectorIdResolver.resolve("starrocks", null, null, null)).isEqualTo("starrocks");
     assertThat(ConnectorIdResolver.resolve("HTTP", null, null, null)).isEqualTo("http");
     assertThat(ConnectorIdResolver.resolve(null, "file", null, null)).isEqualTo("file");
+    assertThat(ConnectorIdResolver.resolve("custom-api", null, null, null)).isEqualTo("custom_api");
   }
 }

--- a/yak-ops-ui/src/pages/integration/batch-link-up/DataSourceSelect.tsx
+++ b/yak-ops-ui/src/pages/integration/batch-link-up/DataSourceSelect.tsx
@@ -1,13 +1,14 @@
 import { SendOutlined } from "@ant-design/icons";
 import { Select } from "antd";
-import { useMemo } from "react";
 import MysqlIcon from "@/components/data-source/icons/MysqlIcon";
 import OracleIcon from "@/components/data-source/icons/OracleIcon";
 import PostgreSQL from "@/components/data-source/icons/PsSqlIcon";
 import DorisIcon from "@/components/data-source/icons/DorisIcon";
 import KingBaseIcon from "@/components/data-source/icons/KingBaseIcon";
 import DaMengIcon from "@/components/data-source/icons/DamengIcon";
+import { defaultOfflineSyncConnectorProfile } from "./connectorProfiles";
 import "./index.less";
+
 // 类型定义
 interface DataSourceType {
   value: string;
@@ -16,12 +17,20 @@ interface DataSourceType {
   connectorType?: string;
   pluginName?: string;
 }
-// 生成数据源选项配置
+
+const executionMetadata = (dbType: string) => {
+  const profile = defaultOfflineSyncConnectorProfile(dbType);
+  return {
+    connectorType: profile?.connectorType,
+    pluginName: profile?.pluginName,
+  };
+};
+
+// 生成数据源选项配置。图标/文案属于 UI；执行 Connector 元数据统一来自 Profile Registry。
 export const generateDataSourceOptions = (): DataSourceType[] => [
   {
     value: "MYSQL",
-    connectorType: "Jdbc",
-    pluginName: "JDBC-MYSQL",
+    ...executionMetadata("MYSQL"),
     label: (
       <div style={{ display: "flex", alignItems: "center" }}>
         <MysqlIcon height="24px" width="24px" />
@@ -31,8 +40,7 @@ export const generateDataSourceOptions = (): DataSourceType[] => [
   },
   {
     value: "ORACLE",
-    connectorType: "Jdbc",
-    pluginName: "JDBC-ORACLE",
+    ...executionMetadata("ORACLE"),
     label: (
       <div style={{ display: "flex", alignItems: "center" }}>
         <OracleIcon />
@@ -42,8 +50,7 @@ export const generateDataSourceOptions = (): DataSourceType[] => [
   },
   {
     value: "POSTGRE_SQL",
-    connectorType: "Jdbc",
-    pluginName: "JDBC-POSTGRESQL",
+    ...executionMetadata("POSTGRE_SQL"),
     label: (
       <div style={{ display: "flex", alignItems: "center" }}>
         <PostgreSQL />
@@ -53,8 +60,7 @@ export const generateDataSourceOptions = (): DataSourceType[] => [
   },
   {
     value: "DORIS",
-    connectorType: "Doris",
-    pluginName: "DORIS",
+    ...executionMetadata("DORIS"),
     label: (
       <div style={{ display: "flex", alignItems: "center" }}>
         <DorisIcon />
@@ -64,8 +70,7 @@ export const generateDataSourceOptions = (): DataSourceType[] => [
   },
   {
     value: "KINGBASE",
-    connectorType: "Jdbc",
-    pluginName: "JDBC-KINGBASE",
+    ...executionMetadata("KINGBASE"),
     label: (
       <div style={{ display: "flex", alignItems: "center" }}>
         <KingBaseIcon />
@@ -75,8 +80,7 @@ export const generateDataSourceOptions = (): DataSourceType[] => [
   },
   {
     value: "DAMENG",
-    connectorType: "Jdbc",
-    pluginName: "JDBC-DAMENG",
+    ...executionMetadata("DAMENG"),
     label: (
       <div style={{ display: "flex", alignItems: "center" }}>
         <DaMengIcon />
@@ -86,14 +90,13 @@ export const generateDataSourceOptions = (): DataSourceType[] => [
   },
 ];
 
-
 // 数据源选择器组件
 interface DataSourceSelectProps {
   value: any;
   onChange: (value: string, option: any) => void;
   placeholder: string;
   prefix: string;
-  dataSourceOptions: any[],
+  dataSourceOptions: any[];
   width?: string;
 }
 

--- a/yak-ops-ui/src/pages/integration/batch-link-up/connectorProfiles.test.ts
+++ b/yak-ops-ui/src/pages/integration/batch-link-up/connectorProfiles.test.ts
@@ -1,0 +1,34 @@
+import {
+  connectorIdForDataSourceType,
+  defaultOfflineSyncConnectorProfile,
+  OFFLINE_SYNC_CONNECTOR_PROFILES,
+} from './connectorProfiles';
+
+test('keeps current datasource profiles on their historical jdbc execution path', () => {
+  expect(OFFLINE_SYNC_CONNECTOR_PROFILES.map((profile) => profile.dbType)).toEqual([
+    'MYSQL',
+    'ORACLE',
+    'POSTGRE_SQL',
+    'DORIS',
+    'KINGBASE',
+    'DAMENG',
+  ]);
+  expect(
+    OFFLINE_SYNC_CONNECTOR_PROFILES.every(
+      (profile) =>
+        profile.sourceConnectorId === 'jdbc' && profile.sinkConnectorId === 'jdbc',
+    ),
+  ).toBe(true);
+});
+
+test('resolves aliases from one frontend registry instead of component-local sets', () => {
+  expect(connectorIdForDataSourceType('POSTGRESQL')).toBe('jdbc');
+  expect(connectorIdForDataSourceType('DB2')).toBe('jdbc');
+  expect(connectorIdForDataSourceType('STARROCKS')).toBe('jdbc');
+  expect(connectorIdForDataSourceType('HTTP')).toBe('http');
+  expect(connectorIdForDataSourceType('custom-api')).toBe('custom_api');
+  expect(defaultOfflineSyncConnectorProfile('postgres')).toMatchObject({
+    profileId: 'postgresql-jdbc',
+    dbType: 'POSTGRE_SQL',
+  });
+});

--- a/yak-ops-ui/src/pages/integration/batch-link-up/connectorProfiles.ts
+++ b/yak-ops-ui/src/pages/integration/batch-link-up/connectorProfiles.ts
@@ -1,0 +1,122 @@
+export type OfflineSyncConnectorRole = 'SOURCE' | 'SINK';
+
+export interface OfflineSyncConnectorProfile {
+  profileId: string;
+  dbType: string;
+  sourceConnectorId: string;
+  sinkConnectorId: string;
+  /** Historical UI label retained until the old editor is fully removed. */
+  connectorType: string;
+  pluginName: string;
+  defaultProfile: boolean;
+}
+
+/**
+ * Control-plane default execution profiles for the datasource types Yak Ops exposes today.
+ *
+ * Keep this module as the only frontend dbType -> connector mapping. The presentation layer may
+ * still own icons/labels, but execution identity must not be redefined in individual components.
+ */
+export const OFFLINE_SYNC_CONNECTOR_PROFILES: readonly OfflineSyncConnectorProfile[] = [
+  {
+    profileId: 'mysql-jdbc',
+    dbType: 'MYSQL',
+    sourceConnectorId: 'jdbc',
+    sinkConnectorId: 'jdbc',
+    connectorType: 'Jdbc',
+    pluginName: 'JDBC-MYSQL',
+    defaultProfile: true,
+  },
+  {
+    profileId: 'oracle-jdbc',
+    dbType: 'ORACLE',
+    sourceConnectorId: 'jdbc',
+    sinkConnectorId: 'jdbc',
+    connectorType: 'Jdbc',
+    pluginName: 'JDBC-ORACLE',
+    defaultProfile: true,
+  },
+  {
+    profileId: 'postgresql-jdbc',
+    dbType: 'POSTGRE_SQL',
+    sourceConnectorId: 'jdbc',
+    sinkConnectorId: 'jdbc',
+    connectorType: 'Jdbc',
+    pluginName: 'JDBC-POSTGRESQL',
+    defaultProfile: true,
+  },
+  {
+    profileId: 'doris-jdbc',
+    dbType: 'DORIS',
+    sourceConnectorId: 'jdbc',
+    sinkConnectorId: 'jdbc',
+    connectorType: 'Doris',
+    pluginName: 'DORIS',
+    defaultProfile: true,
+  },
+  {
+    profileId: 'kingbase-jdbc',
+    dbType: 'KINGBASE',
+    sourceConnectorId: 'jdbc',
+    sinkConnectorId: 'jdbc',
+    connectorType: 'Jdbc',
+    pluginName: 'JDBC-KINGBASE',
+    defaultProfile: true,
+  },
+  {
+    profileId: 'dameng-jdbc',
+    dbType: 'DAMENG',
+    sourceConnectorId: 'jdbc',
+    sinkConnectorId: 'jdbc',
+    connectorType: 'Jdbc',
+    pluginName: 'JDBC-DAMENG',
+    defaultProfile: true,
+  },
+] as const;
+
+const LEGACY_JDBC_TYPES = new Set([
+  'JDBC',
+  'MARIADB',
+  'SQLSERVER',
+  'SQL_SERVER',
+  'STARROCKS',
+  'CLICKHOUSE',
+  'DB2',
+  'HIVE',
+  'DM',
+]);
+
+const DB_TYPE_ALIASES: Record<string, string> = {
+  POSTGRESQL: 'POSTGRE_SQL',
+  POSTGRES: 'POSTGRE_SQL',
+};
+
+const normalizeDbType = (value?: string): string => {
+  const normalized = String(value || '').trim().toUpperCase().replace(/-/g, '_');
+  return DB_TYPE_ALIASES[normalized] || normalized;
+};
+
+export const defaultOfflineSyncConnectorProfile = (
+  dbType?: string,
+): OfflineSyncConnectorProfile | undefined => {
+  const normalized = normalizeDbType(dbType);
+  return OFFLINE_SYNC_CONNECTOR_PROFILES.find(
+    (profile) => profile.defaultProfile && profile.dbType === normalized,
+  );
+};
+
+export const connectorIdForDataSourceType = (
+  value?: string,
+  role: OfflineSyncConnectorRole = 'SOURCE',
+): string => {
+  const normalized = normalizeDbType(value);
+  if (!normalized) return '';
+
+  const profile = defaultOfflineSyncConnectorProfile(normalized);
+  if (profile) {
+    return role === 'SINK' ? profile.sinkConnectorId : profile.sourceConnectorId;
+  }
+  return LEGACY_JDBC_TYPES.has(normalized)
+    ? 'jdbc'
+    : normalized.toLowerCase();
+};

--- a/yak-ops-ui/src/pages/integration/batch-link-up/detail/form-schema/valueAdapter.ts
+++ b/yak-ops-ui/src/pages/integration/batch-link-up/detail/form-schema/valueAdapter.ts
@@ -1,30 +1,7 @@
+import { connectorIdForDataSourceType } from '../../connectorProfiles';
 import type { ConnectorFormValues, ConnectorRole } from './types';
 
-const RELATIONAL_TYPES = new Set([
-  'MYSQL',
-  'MARIADB',
-  'POSTGRE_SQL',
-  'POSTGRESQL',
-  'POSTGRES',
-  'ORACLE',
-  'SQLSERVER',
-  'SQL_SERVER',
-  'DORIS',
-  'STARROCKS',
-  'CLICKHOUSE',
-  'DB2',
-  'HIVE',
-  'KINGBASE',
-  'DAMENG',
-  'DM',
-  'JDBC',
-]);
-
-export const connectorIdForDataSourceType = (value?: string): string => {
-  const normalized = (value || '').trim().toUpperCase().replace(/-/g, '_');
-  if (!normalized) return '';
-  return RELATIONAL_TYPES.has(normalized) ? 'jdbc' : normalized.toLowerCase();
-};
+export { connectorIdForDataSourceType };
 
 const splitKeys = (value: unknown): string[] => {
   if (Array.isArray(value)) return value.map(String).filter(Boolean);


### PR DESCRIPTION
## Summary

Stage 1 of the Yak Ops control-plane connector adaptation plan.

This PR introduces a dedicated **Offline Sync Connector Profile / Registry** layer and removes the duplicated `dbType -> connectorId` type sets from the active offline-sync resolver/form-schema paths.

The scope is intentionally narrow: **no new datasource types, no Link-Up Connector Schema discovery, no runtime capability UI, and no JDBC -> native execution switch**.

## What changed

### Backend profile registry

Add:

- `OfflineSyncConnectorProfile`
- `OfflineSyncConnectorRegistry`

The registry now owns the current control-plane default execution mapping for the six datasource types already exposed by Yak Ops:

- MySQL -> `jdbc`
- Oracle -> `jdbc`
- PostgreSQL -> `jdbc`
- Doris -> `jdbc`
- KingbaseES -> `jdbc`
- Dameng -> `jdbc`

Each profile has a stable `profileId`, product `dbType`, Source/Sink connector IDs, plugin name, and default marker.

### Preserve historical aliases

The old resolver accepted additional JDBC labels that are not yet first-class Yak Ops datasource types, including:

- MariaDB
- SQL Server
- StarRocks
- ClickHouse
- DB2
- Hive
- DM

Those compatibility labels remain mapped to `jdbc` in this stage. This PR does not use the registry refactor to silently change their execution semantics.

### ConnectorIdResolver becomes normalization-only

`ConnectorIdResolver` no longer owns a `JDBC_TYPES` set. It delegates product/legacy mapping to `OfflineSyncConnectorRegistry` and keeps only:

- input precedence
- backward-compatible legacy label handling
- framework-neutral connector ID normalization

A compatibility boundary is made explicit:

- historical mixed/upper-case `connectorId = "Doris"` continues to resolve to `jdbc`
- canonical lower-case `connectorId = "doris"` is preserved as `doris`

This creates room for a future native Doris profile without rewriting an explicit engine connector ID.

### Frontend connector profile registry

Add `connectorProfiles.ts` as the only active frontend execution-mapping module.

It now owns:

- current datasource execution profiles
- PostgreSQL aliases
- legacy JDBC compatibility labels
- Source/Sink connector selection helper

`DataSourceSelect.tsx` keeps presentation concerns (icons / labels) but obtains connector/plugin metadata from the profile registry.

`valueAdapter.ts` no longer maintains its own `RELATIONAL_TYPES` set and reuses the central profile resolver instead.

## Compatibility / non-goals

This PR deliberately does **not**:

- add DB2/openGauss/SQL Server/OceanBase/etc. to `DataSourceDbType`
- change Doris from JDBC to native
- enable StarRocks/ClickHouse native execution in Yak Ops
- expose Link-Up connector capabilities
- change single-table or multi-table UI behavior
- add Worker connector runtime discovery
- modify Link-Up JobSpec shape

The purpose of this stage is only to establish a stable profile boundary before those adaptations begin.

## Tests

Added/updated coverage for:

- one default backend profile for every currently supported `DataSourceDbType`
- current six product types remain JDBC
- PostgreSQL and historical JDBC aliases stay compatible
- canonical lower-case native-style connector IDs remain framework-neutral
- unknown connector normalization preserves the previous `-` -> `_` behavior
- frontend profile defaults and aliases
- existing `valueAdapter` datasource mapping expectations continue to pass through the new registry

## Validation status

- branch is based directly on current `main` (`760aad14651b0158f93569f9fde8a2dede8ba85b`)
- compare result is ahead by 1 commit and behind by 0
- final diff is limited to the offline-sync connector mapping/profile boundary and its tests
- GitHub currently returns no commit statuses and no workflow runs for this head commit
- the execution environment cannot resolve `github.com` for a local clone/build, so no Maven or frontend test pass is claimed here

## Next stage

PR 2 can consume Link-Up Connector Schema / Worker runtime discovery on top of this profile boundary, without reintroducing datasource-specific mapping sets across the control plane.