### PR TITLE
feat(sync): discover Link-Up connector runtime capabilities

### DIFF
--- a/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-offline/src/main/java/io/yak/ops/business/sync/offline/controller/OfflineJobExecutionController.java
+++ b/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-offline/src/main/java/io/yak/ops/business/sync/offline/controller/OfflineJobExecutionController.java
@@ -8,6 +8,7 @@ import io.yak.ops.business.sync.offline.execution.OfflineJobExecutionService;
 import io.yak.ops.common.bean.dto.sync.offline.OfflineBatchOperationDTO;
 import io.yak.ops.common.bean.dto.sync.offline.OfflineJobExecutionQueryDTO;
 import io.yak.ops.common.bean.vo.sync.offline.OfflineBatchOperationVO;
+import io.yak.ops.common.bean.vo.sync.offline.OfflineConnectorRuntimeSnapshotVO;
 import io.yak.ops.common.bean.vo.sync.offline.OfflineEngineHealthVO;
 import io.yak.ops.common.bean.vo.sync.offline.OfflineExecutionLogPageVO;
 import io.yak.ops.common.bean.vo.sync.offline.OfflineJobExecutionDetailVO;
@@ -35,6 +36,20 @@ public class OfflineJobExecutionController {
   @GetMapping({"/api/v1/job/batch-execution/health", "/api/v1/executor/health"})
   @ProjectScope(ProjectMigrationMode.LEGACY_GLOBAL)
   public Result<OfflineEngineHealthVO> health() { return Result.success(service.health()); }
+
+  @GetMapping("/api/v1/job/batch-execution/connectors")
+  @ProjectScope(ProjectMigrationMode.LEGACY_GLOBAL)
+  public Result<OfflineConnectorRuntimeSnapshotVO> connectors() {
+    return Result.success(service.connectorRuntime());
+  }
+
+  @GetMapping("/api/v1/job/batch-execution/connectors/{connectorId}/schema")
+  @ProjectScope(ProjectMigrationMode.LEGACY_GLOBAL)
+  public Result<JsonNode> connectorSchema(
+      @PathVariable String connectorId,
+      @RequestParam String role) {
+    return Result.success(service.connectorSchema(connectorId, role));
+  }
 
   @PostMapping("/api/v1/job/batch-execution/{jobDefineId}/execute")
   public Result<OfflineJobExecutionVO> execute(@PathVariable Long jobDefineId) {

--- a/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-offline/src/main/java/io/yak/ops/business/sync/offline/engine/ConnectorIdResolver.java
+++ b/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-offline/src/main/java/io/yak/ops/business/sync/offline/engine/ConnectorIdResolver.java
@@ -1,6 +1,6 @@
 package io.yak.ops.business.sync.offline.engine;
 
-import io.yak.ops.business.sync.offline.connector.OfflineSyncConnectorRegistry;
+import io.yak.ops.business.sync.offline.engine.connector.OfflineSyncConnectorRegistry;
 import java.util.Locale;
 import org.springframework.util.StringUtils;
 

--- a/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-offline/src/main/java/io/yak/ops/business/sync/offline/engine/connector/LinkUpConnectorDiscoveryClient.java
+++ b/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-offline/src/main/java/io/yak/ops/business/sync/offline/engine/connector/LinkUpConnectorDiscoveryClient.java
@@ -1,0 +1,202 @@
+package io.yak.ops.business.sync.offline.engine.connector;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.yak.ops.business.sync.offline.config.ConditionalOnOfflineSyncEnabled;
+import io.yak.ops.business.sync.offline.config.OfflineSyncProperties;
+import java.io.IOException;
+import java.net.URI;
+import java.net.URLEncoder;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
+import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Locale;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.stereotype.Component;
+import org.springframework.util.StringUtils;
+
+/** Read-only client for Link-Up Connector Schema discovery. */
+@ConditionalOnOfflineSyncEnabled
+@Component
+public class LinkUpConnectorDiscoveryClient {
+
+  private final HttpClient httpClient;
+  private final ObjectMapper objectMapper;
+  private final OfflineSyncProperties properties;
+
+  public LinkUpConnectorDiscoveryClient(
+      @Qualifier("offlineSyncHttpClient") HttpClient httpClient,
+      @Qualifier("offlineSyncJsonMapper") ObjectMapper objectMapper,
+      OfflineSyncProperties properties) {
+    this.httpClient = httpClient;
+    this.objectMapper = objectMapper;
+    this.properties = properties;
+  }
+
+  /** Returns schemas exported by factories that are actually loaded in the configured Worker. */
+  public List<JsonNode> schemas() {
+    JsonNode value = get("/api/v1/connectors");
+    if (!value.isArray()) {
+      throw new DiscoveryException(
+          502,
+          "Link-Up /api/v1/connectors 返回格式不正确：预期 JSON 数组");
+    }
+
+    List<JsonNode> result = new ArrayList<>();
+    value.forEach(schema -> result.add(schema.deepCopy()));
+    return List.copyOf(result);
+  }
+
+  /** Reads one current schema directly from the Worker; stale cache is never used here. */
+  public JsonNode schema(String connectorId, String role) {
+    String id = requireText(connectorId, "connectorId 不能为空");
+    String normalizedRole = normalizeRole(role);
+    return get(
+        "/api/v1/connectors/"
+            + encode(id)
+            + "/schema?role="
+            + encode(normalizedRole));
+  }
+
+  private JsonNode get(String path) {
+    requireEnabled();
+    HttpRequest request =
+        HttpRequest.newBuilder(uri(path))
+            .timeout(properties.getEngine().getRequestTimeout())
+            .header("Accept", "application/json")
+            .GET()
+            .build();
+
+    try {
+      HttpResponse<String> response =
+          httpClient.send(request, HttpResponse.BodyHandlers.ofString(StandardCharsets.UTF_8));
+      if (response.statusCode() >= 200 && response.statusCode() < 300) {
+        return read(response.body());
+      }
+      throw new DiscoveryException(
+          response.statusCode(),
+          "Link-Up Connector Schema 请求失败：HTTP "
+              + response.statusCode()
+              + " - "
+              + errorMessage(response.body()));
+    } catch (InterruptedException exception) {
+      Thread.currentThread().interrupt();
+      throw new DiscoveryException(503, "Link-Up Connector Schema 请求被中断", exception);
+    } catch (IOException exception) {
+      throw new DiscoveryException(
+          503,
+          "无法连接 Link-Up Connector Schema API：" + baseUrl(),
+          exception);
+    }
+  }
+
+  private JsonNode read(String body) {
+    if (!StringUtils.hasText(body)) {
+      throw new DiscoveryException(502, "Link-Up Connector Schema 返回为空");
+    }
+    try {
+      return objectMapper.readTree(body);
+    } catch (JsonProcessingException exception) {
+      throw new DiscoveryException(502, "Link-Up Connector Schema 返回了无效 JSON", exception);
+    }
+  }
+
+  private String errorMessage(String body) {
+    if (!StringUtils.hasText(body)) {
+      return "empty response";
+    }
+    try {
+      JsonNode value = objectMapper.readTree(body);
+      String message = value.path("message").asText(null);
+      if (!StringUtils.hasText(message)) {
+        message = value.path("error").asText(null);
+      }
+      return sanitize(StringUtils.hasText(message) ? message : body);
+    } catch (JsonProcessingException ignored) {
+      return sanitize(body);
+    }
+  }
+
+  private String sanitize(String value) {
+    String sanitized =
+        String.valueOf(value)
+            .replaceAll(
+                "(?i)(password|passwd|pwd|token|secret)\\s*[=:]\\s*[^,;\\s]+",
+                "$1=***");
+    return sanitized.length() <= 500 ? sanitized : sanitized.substring(0, 500);
+  }
+
+  private URI uri(String path) {
+    try {
+      return URI.create(baseUrl() + path);
+    } catch (IllegalArgumentException exception) {
+      throw new DiscoveryException(
+          500,
+          "Link-Up 地址不合法：" + properties.getEngine().getBaseUrl(),
+          exception);
+    }
+  }
+
+  private String baseUrl() {
+    String value = properties.getEngine().getBaseUrl();
+    if (!StringUtils.hasText(value)) {
+      throw new DiscoveryException(500, "yak.sync.offline.engine.base-url 不能为空");
+    }
+
+    String normalized = value.trim();
+    while (normalized.endsWith("/")) {
+      normalized = normalized.substring(0, normalized.length() - 1);
+    }
+    if (!normalized.startsWith("http://") && !normalized.startsWith("https://")) {
+      throw new DiscoveryException(500, "Link-Up 地址必须使用 HTTP 或 HTTPS");
+    }
+    return normalized;
+  }
+
+  private String encode(String value) {
+    return URLEncoder.encode(value, StandardCharsets.UTF_8).replace("+", "%20");
+  }
+
+  private String normalizeRole(String role) {
+    String value = requireText(role, "role 不能为空").toUpperCase(Locale.ROOT);
+    if (!"SOURCE".equals(value) && !"SINK".equals(value)) {
+      throw new IllegalArgumentException("role 必须是 SOURCE 或 SINK");
+    }
+    return value;
+  }
+
+  private String requireText(String value, String message) {
+    if (!StringUtils.hasText(value)) {
+      throw new IllegalArgumentException(message);
+    }
+    return value.trim();
+  }
+
+  private void requireEnabled() {
+    if (!properties.getEngine().isEnabled()) {
+      throw new DiscoveryException(503, "Link-Up 引擎对接已关闭");
+    }
+  }
+
+  public static class DiscoveryException extends RuntimeException {
+    private final int statusCode;
+
+    public DiscoveryException(int statusCode, String message) {
+      super(message);
+      this.statusCode = statusCode;
+    }
+
+    public DiscoveryException(int statusCode, String message, Throwable cause) {
+      super(message, cause);
+      this.statusCode = statusCode;
+    }
+
+    public int getStatusCode() {
+      return statusCode;
+    }
+  }
+}

--- a/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-offline/src/main/java/io/yak/ops/business/sync/offline/engine/connector/OfflineSyncConnectorProfile.java
+++ b/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-offline/src/main/java/io/yak/ops/business/sync/offline/engine/connector/OfflineSyncConnectorProfile.java
@@ -1,4 +1,4 @@
-package io.yak.ops.business.sync.offline.connector;
+package io.yak.ops.business.sync.offline.engine.connector;
 
 import io.yak.ops.common.enums.datasource.DataSourceDbType;
 import java.util.Objects;

--- a/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-offline/src/main/java/io/yak/ops/business/sync/offline/engine/connector/OfflineSyncConnectorRegistry.java
+++ b/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-offline/src/main/java/io/yak/ops/business/sync/offline/engine/connector/OfflineSyncConnectorRegistry.java
@@ -1,4 +1,4 @@
-package io.yak.ops.business.sync.offline.connector;
+package io.yak.ops.business.sync.offline.engine.connector;
 
 import io.yak.ops.common.enums.datasource.DataSourceDbType;
 import java.util.EnumMap;

--- a/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-offline/src/main/java/io/yak/ops/business/sync/offline/engine/connector/OfflineSyncConnectorRuntime.java
+++ b/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-offline/src/main/java/io/yak/ops/business/sync/offline/engine/connector/OfflineSyncConnectorRuntime.java
@@ -1,0 +1,263 @@
+package io.yak.ops.business.sync.offline.engine.connector;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import io.yak.ops.business.sync.offline.config.ConditionalOnOfflineSyncEnabled;
+import io.yak.ops.common.bean.vo.sync.offline.OfflineConnectorRoleRuntimeVO;
+import io.yak.ops.common.bean.vo.sync.offline.OfflineConnectorRuntimeProfileVO;
+import io.yak.ops.common.bean.vo.sync.offline.OfflineConnectorRuntimeSnapshotVO;
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.LinkedHashMap;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+import java.util.Set;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Component;
+import org.springframework.util.StringUtils;
+
+/**
+ * Merges Yak Ops Connector Profiles with schemas discovered from the configured Link-Up Worker.
+ *
+ * <p>The Worker is still a fixed endpoint in the current offline runtime. This component therefore
+ * keeps a short read-through cache rather than introducing a second worker scheduler. If refresh
+ * fails after a successful discovery, schema metadata may remain visible as stale evidence, but
+ * {@code available} is always false until a live discovery succeeds again.</p>
+ */
+@ConditionalOnOfflineSyncEnabled
+@Component
+public class OfflineSyncConnectorRuntime {
+
+  static final long DEFAULT_CACHE_TTL_MILLIS = 30_000L;
+
+  private final LinkUpConnectorDiscoveryClient discoveryClient;
+  private final long cacheTtlMillis;
+  private final Object refreshLock = new Object();
+  private volatile Snapshot cached = Snapshot.empty();
+
+  @Autowired
+  public OfflineSyncConnectorRuntime(LinkUpConnectorDiscoveryClient discoveryClient) {
+    this(discoveryClient, DEFAULT_CACHE_TTL_MILLIS);
+  }
+
+  OfflineSyncConnectorRuntime(
+      LinkUpConnectorDiscoveryClient discoveryClient,
+      long cacheTtlMillis) {
+    this.discoveryClient = discoveryClient;
+    this.cacheTtlMillis = Math.max(0L, cacheTtlMillis);
+  }
+
+  public OfflineConnectorRuntimeSnapshotVO snapshot() {
+    return toView(current());
+  }
+
+  /** Fetches a full schema from the Worker directly; the summary cache is intentionally bypassed. */
+  public JsonNode schema(String connectorId, String role) {
+    return discoveryClient.schema(
+        normalizeConnectorId(connectorId),
+        normalizeRole(role));
+  }
+
+  private Snapshot current() {
+    long now = System.currentTimeMillis();
+    Snapshot current = cached;
+    if (fresh(current, now)) {
+      return current;
+    }
+
+    synchronized (refreshLock) {
+      current = cached;
+      now = System.currentTimeMillis();
+      if (fresh(current, now)) {
+        return current;
+      }
+
+      try {
+        Map<String, JsonNode> schemas = index(discoveryClient.schemas());
+        cached = Snapshot.success(schemas, now);
+      } catch (RuntimeException exception) {
+        cached = current.failure(now, safeMessage(exception));
+      }
+      return cached;
+    }
+  }
+
+  private boolean fresh(Snapshot value, long now) {
+    return cacheTtlMillis > 0L
+        && value.checkedAtMillis() > 0L
+        && now - value.checkedAtMillis() < cacheTtlMillis;
+  }
+
+  private Map<String, JsonNode> index(List<JsonNode> discovered) {
+    Map<String, JsonNode> result = new LinkedHashMap<>();
+    for (JsonNode schema : discovered == null ? List.<JsonNode>of() : discovered) {
+      String connectorId = text(schema, "connectorId");
+      String role = text(schema, "role");
+      if (!StringUtils.hasText(connectorId) || !StringUtils.hasText(role)) {
+        continue;
+      }
+      String normalizedRole = normalizeRole(role);
+      String normalizedId = normalizeConnectorId(connectorId);
+      String key = key(normalizedId, normalizedRole);
+      if (result.put(key, schema.deepCopy()) != null) {
+        throw new IllegalStateException(
+            "Link-Up 返回重复 Connector Schema：" + normalizedRole + "/" + normalizedId);
+      }
+    }
+    return Map.copyOf(result);
+  }
+
+  private OfflineConnectorRuntimeSnapshotVO toView(Snapshot snapshot) {
+    List<OfflineConnectorRoleRuntimeVO> connectors = new ArrayList<>();
+    snapshot.schemas().entrySet().stream()
+        .sorted(Map.Entry.comparingByKey())
+        .forEach(
+            entry -> connectors.add(roleView(entry.getValue(), snapshot.reachable())));
+
+    List<OfflineConnectorRuntimeProfileVO> profiles =
+        OfflineSyncConnectorRegistry.profiles().stream()
+            .map(profile -> profileView(profile, snapshot))
+            .toList();
+
+    return OfflineConnectorRuntimeSnapshotVO.builder()
+        .reachable(snapshot.reachable())
+        .stale(snapshot.stale())
+        .syncedAtMillis(snapshot.syncedAtMillis() > 0L ? snapshot.syncedAtMillis() : null)
+        .checkedAtMillis(snapshot.checkedAtMillis() > 0L ? snapshot.checkedAtMillis() : null)
+        .errorMessage(snapshot.errorMessage())
+        .connectors(List.copyOf(connectors))
+        .profiles(profiles)
+        .build();
+  }
+
+  private OfflineConnectorRuntimeProfileVO profileView(
+      OfflineSyncConnectorProfile profile,
+      Snapshot snapshot) {
+    JsonNode sourceSchema =
+        snapshot.schemas().get(key(profile.sourceConnectorId(), "SOURCE"));
+    JsonNode sinkSchema =
+        snapshot.schemas().get(key(profile.sinkConnectorId(), "SINK"));
+
+    return OfflineConnectorRuntimeProfileVO.builder()
+        .profileId(profile.profileId())
+        .dbType(profile.dbType().name())
+        .displayName(profile.dbType().getDisplayName())
+        .pluginName(profile.pluginName())
+        .defaultProfile(profile.defaultProfile())
+        .source(roleView(profile.sourceConnectorId(), "SOURCE", sourceSchema, snapshot.reachable()))
+        .sink(roleView(profile.sinkConnectorId(), "SINK", sinkSchema, snapshot.reachable()))
+        .build();
+  }
+
+  private OfflineConnectorRoleRuntimeVO roleView(JsonNode schema, boolean live) {
+    return roleView(
+        normalizeConnectorId(text(schema, "connectorId")),
+        normalizeRole(text(schema, "role")),
+        schema,
+        live);
+  }
+
+  private OfflineConnectorRoleRuntimeVO roleView(
+      String connectorId,
+      String role,
+      JsonNode schema,
+      boolean live) {
+    return OfflineConnectorRoleRuntimeVO.builder()
+        .connectorId(connectorId)
+        .role(role)
+        .available(live && schema != null)
+        .schemaVersion(text(schema, "schemaVersion"))
+        .schemaFingerprint(text(schema, "schemaFingerprint"))
+        .implementationVersion(text(schema, "implementationVersion"))
+        .capabilities(capabilities(schema))
+        .build();
+  }
+
+  private List<String> capabilities(JsonNode schema) {
+    if (schema == null || !schema.path("capabilities").isArray()) {
+      return List.of();
+    }
+    Set<String> values = new LinkedHashSet<>();
+    schema.path("capabilities").forEach(
+        item -> {
+          if (item.isValueNode() && StringUtils.hasText(item.asText())) {
+            values.add(item.asText().trim().toUpperCase(Locale.ROOT));
+          }
+        });
+    return values.stream().sorted(Comparator.naturalOrder()).toList();
+  }
+
+  private String text(JsonNode node, String field) {
+    if (node == null) {
+      return null;
+    }
+    JsonNode value = node.get(field);
+    if (value == null || value.isNull() || !value.isValueNode()) {
+      return null;
+    }
+    String text = value.asText(null);
+    return StringUtils.hasText(text) ? text.trim() : null;
+  }
+
+  private String normalizeConnectorId(String value) {
+    if (!StringUtils.hasText(value)) {
+      throw new IllegalArgumentException("connectorId 不能为空");
+    }
+    return value.trim().toLowerCase(Locale.ROOT);
+  }
+
+  private String normalizeRole(String value) {
+    if (!StringUtils.hasText(value)) {
+      throw new IllegalArgumentException("role 不能为空");
+    }
+    String normalized = value.trim().toUpperCase(Locale.ROOT);
+    if (!"SOURCE".equals(normalized) && !"SINK".equals(normalized)) {
+      throw new IllegalArgumentException("role 必须是 SOURCE 或 SINK");
+    }
+    return normalized;
+  }
+
+  private String key(String connectorId, String role) {
+    return normalizeConnectorId(connectorId) + "|" + normalizeRole(role);
+  }
+
+  private String safeMessage(RuntimeException exception) {
+    String value = exception.getMessage();
+    if (!StringUtils.hasText(value)) {
+      value = exception.getClass().getSimpleName();
+    }
+    value = value.replaceAll(
+        "(?i)(password|passwd|pwd|token|secret)\\s*[=:]\\s*[^,;\\s]+",
+        "$1=***");
+    return value.length() <= 500 ? value : value.substring(0, 500);
+  }
+
+  private record Snapshot(
+      Map<String, JsonNode> schemas,
+      long syncedAtMillis,
+      long checkedAtMillis,
+      boolean reachable,
+      boolean stale,
+      String errorMessage) {
+
+    static Snapshot empty() {
+      return new Snapshot(Map.of(), 0L, 0L, false, false, null);
+    }
+
+    static Snapshot success(Map<String, JsonNode> schemas, long now) {
+      return new Snapshot(schemas, now, now, true, false, null);
+    }
+
+    Snapshot failure(long now, String message) {
+      boolean hasStaleSchema = syncedAtMillis > 0L || !schemas.isEmpty();
+      return new Snapshot(
+          schemas,
+          syncedAtMillis,
+          now,
+          false,
+          hasStaleSchema,
+          message);
+    }
+  }
+}

--- a/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-offline/src/main/java/io/yak/ops/business/sync/offline/execution/OfflineJobExecutionService.java
+++ b/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-offline/src/main/java/io/yak/ops/business/sync/offline/execution/OfflineJobExecutionService.java
@@ -7,6 +7,7 @@ import io.yak.ops.business.sync.offline.domain.OfflineJobExecution;
 import io.yak.ops.business.sync.offline.domain.core.BatchTriggerToken;
 import io.yak.ops.business.sync.offline.engine.LinkUpClient;
 import io.yak.ops.business.sync.offline.engine.LinkUpClient.LinkUpJobResponse;
+import io.yak.ops.business.sync.offline.engine.connector.OfflineSyncConnectorRuntime;
 import io.yak.ops.business.sync.offline.execution.query.OfflineExecutionLogQuery;
 import io.yak.ops.business.sync.offline.execution.query.OfflineExecutionQuery;
 import io.yak.ops.business.sync.offline.mapping.OfflineSyncViewMapper;
@@ -15,6 +16,7 @@ import io.yak.ops.common.bean.dto.sync.offline.OfflineBatchOperationDTO;
 import io.yak.ops.common.bean.dto.sync.offline.OfflineJobExecutionQueryDTO;
 import io.yak.ops.common.bean.vo.sync.offline.OfflineBatchOperationErrorVO;
 import io.yak.ops.common.bean.vo.sync.offline.OfflineBatchOperationVO;
+import io.yak.ops.common.bean.vo.sync.offline.OfflineConnectorRuntimeSnapshotVO;
 import io.yak.ops.common.bean.vo.sync.offline.OfflineEngineHealthVO;
 import io.yak.ops.common.bean.vo.sync.offline.OfflineExecutionEventVO;
 import io.yak.ops.common.bean.vo.sync.offline.OfflineExecutionLogPageVO;
@@ -37,9 +39,20 @@ public class OfflineJobExecutionService implements OfflineScheduleExecutionGatew
   private final OfflineExecutionLogQuery executionLogQuery;
   private final LinkUpClient linkUpClient;
   private final OfflineSyncViewMapper viewMapper;
+  private final OfflineSyncConnectorRuntime connectorRuntime;
 
   public OfflineEngineHealthVO health() {
     return viewMapper.engineHealth(linkUpClient.node());
+  }
+
+  /** Global runtime inventory for the currently configured Link-Up Worker. */
+  public OfflineConnectorRuntimeSnapshotVO connectorRuntime() {
+    return connectorRuntime.snapshot();
+  }
+
+  /** Full current Worker schema. Unlike the inventory summary, this never falls back to stale data. */
+  public JsonNode connectorSchema(String connectorId, String role) {
+    return connectorRuntime.schema(connectorId, role);
   }
 
   @Override

--- a/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-offline/src/test/java/io/yak/ops/business/sync/offline/controller/OfflineConnectorRuntimeContractTest.java
+++ b/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-offline/src/test/java/io/yak/ops/business/sync/offline/controller/OfflineConnectorRuntimeContractTest.java
@@ -1,0 +1,24 @@
+package io.yak.ops.business.sync.offline.controller;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.yak.ops.core.project.ProjectMigrationMode;
+import io.yak.ops.core.project.ProjectScope;
+import java.lang.reflect.Method;
+import org.junit.jupiter.api.Test;
+
+class OfflineConnectorRuntimeContractTest {
+
+  @Test
+  void connectorDiscoveryEndpointsStayGlobalInfrastructureReads() throws Exception {
+    Method inventory = OfflineJobExecutionController.class.getMethod("connectors");
+    Method schema =
+        OfflineJobExecutionController.class.getMethod(
+            "connectorSchema", String.class, String.class);
+
+    assertThat(inventory.getAnnotation(ProjectScope.class).value())
+        .isEqualTo(ProjectMigrationMode.LEGACY_GLOBAL);
+    assertThat(schema.getAnnotation(ProjectScope.class).value())
+        .isEqualTo(ProjectMigrationMode.LEGACY_GLOBAL);
+  }
+}

--- a/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-offline/src/test/java/io/yak/ops/business/sync/offline/engine/connector/LinkUpConnectorDiscoveryClientTest.java
+++ b/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-offline/src/test/java/io/yak/ops/business/sync/offline/engine/connector/LinkUpConnectorDiscoveryClientTest.java
@@ -1,0 +1,99 @@
+package io.yak.ops.business.sync.offline.engine.connector;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.sun.net.httpserver.HttpExchange;
+import com.sun.net.httpserver.HttpServer;
+import io.yak.ops.business.sync.offline.config.OfflineSyncProperties;
+import java.io.IOException;
+import java.net.InetSocketAddress;
+import java.net.http.HttpClient;
+import java.nio.charset.StandardCharsets;
+import java.util.List;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+class LinkUpConnectorDiscoveryClientTest {
+
+  private HttpServer server;
+  private LinkUpConnectorDiscoveryClient client;
+
+  @BeforeEach
+  void setUp() throws Exception {
+    server = HttpServer.create(new InetSocketAddress("127.0.0.1", 0), 0);
+    server.createContext("/api/v1/connectors", this::connectors);
+    server.start();
+
+    OfflineSyncProperties properties = new OfflineSyncProperties();
+    properties.getEngine().setBaseUrl("http://127.0.0.1:" + server.getAddress().getPort());
+    client =
+        new LinkUpConnectorDiscoveryClient(
+            HttpClient.newHttpClient(),
+            new ObjectMapper(),
+            properties);
+  }
+
+  @AfterEach
+  void tearDown() {
+    if (server != null) {
+      server.stop(0);
+    }
+  }
+
+  @Test
+  void listsSchemasFromLoadedWorkerFactories() {
+    List<JsonNode> schemas = client.schemas();
+
+    assertThat(schemas).hasSize(2);
+    assertThat(schemas.get(0).path("connectorId").asText()).isEqualTo("jdbc");
+    assertThat(schemas.get(0).path("role").asText()).isEqualTo("SOURCE");
+    assertThat(schemas.get(0).path("capabilities").get(0).asText())
+        .isEqualTo("MULTI_TABLE");
+  }
+
+  @Test
+  void fetchesOneFullSchemaWithExplicitRole() {
+    JsonNode schema = client.schema("jdbc", "source");
+
+    assertThat(schema.path("connectorId").asText()).isEqualTo("jdbc");
+    assertThat(schema.path("role").asText()).isEqualTo("SOURCE");
+    assertThat(schema.path("schemaFingerprint").asText()).isEqualTo("source-fp");
+  }
+
+  private void connectors(HttpExchange exchange) throws IOException {
+    String path = exchange.getRequestURI().getPath();
+    if (path.endsWith("/jdbc/schema")) {
+      assertThat(exchange.getRequestURI().getQuery()).isEqualTo("role=SOURCE");
+      json(exchange, sourceSchema());
+      return;
+    }
+    json(exchange, "[" + sourceSchema() + "," + sinkSchema() + "]");
+  }
+
+  private String sourceSchema() {
+    return "{\"connectorId\":\"jdbc\",\"role\":\"SOURCE\","
+        + "\"schemaVersion\":\"1\",\"schemaFingerprint\":\"source-fp\","
+        + "\"implementationVersion\":\"1.0.0\","
+        + "\"capabilities\":[\"MULTI_TABLE\",\"CUSTOM_SQL\"],"
+        + "\"options\":[],\"rules\":[]}";
+  }
+
+  private String sinkSchema() {
+    return "{\"connectorId\":\"jdbc\",\"role\":\"SINK\","
+        + "\"schemaVersion\":\"1\",\"schemaFingerprint\":\"sink-fp\","
+        + "\"implementationVersion\":\"1.0.0\","
+        + "\"capabilities\":[\"UPSERT\",\"AUTO_CREATE_TABLE\"],"
+        + "\"options\":[],\"rules\":[]}";
+  }
+
+  private void json(HttpExchange exchange, String body) throws IOException {
+    byte[] bytes = body.getBytes(StandardCharsets.UTF_8);
+    exchange.getResponseHeaders().set("Content-Type", "application/json;charset=UTF-8");
+    exchange.sendResponseHeaders(200, bytes.length);
+    exchange.getResponseBody().write(bytes);
+    exchange.close();
+  }
+}

--- a/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-offline/src/test/java/io/yak/ops/business/sync/offline/engine/connector/OfflineSyncConnectorRegistryTest.java
+++ b/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-offline/src/test/java/io/yak/ops/business/sync/offline/engine/connector/OfflineSyncConnectorRegistryTest.java
@@ -1,4 +1,4 @@
-package io.yak.ops.business.sync.offline.connector;
+package io.yak.ops.business.sync.offline.engine.connector;
 
 import static org.assertj.core.api.Assertions.assertThat;
 

--- a/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-offline/src/test/java/io/yak/ops/business/sync/offline/engine/connector/OfflineSyncConnectorRuntimeTest.java
+++ b/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-offline/src/test/java/io/yak/ops/business/sync/offline/engine/connector/OfflineSyncConnectorRuntimeTest.java
@@ -1,0 +1,121 @@
+package io.yak.ops.business.sync.offline.engine.connector;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.yak.ops.common.bean.vo.sync.offline.OfflineConnectorRuntimeProfileVO;
+import io.yak.ops.common.bean.vo.sync.offline.OfflineConnectorRuntimeSnapshotVO;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+
+class OfflineSyncConnectorRuntimeTest {
+
+  private final ObjectMapper objectMapper = new ObjectMapper();
+
+  @Test
+  void mergesCurrentProfilesWithLiveWorkerSchemas() throws Exception {
+    LinkUpConnectorDiscoveryClient client = mock(LinkUpConnectorDiscoveryClient.class);
+    when(client.schemas()).thenReturn(List.of(source(), sink(), starRocksSource()));
+
+    OfflineSyncConnectorRuntime runtime = new OfflineSyncConnectorRuntime(client, 60_000L);
+    OfflineConnectorRuntimeSnapshotVO result = runtime.snapshot();
+
+    assertThat(result.getReachable()).isTrue();
+    assertThat(result.getStale()).isFalse();
+    assertThat(result.getConnectors()).hasSize(3);
+    assertThat(result.getConnectors())
+        .anySatisfy(
+            connector -> {
+              assertThat(connector.getConnectorId()).isEqualTo("starrocks");
+              assertThat(connector.getRole()).isEqualTo("SOURCE");
+              assertThat(connector.getAvailable()).isTrue();
+            });
+
+    OfflineConnectorRuntimeProfileVO mysql =
+        result.getProfiles().stream()
+            .filter(profile -> "MYSQL".equals(profile.getDbType()))
+            .findFirst()
+            .orElseThrow();
+    assertThat(mysql.getSource().getAvailable()).isTrue();
+    assertThat(mysql.getSource().getSchemaFingerprint()).isEqualTo("source-fp");
+    assertThat(mysql.getSource().getCapabilities())
+        .containsExactly("CUSTOM_SQL", "MULTI_TABLE");
+    assertThat(mysql.getSink().getAvailable()).isTrue();
+    assertThat(mysql.getSink().getCapabilities())
+        .containsExactly("AUTO_CREATE_TABLE", "UPSERT");
+  }
+
+  @Test
+  void initialDiscoveryFailureIsUnavailableButNotStale() {
+    LinkUpConnectorDiscoveryClient client = mock(LinkUpConnectorDiscoveryClient.class);
+    when(client.schemas())
+        .thenThrow(new LinkUpConnectorDiscoveryClient.DiscoveryException(503, "worker down"));
+
+    OfflineSyncConnectorRuntime runtime = new OfflineSyncConnectorRuntime(client, 0L);
+    OfflineConnectorRuntimeSnapshotVO result = runtime.snapshot();
+
+    assertThat(result.getReachable()).isFalse();
+    assertThat(result.getStale()).isFalse();
+    assertThat(result.getSyncedAtMillis()).isNull();
+    assertThat(result.getConnectors()).isEmpty();
+    assertThat(result.getProfiles())
+        .allSatisfy(
+            profile -> {
+              assertThat(profile.getSource().getAvailable()).isFalse();
+              assertThat(profile.getSink().getAvailable()).isFalse();
+            });
+  }
+
+  @Test
+  void staleSchemaMetadataNeverPretendsWorkerIsCurrentlyAvailable() throws Exception {
+    LinkUpConnectorDiscoveryClient client = mock(LinkUpConnectorDiscoveryClient.class);
+    when(client.schemas())
+        .thenReturn(List.of(source(), sink()))
+        .thenThrow(new LinkUpConnectorDiscoveryClient.DiscoveryException(503, "worker down"));
+
+    OfflineSyncConnectorRuntime runtime = new OfflineSyncConnectorRuntime(client, 0L);
+    OfflineConnectorRuntimeSnapshotVO live = runtime.snapshot();
+    OfflineConnectorRuntimeSnapshotVO stale = runtime.snapshot();
+
+    assertThat(live.getReachable()).isTrue();
+    assertThat(stale.getReachable()).isFalse();
+    assertThat(stale.getStale()).isTrue();
+    assertThat(stale.getErrorMessage()).contains("worker down");
+
+    OfflineConnectorRuntimeProfileVO mysql =
+        stale.getProfiles().stream()
+            .filter(profile -> "MYSQL".equals(profile.getDbType()))
+            .findFirst()
+            .orElseThrow();
+    assertThat(mysql.getSource().getAvailable()).isFalse();
+    assertThat(mysql.getSource().getSchemaFingerprint()).isEqualTo("source-fp");
+    assertThat(mysql.getSink().getAvailable()).isFalse();
+    assertThat(stale.getConnectors()).allSatisfy(item -> assertThat(item.getAvailable()).isFalse());
+  }
+
+  private JsonNode source() throws Exception {
+    return objectMapper.readTree(
+        "{\"connectorId\":\"jdbc\",\"role\":\"SOURCE\","
+            + "\"schemaVersion\":\"1\",\"schemaFingerprint\":\"source-fp\","
+            + "\"implementationVersion\":\"1.0.0\","
+            + "\"capabilities\":[\"MULTI_TABLE\",\"CUSTOM_SQL\"]}");
+  }
+
+  private JsonNode sink() throws Exception {
+    return objectMapper.readTree(
+        "{\"connectorId\":\"jdbc\",\"role\":\"SINK\","
+            + "\"schemaVersion\":\"1\",\"schemaFingerprint\":\"sink-fp\","
+            + "\"implementationVersion\":\"1.0.0\","
+            + "\"capabilities\":[\"UPSERT\",\"AUTO_CREATE_TABLE\"]}");
+  }
+
+  private JsonNode starRocksSource() throws Exception {
+    return objectMapper.readTree(
+        "{\"connectorId\":\"starrocks\",\"role\":\"SOURCE\","
+            + "\"schemaVersion\":\"1\",\"schemaFingerprint\":\"starrocks-fp\","
+            + "\"capabilities\":[\"MULTI_TABLE\",\"PARTITION_SPLIT\"]}");
+  }
+}

--- a/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-offline/src/test/java/io/yak/ops/business/sync/offline/execution/OfflineJobExecutionServiceEntryPointTest.java
+++ b/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-offline/src/test/java/io/yak/ops/business/sync/offline/execution/OfflineJobExecutionServiceEntryPointTest.java
@@ -7,6 +7,7 @@ import static org.mockito.Mockito.when;
 
 import io.yak.ops.business.sync.offline.domain.OfflineJobExecution;
 import io.yak.ops.business.sync.offline.engine.LinkUpClient;
+import io.yak.ops.business.sync.offline.engine.connector.OfflineSyncConnectorRuntime;
 import io.yak.ops.business.sync.offline.execution.query.OfflineExecutionLogQuery;
 import io.yak.ops.business.sync.offline.execution.query.OfflineExecutionQuery;
 import io.yak.ops.business.sync.offline.mapping.OfflineSyncViewMapper;
@@ -82,6 +83,7 @@ class OfflineJobExecutionServiceEntryPointTest {
     OfflineExecutionLogQuery executionLogQuery = mock(OfflineExecutionLogQuery.class);
     LinkUpClient linkUpClient = mock(LinkUpClient.class);
     OfflineSyncViewMapper viewMapper = mock(OfflineSyncViewMapper.class);
+    OfflineSyncConnectorRuntime connectorRuntime = mock(OfflineSyncConnectorRuntime.class);
     return new Fixture(
         new OfflineJobExecutionService(
             coordinator,
@@ -89,7 +91,8 @@ class OfflineJobExecutionServiceEntryPointTest {
             executionQuery,
             executionLogQuery,
             linkUpClient,
-            viewMapper),
+            viewMapper,
+            connectorRuntime),
         coordinator,
         runtime,
         executionQuery);

--- a/yak-ops-common/src/main/java/io/yak/ops/common/bean/vo/sync/offline/OfflineConnectorRoleRuntimeVO.java
+++ b/yak-ops-common/src/main/java/io/yak/ops/common/bean/vo/sync/offline/OfflineConnectorRoleRuntimeVO.java
@@ -1,0 +1,22 @@
+package io.yak.ops.common.bean.vo.sync.offline;
+
+import java.util.List;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+/** Link-Up Worker 中一个 Connector Role 的运行时发现结果。 */
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class OfflineConnectorRoleRuntimeVO {
+  private String connectorId;
+  private String role;
+  private Boolean available;
+  private String schemaVersion;
+  private String schemaFingerprint;
+  private String implementationVersion;
+  private List<String> capabilities;
+}

--- a/yak-ops-common/src/main/java/io/yak/ops/common/bean/vo/sync/offline/OfflineConnectorRuntimeProfileVO.java
+++ b/yak-ops-common/src/main/java/io/yak/ops/common/bean/vo/sync/offline/OfflineConnectorRuntimeProfileVO.java
@@ -1,0 +1,21 @@
+package io.yak.ops.common.bean.vo.sync.offline;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+/** Yak Ops 离线同步 Profile 与当前 Link-Up Worker 能力的合并视图。 */
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class OfflineConnectorRuntimeProfileVO {
+  private String profileId;
+  private String dbType;
+  private String displayName;
+  private String pluginName;
+  private Boolean defaultProfile;
+  private OfflineConnectorRoleRuntimeVO source;
+  private OfflineConnectorRoleRuntimeVO sink;
+}

--- a/yak-ops-common/src/main/java/io/yak/ops/common/bean/vo/sync/offline/OfflineConnectorRuntimeSnapshotVO.java
+++ b/yak-ops-common/src/main/java/io/yak/ops/common/bean/vo/sync/offline/OfflineConnectorRuntimeSnapshotVO.java
@@ -1,0 +1,22 @@
+package io.yak.ops.common.bean.vo.sync.offline;
+
+import java.util.List;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+/** 当前固定 Link-Up Worker 的 Connector 发现快照。 */
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class OfflineConnectorRuntimeSnapshotVO {
+  private Boolean reachable;
+  private Boolean stale;
+  private Long syncedAtMillis;
+  private Long checkedAtMillis;
+  private String errorMessage;
+  private List<OfflineConnectorRoleRuntimeVO> connectors;
+  private List<OfflineConnectorRuntimeProfileVO> profiles;
+}

--- a/yak-ops-ui/src/services/batch-link-up/connectors.ts
+++ b/yak-ops-ui/src/services/batch-link-up/connectors.ts
@@ -1,0 +1,60 @@
+import HttpUtils from '@/utils/HttpUtils';
+
+export type OfflineConnectorRole = 'SOURCE' | 'SINK';
+
+export interface OfflineConnectorRoleRuntime {
+  connectorId: string;
+  role: OfflineConnectorRole;
+  available: boolean;
+  schemaVersion?: string;
+  schemaFingerprint?: string;
+  implementationVersion?: string;
+  capabilities: string[];
+}
+
+export interface OfflineConnectorRuntimeProfile {
+  profileId: string;
+  dbType: string;
+  displayName?: string;
+  pluginName?: string;
+  defaultProfile: boolean;
+  source: OfflineConnectorRoleRuntime;
+  sink: OfflineConnectorRoleRuntime;
+}
+
+export interface OfflineConnectorRuntimeSnapshot {
+  reachable: boolean;
+  stale: boolean;
+  syncedAtMillis?: number;
+  checkedAtMillis?: number;
+  errorMessage?: string;
+  /** Every Source/Sink factory actually discovered from the configured Link-Up Worker. */
+  connectors: OfflineConnectorRoleRuntime[];
+  /** Yak Ops product profiles from the control-plane registry merged with runtime availability. */
+  profiles: OfflineConnectorRuntimeProfile[];
+}
+
+export type LinkUpConnectorSchema = Record<string, unknown> & {
+  connectorId: string;
+  role: OfflineConnectorRole;
+  schemaVersion?: string;
+  schemaFingerprint?: string;
+  implementationClass?: string;
+  implementationVersion?: string;
+  capabilities?: string[];
+  options?: unknown[];
+  rules?: unknown[];
+};
+
+const CONNECTOR_RUNTIME_API = '/api/v1/job/batch-execution/connectors';
+
+export const getOfflineSyncConnectorRuntime = (): Promise<OfflineConnectorRuntimeSnapshot> =>
+  HttpUtils.getData<OfflineConnectorRuntimeSnapshot>(CONNECTOR_RUNTIME_API);
+
+export const getOfflineSyncConnectorSchema = (
+  connectorId: string,
+  role: OfflineConnectorRole,
+): Promise<LinkUpConnectorSchema> =>
+  HttpUtils.getData<LinkUpConnectorSchema>(
+    `${CONNECTOR_RUNTIME_API}/${encodeURIComponent(connectorId)}/schema?role=${encodeURIComponent(role)}`,
+  );

--- a/yak-ops-ui/src/services/batch-link-up/index.ts
+++ b/yak-ops-ui/src/services/batch-link-up/index.ts
@@ -1,2 +1,3 @@
 export * from './api';
+export * from './connectors';
 export type * from './types';


### PR DESCRIPTION
## Summary

PR 2 of the Yak Ops control-plane connector adaptation plan.

PR #1023 has already merged the Offline Sync Connector Profile / Registry into `main`. This PR connects that product-side profile model to the **actual Connector Schemas exported by the configured Link-Up Worker**.

The scope remains intentionally narrow: this PR discovers runtime truth and exposes it to the control plane, but it does **not** yet change single-table/multi-table UI behavior or switch any datasource from JDBC to a native connector.

## Why this shape

Yak Ops offline sync currently executes against one fixed `yak.sync.offline.engine.base-url`; it does not yet have a multi-worker lease/scheduling model. Link-Up already exposes the required runtime APIs:

- `GET /api/v1/connectors`
- `GET /api/v1/connectors/{connectorId}/schema?role=SOURCE|SINK`

So this stage consumes those existing APIs directly instead of introducing a second worker registry or duplicating Link-Up capability knowledge inside Yak Ops.

## What changed

### 1. Runtime Connector discovery client

Add `engine.connector.LinkUpConnectorDiscoveryClient`.

It reads Connector Schemas from the currently configured Link-Up Worker and keeps the boundary read-only:

- list every loaded SOURCE/SINK factory
- fetch one full current Connector Schema by `connectorId + role`
- reuse the existing offline HTTP client, base URL and request timeout
- validate role values
- sanitize connector discovery error messages

No Link-Up repository change is required because the Worker API already exists.

### 2. Runtime inventory + short cache

Add `engine.connector.OfflineSyncConnectorRuntime`.

The summary path uses a 30-second read-through cache and returns two views:

- `connectors`: every SOURCE/SINK factory actually discovered from the Worker, including connectors that do not yet have a Yak Ops datasource profile
- `profiles`: PR #1023 product profiles merged with the matching SOURCE/SINK runtime schema

This lets Yak Ops distinguish:

```text
product profile exists
        !=
Worker currently has that Connector role loaded
```

### 3. Explicit availability / stale semantics

Runtime availability is deliberately conservative:

- live discovery succeeds + matching role exists -> `available=true`
- first discovery fails -> `reachable=false`, `stale=false`, `available=false`
- a previous successful schema exists but refresh later fails -> schema version/fingerprint/capabilities may remain as stale evidence, but `available=false`

A stale cache must never allow the UI to pretend a task is executable right now.

### 4. Full schema remains live

The full schema endpoint bypasses the summary cache and fetches the current Worker directly.

This is intended for later dynamic form/capability work where `options` and `rules` must reflect the actual loaded connector implementation rather than old cache data.

### 5. Yak Ops read-only control-plane APIs

Add global infrastructure reads:

- `GET /api/v1/job/batch-execution/connectors`
- `GET /api/v1/job/batch-execution/connectors/{connectorId}/schema?role=SOURCE|SINK`

They follow the existing engine health endpoint and use `ProjectMigrationMode.LEGACY_GLOBAL`, because Worker connector availability is infrastructure state rather than Project-owned business data.

### 6. Frontend service contract only

Add `yak-ops-ui/src/services/batch-link-up/connectors.ts` with:

- runtime snapshot/profile/role types
- `getOfflineSyncConnectorRuntime()`
- `getOfflineSyncConnectorSchema()`

This PR does not yet wire these values into the create/editor UI. Capability-driven hiding of `CUSTOM_SQL`, `MULTI_TABLE`, `UPSERT`, `AUTO_CREATE_TABLE`, etc. remains a later UI stage.

### 7. Keep the registry inside the engine boundary

During the PR 2 architecture review, the registry introduced by #1023 was found to live as a new top-level `offline.connector` package even though it is specifically the Link-Up execution binding layer.

This PR moves the Java registry/profile into `offline.engine.connector` and updates the resolver import. This keeps the repository's existing top-level dependency graph intact instead of widening the permanent architecture whitelist for a transport/engine concern.

There is no behavior change in the registry mapping.

## Compatibility / non-goals

This PR deliberately does **not**:

- add new `DataSourceDbType` values
- change Doris from `jdbc` to `doris`
- enable native StarRocks / ClickHouse / Elasticsearch tasks in Yak Ops
- modify Link-Up JobSpec generation
- add multi-worker scheduling / lease management
- reject task creation based on runtime capability yet
- change single-table or multi-table editor controls
- use stale Connector Schema as runtime availability

Current six datasource profiles continue to use the execution mapping established by #1023.

## Tests

Added coverage for:

- reading the real Link-Up connector list contract
- fetching one full schema with explicit SOURCE/SINK role
- merging JDBC runtime schemas into all current JDBC product profiles
- exposing native runtime inventory even without a Yak Ops datasource profile
- sorting/preserving Connector capabilities and fingerprints
- first discovery failure: unavailable but not stale
- later Worker outage: stale schema retained but all `available=false`
- connector discovery APIs remain global infrastructure reads
- existing `OfflineJobExecutionService` constructor tests updated for the new runtime dependency

## Validation status

- based directly on current `main` after #1023 merge (`e15a7fd868025d47712fa2a26fc4faf9e74f499d`)
- branch is ahead of `main` and behind by 0
- GitHub had not returned commit statuses or workflow runs before opening this PR
- no local Maven/frontend test pass is claimed because this execution environment does not have a working repository checkout/build path

## Next stage

With runtime truth now available, the next implementation stage can refactor JobSpec construction behind connector adapters without guessing capabilities from `dbType`. Capability-driven editor behavior can then consume this runtime contract without duplicating Link-Up knowledge.