### PR TITLE
refactor(sync): delegate Link-Up JobSpec connector translation

### DIFF
--- a/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-offline/src/main/java/io/yak/ops/business/sync/offline/engine/ColumnMappingLinkUpJobSpecFactory.java
+++ b/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-offline/src/main/java/io/yak/ops/business/sync/offline/engine/ColumnMappingLinkUpJobSpecFactory.java
@@ -7,8 +7,10 @@ import com.fasterxml.jackson.databind.node.ArrayNode;
 import com.fasterxml.jackson.databind.node.ObjectNode;
 import io.yak.ops.business.datasource.dao.DataSourceDao;
 import io.yak.ops.business.sync.offline.config.ConditionalOnOfflineSyncEnabled;
+import io.yak.ops.business.sync.offline.engine.connector.adapter.OfflineSyncConnectorAdapterRegistry;
 import java.util.HashSet;
 import java.util.Set;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.context.annotation.Primary;
 import org.springframework.stereotype.Component;
@@ -29,9 +31,19 @@ public class ColumnMappingLinkUpJobSpecFactory extends LinkUpJobSpecFactory {
 
   private final ObjectMapper objectMapper;
 
+  @Autowired
   public ColumnMappingLinkUpJobSpecFactory(
       DataSourceDao dataSourceDao,
-      @Qualifier("offlineSyncJsonMapper") ObjectMapper objectMapper) {
+      @Qualifier("offlineSyncJsonMapper") ObjectMapper objectMapper,
+      OfflineSyncConnectorAdapterRegistry adapterRegistry) {
+    super(dataSourceDao, objectMapper, adapterRegistry);
+    this.objectMapper = objectMapper;
+  }
+
+  /** Keeps focused unit tests and historical direct construction source-compatible. */
+  public ColumnMappingLinkUpJobSpecFactory(
+      DataSourceDao dataSourceDao,
+      ObjectMapper objectMapper) {
     super(dataSourceDao, objectMapper);
     this.objectMapper = objectMapper;
   }
@@ -42,9 +54,8 @@ public class ColumnMappingLinkUpJobSpecFactory extends LinkUpJobSpecFactory {
     ObjectNode mapping = objectMapping(normalizedDefinition.get("mapping"));
 
     if (mapping != null) {
-      String mode = normalizedDefinition.path("basic")
-          .path("mode")
-          .asText("GUIDE_SINGLE");
+      String mode =
+          normalizedDefinition.path("basic").path("mode").asText("GUIDE_SINGLE");
       if (!"GUIDE_SINGLE".equalsIgnoreCase(mode)) {
         throw new IllegalArgumentException("多表同步暂不支持自定义字段映射");
       }
@@ -128,9 +139,7 @@ public class ColumnMappingLinkUpJobSpecFactory extends LinkUpJobSpecFactory {
         throw new IllegalArgumentException("目标字段不能重复映射：" + target);
       }
 
-      normalizedColumns.addObject()
-          .put("source", source)
-          .put("target", target);
+      normalizedColumns.addObject().put("source", source).put("target", target);
     }
 
     ObjectNode normalized = objectMapper.createObjectNode();
@@ -139,9 +148,7 @@ public class ColumnMappingLinkUpJobSpecFactory extends LinkUpJobSpecFactory {
   }
 
   private ObjectNode objectMapping(JsonNode mapping) {
-    return mapping != null && mapping.isObject()
-        ? (ObjectNode) mapping
-        : null;
+    return mapping != null && mapping.isObject() ? (ObjectNode) mapping : null;
   }
 
   private String text(JsonNode node, String field, String fallback) {

--- a/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-offline/src/main/java/io/yak/ops/business/sync/offline/engine/LinkUpJobSpecFactory.java
+++ b/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-offline/src/main/java/io/yak/ops/business/sync/offline/engine/LinkUpJobSpecFactory.java
@@ -7,16 +7,17 @@ import com.fasterxml.jackson.databind.node.ArrayNode;
 import com.fasterxml.jackson.databind.node.ObjectNode;
 import io.yak.ops.business.datasource.dao.DataSourceDao;
 import io.yak.ops.business.sync.offline.config.ConditionalOnOfflineSyncEnabled;
+import io.yak.ops.business.sync.offline.engine.connector.adapter.OfflineSyncConnectorAdapter;
+import io.yak.ops.business.sync.offline.engine.connector.adapter.OfflineSyncConnectorAdapter.BuildContext;
+import io.yak.ops.business.sync.offline.engine.connector.adapter.OfflineSyncConnectorAdapter.ExecutionContext;
+import io.yak.ops.business.sync.offline.engine.connector.adapter.OfflineSyncConnectorAdapter.Role;
+import io.yak.ops.business.sync.offline.engine.connector.adapter.OfflineSyncConnectorAdapterRegistry;
 import io.yak.ops.common.bean.po.datasource.DataSourcePO;
-import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.Iterator;
-import java.util.LinkedHashSet;
 import java.util.List;
-import java.util.Locale;
 import java.util.Map;
-import java.util.Set;
 import java.util.TreeMap;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.stereotype.Component;
 import org.springframework.util.StringUtils;
@@ -27,6 +28,10 @@ import org.springframework.util.StringUtils;
  * <p>新定义使用固定的 basic + source + sink + channel 结构。读取历史版本时仍兼容
  * workflow.nodes 与 env，避免旧任务版本在执行或回看时失效。</p>
  *
+ * <p>Connector-specific task options and datasource translation are delegated to
+ * {@link OfflineSyncConnectorAdapter}. This factory only owns definition parsing, runtime
+ * orchestration and canonical JobSpec assembly.</p>
+ *
  * @author weifuwan
  */
 @ConditionalOnOfflineSyncEnabled
@@ -35,30 +40,32 @@ public class LinkUpJobSpecFactory {
 
   private static final String API_VERSION = "link-up/v1";
   private static final String KIND = "BatchSyncJob";
-  private static final Set<String> DATASOURCE_OWNED_OPTIONS = Set.of(
-      "url",
-      "driver",
-      "username",
-      "password",
-      "schema",
-      "dialect",
-      "compatible_mode",
-      "properties",
-      "connection_check_timeout_sec",
-      "connect_timeout_ms",
-      "socket_timeout_ms");
 
   private final DataSourceDao dataSourceDao;
   private final ObjectMapper objectMapper;
+  private final OfflineSyncConnectorAdapterRegistry adapterRegistry;
 
+  @Autowired
   public LinkUpJobSpecFactory(
       DataSourceDao dataSourceDao,
-      @Qualifier("offlineSyncJsonMapper") ObjectMapper objectMapper) {
+      @Qualifier("offlineSyncJsonMapper") ObjectMapper objectMapper,
+      OfflineSyncConnectorAdapterRegistry adapterRegistry) {
     this.dataSourceDao = dataSourceDao;
     this.objectMapper = objectMapper;
+    this.adapterRegistry = adapterRegistry;
   }
 
-  /** Builds a logical, durable JobSpec. JDBC credentials are intentionally not included. */
+  /** Keeps focused unit tests and historical direct construction source-compatible. */
+  public LinkUpJobSpecFactory(
+      DataSourceDao dataSourceDao,
+      ObjectMapper objectMapper) {
+    this(
+        dataSourceDao,
+        objectMapper,
+        OfflineSyncConnectorAdapterRegistry.standard(objectMapper));
+  }
+
+  /** Builds a logical, durable JobSpec. Datasource credentials are intentionally not included. */
   public BuildResult build(JsonNode definition) {
     requireObject(definition, "任务定义不能为空");
     JsonNode basic = definition.path("basic");
@@ -75,123 +82,72 @@ public class LinkUpJobSpecFactory {
     JsonNode channel = channel(definition);
     String sourceConnectorId = connectorId(source, "jdbc");
     String sinkConnectorId = connectorId(sink, "jdbc");
-    boolean jdbcSource = ConnectorIdResolver.isJdbc(sourceConnectorId);
-    boolean jdbcSink = ConnectorIdResolver.isJdbc(sinkConnectorId);
 
-    Long sourceDataSourceId = resolveDataSourceId(
-        source, definition, true, jdbcSource);
-    Long sinkDataSourceId = resolveDataSourceId(
-        sink, definition, false, jdbcSink);
+    OfflineSyncConnectorAdapter sourceAdapter =
+        adapterRegistry.resolve(sourceConnectorId, Role.SOURCE);
+    OfflineSyncConnectorAdapter sinkAdapter =
+        adapterRegistry.resolve(sinkConnectorId, Role.SINK);
+
+    Long sourceDataSourceId =
+        resolveDataSourceId(
+            source,
+            definition,
+            true,
+            sourceAdapter.requiresDataSource(sourceConnectorId, Role.SOURCE));
+    Long sinkDataSourceId =
+        resolveDataSourceId(
+            sink,
+            definition,
+            false,
+            sinkAdapter.requiresDataSource(sinkConnectorId, Role.SINK));
+
     DataSourcePO sourceDataSource = dataSource(sourceDataSourceId, "来源端");
     DataSourcePO sinkDataSource = dataSource(sinkDataSourceId, "目标端");
 
-    ObjectNode sourceOptions = connectorOptions(source.config);
-    ObjectNode sinkOptions = connectorOptions(sink.config);
-    if (jdbcSource) {
-      removeDatasourceOwnedOptions(sourceOptions);
-    }
-    if (jdbcSink) {
-      removeDatasourceOwnedOptions(sinkOptions);
-    }
-
-    String sourceTableView = text(sourceOptions, "table_path", null);
-    String sinkTableView = text(sinkOptions, "table_path", null);
-    int parallelism = Math.max(
-        1,
-        intValue(
-            channel,
-            "parallelism",
-            definition.path("env").path("parallelism").asInt(1)));
-    int channelCapacity = Math.max(
-        1,
-        intValue(
-            channel,
-            "channelCapacity",
-            definition.path("env").path("channelCapacity").asInt(64)));
+    int parallelism =
+        Math.max(
+            1,
+            intValue(
+                channel,
+                "parallelism",
+                definition.path("env").path("parallelism").asInt(1)));
+    int channelCapacity =
+        Math.max(
+            1,
+            intValue(
+                channel,
+                "channelCapacity",
+                definition.path("env").path("channelCapacity").asInt(64)));
     int batchSize = Math.max(1, sink.config.path("batchSize").asInt(1000));
     int fetchSize = Math.max(1, source.config.path("fetchSize").asInt(batchSize));
 
-    List<String> sourceTables = new ArrayList<>();
-    if (jdbcSource) {
-      sourceTables = sourceTables(source.config, mode, jobName);
-      String sourceQuery = sourceQuery(source.config);
-      sourceOptions.put("fetch_size", fetchSize);
-      if ("GUIDE_MULTI".equals(mode)) {
-        ArrayNode tableList = objectMapper.createArrayNode();
-        for (String table : sourceTables) {
-          tableList.addObject().put("table_path", table);
-        }
-        sourceOptions.set("table_list", tableList);
-        sourceOptions.remove("table_path");
-      } else {
-        sourceOptions.put("table_path", sourceTables.get(0));
-        sourceOptions.remove("table_list");
-        if (StringUtils.hasText(sourceQuery)) {
-          sourceOptions.put("query", sourceQuery);
-        } else {
-          sourceOptions.remove("query");
-        }
-      }
-      String whereCondition = text(source.config, "whereCondition", null);
-      if (StringUtils.hasText(whereCondition)) {
-        sourceOptions.put("where_condition", whereCondition.trim());
-      }
-      sourceTableView = tableView(sourceTables, mode);
-    }
+    OfflineSyncConnectorAdapter.BuildResult sourceBuild =
+        sourceAdapter.build(
+            new BuildContext(
+                sourceConnectorId,
+                Role.SOURCE,
+                mode,
+                jobName,
+                source.config,
+                channel,
+                connectorOptions(source.config),
+                batchSize,
+                fetchSize,
+                List.of()));
 
-    if (jdbcSink) {
-      String sinkTableTemplate;
-      if (jdbcSource) {
-        sinkTableTemplate = sinkTable(sink.config, mode, sourceTables);
-        sinkTableView = sinkTableView(sinkTableTemplate, sourceTables, mode);
-      } else {
-        sinkTableTemplate = text(
-            sink.config,
-            "targetTableName",
-            text(sink.config, "table", text(sinkOptions, "table_path", null)));
-        if (!StringUtils.hasText(sinkTableTemplate)) {
-          throw new IllegalArgumentException("请选择或填写目标表");
-        }
-        sinkTableTemplate = sinkTableTemplate.trim();
-        sinkTableView = sinkTableTemplate;
-      }
-      sinkOptions.put("table_path", sinkTableTemplate);
-      sinkOptions.put(
-          "schema_save_mode",
-          sink.config.path("autoCreateTable").asBoolean(false)
-              ? "CREATE_SCHEMA_WHEN_NOT_EXIST"
-              : "ERROR_WHEN_SCHEMA_NOT_EXIST");
-      String writeMode = text(sink.config, "writeMode", "append").toLowerCase(Locale.ROOT);
-      sinkOptions.put(
-          "data_save_mode",
-          "overwrite".equals(writeMode) ? "DROP_DATA" : "APPEND_DATA");
-      sinkOptions.put("write_mode", "upsert".equals(writeMode) ? "UPSERT" : "INSERT");
-      if ("upsert".equals(writeMode)) {
-        List<String> primaryKeys = splitValues(text(sink.config, "primaryKey", null));
-        if (primaryKeys.isEmpty()) {
-          throw new IllegalArgumentException("UPSERT 写入模式必须配置主键字段");
-        }
-        sinkOptions.set("primary_keys", objectMapper.valueToTree(primaryKeys));
-      } else {
-        sinkOptions.remove("primary_keys");
-      }
-      String customSql = text(sink.config, "sql", null);
-      if (StringUtils.hasText(customSql)) {
-        sinkOptions.put("custom_sql", customSql.trim());
-      }
-      sinkOptions.put("batch_size", batchSize);
-      String dirtyPolicy = text(channel, "dirtyDataPolicy", "stop");
-      sinkOptions.put(
-          "dirty_data_policy",
-          "skip".equalsIgnoreCase(dirtyPolicy) ? "SKIP" : "FAIL_FAST");
-      if ("skip".equalsIgnoreCase(dirtyPolicy)) {
-        sinkOptions.put(
-            "dirty_data_max_count",
-            Math.max(0L, longValue(channel, "dirtyDataLimit", 0L)));
-      } else {
-        sinkOptions.remove("dirty_data_max_count");
-      }
-    }
+    OfflineSyncConnectorAdapter.BuildResult sinkBuild =
+        sinkAdapter.build(
+            new BuildContext(
+                sinkConnectorId,
+                Role.SINK,
+                mode,
+                jobName,
+                sink.config,
+                channel,
+                connectorOptions(sink.config),
+                batchSize,
+                fetchSize,
+                sourceBuild.sourceTables()));
 
     ObjectNode runtime = objectMapper.createObjectNode();
     runtime.put("batchSize", fetchSize);
@@ -213,10 +169,10 @@ public class LinkUpJobSpecFactory {
     jobSpec.put("name", jobName.trim());
     jobSpec.set(
         "source",
-        connector(sourceConnectorId, sourceOptions, sourceDataSourceId));
+        connector(sourceConnectorId, sourceBuild.options(), sourceDataSourceId));
     jobSpec.set(
         "sink",
-        connector(sinkConnectorId, sinkOptions, sinkDataSourceId));
+        connector(sinkConnectorId, sinkBuild.options(), sinkDataSourceId));
     jobSpec.set("runtime", runtime);
 
     JsonNode canonical = canonical(jobSpec);
@@ -227,16 +183,16 @@ public class LinkUpJobSpecFactory {
         sinkDataSource,
         sourceConnectorId,
         sinkConnectorId,
-        sourceTableView,
-        sinkTableView);
+        sourceBuild.tableView(),
+        sinkBuild.tableView());
   }
 
   /** Resolves datasource references immediately before a Worker submission. */
   public JsonNode resolveForExecution(JsonNode logicalJobSpec) {
     requireObject(logicalJobSpec, "JobSpec 不能为空");
     ObjectNode resolved = (ObjectNode) logicalJobSpec.deepCopy();
-    resolveEndpointForExecution(resolved, "source", "来源端");
-    resolveEndpointForExecution(resolved, "sink", "目标端");
+    resolveEndpointForExecution(resolved, "source", "来源端", Role.SOURCE);
+    resolveEndpointForExecution(resolved, "sink", "目标端", Role.SINK);
     return canonical(resolved);
   }
 
@@ -254,22 +210,32 @@ public class LinkUpJobSpecFactory {
   private void resolveEndpointForExecution(
       ObjectNode root,
       String endpointName,
-      String endpointLabel) {
+      String endpointLabel,
+      Role role) {
     JsonNode value = root.get(endpointName);
     requireObject(value, endpointLabel + " JobSpec 不完整");
     ObjectNode endpoint = (ObjectNode) value;
-    String connectorId = ConnectorIdResolver.resolve(
-        text(endpoint, "connectorId", null), null, null, null);
+
+    String connectorId =
+        ConnectorIdResolver.resolve(text(endpoint, "connectorId", null), null, null, null);
     endpoint.put("connectorId", connectorId);
-    if (ConnectorIdResolver.isJdbc(connectorId)) {
+
+    OfflineSyncConnectorAdapter adapter = adapterRegistry.resolve(connectorId, role);
+    DataSourcePO dataSource = null;
+    if (adapter.requiresDataSource(connectorId, role)) {
       long dataSourceId = endpoint.path("dataSourceRef").path("id").asLong(0L);
       if (dataSourceId <= 0L) {
-        throw new IllegalStateException(endpointLabel + " JDBC JobSpec 缺少 dataSourceRef.id");
+        String connectorLabel =
+            "jdbc".equalsIgnoreCase(connectorId) ? "JDBC" : connectorId;
+        throw new IllegalStateException(
+            endpointLabel + " " + connectorLabel + " JobSpec 缺少 dataSourceRef.id");
       }
-      ObjectNode options = endpoint.with("options");
-      removeDatasourceOwnedOptions(options);
-      appendConnection(options, connection(dataSource(dataSourceId, endpointLabel)));
+      dataSource = dataSource(dataSourceId, endpointLabel);
     }
+
+    ObjectNode options = endpoint.with("options");
+    adapter.resolveForExecution(
+        new ExecutionContext(connectorId, role, endpointLabel, dataSource, options));
     endpoint.remove("dataSourceRef");
   }
 
@@ -301,10 +267,6 @@ public class LinkUpJobSpecFactory {
         : objectMapper.createObjectNode();
   }
 
-  private void removeDatasourceOwnedOptions(ObjectNode options) {
-    DATASOURCE_OWNED_OPTIONS.forEach(options::remove);
-  }
-
   private void copyRuntime(JsonNode source, ObjectNode runtime) {
     copyPositiveLong(source, runtime, "maxBufferedRecords", "maxBufferedRecords");
     copyPositiveLong(source, runtime, "maxBufferedBytes", "maxBufferedBytes");
@@ -333,20 +295,6 @@ public class LinkUpJobSpecFactory {
     String value = text(source, sourceKey, null);
     if (StringUtils.hasText(value)) {
       target.put(targetKey, value.trim());
-    }
-  }
-
-  private void appendConnection(ObjectNode options, ConnectionDetails connection) {
-    options.put("url", connection.url);
-    options.put("driver", connection.driver);
-    if (connection.username != null) {
-      options.put("username", connection.username);
-    }
-    if (connection.password != null) {
-      options.put("password", connection.password);
-    }
-    if (StringUtils.hasText(connection.schema)) {
-      options.put("schema", connection.schema);
     }
   }
 
@@ -419,16 +367,18 @@ public class LinkUpJobSpecFactory {
       id = longValue(endpoint.config, "dataSourceId", 0L);
     }
     if (id <= 0L) {
-      id = longValue(
-          definition.path("basic"),
-          source ? "sourceDataSourceId" : "targetDataSourceId",
-          0L);
+      id =
+          longValue(
+              definition.path("basic"),
+              source ? "sourceDataSourceId" : "targetDataSourceId",
+              0L);
     }
     if (id <= 0L) {
-      id = longValue(
-          definition.path("workflow"),
-          source ? "sourceDataSourceId" : "targetDataSourceId",
-          0L);
+      id =
+          longValue(
+              definition.path("workflow"),
+              source ? "sourceDataSourceId" : "targetDataSourceId",
+              0L);
     }
     if (id <= 0L && required) {
       throw new IllegalArgumentException(source ? "请选择来源数据源" : "请选择目标数据源");
@@ -447,272 +397,12 @@ public class LinkUpJobSpecFactory {
     return dataSource;
   }
 
-  private ConnectionDetails connection(DataSourcePO dataSource) {
-    if (dataSource == null) {
-      throw new IllegalArgumentException("JDBC Connector 必须选择数据源");
-    }
-    JsonNode parameters = parseJson(dataSource.getConnectionParams());
-    String url = firstText(parameters, "url", "jdbcUrl", "jdbc_url", "jdbc-url");
-    if (!StringUtils.hasText(url)) {
-      url = dataSource.getJdbcUrl();
-    }
-    if (!StringUtils.hasText(url)) {
-      throw new IllegalArgumentException("数据源 " + dataSource.getName() + " 缺少 JDBC URL");
-    }
-    String driver = firstText(
-        parameters,
-        "driver",
-        "driverClassName",
-        "driver_class_name",
-        "driver-class-name");
-    if (!StringUtils.hasText(driver)) {
-      driver = defaultDriver(
-          url,
-          dataSource.getDbType() == null ? null : dataSource.getDbType().name());
-    }
-    if (!StringUtils.hasText(driver)) {
-      throw new IllegalArgumentException("数据源 " + dataSource.getName() + " 缺少 JDBC Driver");
-    }
-    return new ConnectionDetails(
-        url.trim(),
-        driver.trim(),
-        firstTextAllowEmpty(parameters, "username", "user"),
-        firstTextAllowEmpty(parameters, "password", "passwd"),
-        firstText(parameters, "schema", "schemaName", "schema_name"));
-  }
-
-  private JsonNode parseJson(String value) {
-    if (!StringUtils.hasText(value)) {
-      return objectMapper.createObjectNode();
-    }
-    try {
-      return objectMapper.readTree(value);
-    } catch (JsonProcessingException exception) {
-      throw new IllegalArgumentException("数据源连接参数不是有效 JSON", exception);
-    }
-  }
-
-  private List<String> sourceTables(JsonNode config, String mode, String jobName) {
-    if ("GUIDE_MULTI".equals(mode)) {
-      List<String> tables = flattenTables(config.path("tables"));
-      if (tables.isEmpty()) {
-        String pattern = text(config, "tablePattern", null);
-        if (StringUtils.hasText(pattern) && !containsWildcard(pattern)) {
-          tables.add(pattern.trim());
-        }
-      }
-      if (tables.isEmpty()) {
-        throw new IllegalArgumentException(
-            "多表同步必须选择至少一张来源表，Link-Up 暂不直接执行通配符表名");
-      }
-      return tables;
-    }
-    String table = text(config, "table", null);
-    String query = sourceQuery(config);
-    if (!StringUtils.hasText(table) && StringUtils.hasText(query)) {
-      table = "yak_query." + safeIdentifier(jobName);
-    }
-    if (!StringUtils.hasText(table)) {
-      throw new IllegalArgumentException("请选择来源表");
-    }
-    return new ArrayList<>(List.of(table.trim()));
-  }
-
-  private String sourceQuery(JsonNode config) {
-    if (!"sql".equalsIgnoreCase(text(config, "readMode", "table"))) {
-      return null;
-    }
-    String query = text(config, "sql", null);
-    if (!StringUtils.hasText(query)) {
-      throw new IllegalArgumentException("SQL 读取模式必须填写来源查询 SQL");
-    }
-    return query.trim();
-  }
-
-  private String sinkTable(JsonNode config, String mode, List<String> sourceTables) {
-    String explicit = text(config, "targetTableName", text(config, "table", null));
-    if ("GUIDE_SINGLE".equals(mode)) {
-      if (!StringUtils.hasText(explicit)) {
-        throw new IllegalArgumentException("请选择或填写目标表");
-      }
-      return explicit.trim();
-    }
-    if (StringUtils.hasText(explicit)) {
-      return explicit.trim();
-    }
-    String rule = text(config, "tableNamingRule", "same_name");
-    String affix = text(config, "tableNameAffix", "");
-    if ("prefix".equalsIgnoreCase(rule)) {
-      return affix + "${table_name}";
-    }
-    if ("suffix".equalsIgnoreCase(rule)) {
-      return "${table_name}" + affix;
-    }
-    if (!"same_name".equalsIgnoreCase(rule) && StringUtils.hasText(affix)) {
-      return affix + "${table_name}";
-    }
-    return "${table_name}";
-  }
-
-  private String sinkTableView(
-      String template,
-      List<String> sourceTables,
-      String mode) {
-    if ("GUIDE_SINGLE".equals(mode)) {
-      return template;
-    }
-    List<String> targetTables = new ArrayList<>();
-    for (String sourceTable : sourceTables) {
-      String schemaName = "";
-      String tableName = sourceTable;
-      int separator = sourceTable.lastIndexOf('.');
-      if (separator >= 0) {
-        schemaName = sourceTable.substring(0, separator);
-        tableName = sourceTable.substring(separator + 1);
-      }
-      targetTables.add(
-          template
-              .replace("${schema_name}", schemaName)
-              .replace("${table_name}", tableName));
-    }
-    return writeJson(targetTables);
-  }
-
-  private String tableView(List<String> tables, String mode) {
-    return "GUIDE_MULTI".equals(mode) ? writeJson(tables) : tables.get(0);
-  }
-
-  private String writeJson(Object value) {
-    try {
-      return objectMapper.writeValueAsString(value);
-    } catch (JsonProcessingException exception) {
-      throw new IllegalStateException("序列化表信息失败", exception);
-    }
-  }
-
   private String write(JsonNode value) {
     try {
       return objectMapper.writeValueAsString(value);
     } catch (JsonProcessingException exception) {
       throw new IllegalStateException("序列化 JobSpec 失败", exception);
     }
-  }
-
-  private List<String> flattenTables(JsonNode value) {
-    LinkedHashSet<String> result = new LinkedHashSet<>();
-    flattenTables(value, null, result);
-    return new ArrayList<>(result);
-  }
-
-  private void flattenTables(JsonNode value, String schema, Set<String> result) {
-    if (value == null || value.isNull() || value.isMissingNode()) {
-      return;
-    }
-    if (value.isTextual()) {
-      String table = value.asText().trim();
-      if (StringUtils.hasText(table)) {
-        result.add(
-            StringUtils.hasText(schema) && !table.contains(".")
-                ? schema + "." + table
-                : table);
-      }
-      return;
-    }
-    if (value.isArray()) {
-      for (JsonNode item : value) {
-        flattenTables(item, schema, result);
-      }
-      return;
-    }
-    if (value.isObject()) {
-      value.fields().forEachRemaining(
-          entry -> flattenTables(entry.getValue(), entry.getKey(), result));
-    }
-  }
-
-  private String firstText(JsonNode node, String... keys) {
-    String value = firstTextAllowEmpty(node, keys);
-    return StringUtils.hasText(value) ? value.trim() : null;
-  }
-
-  private String firstTextAllowEmpty(JsonNode node, String... keys) {
-    Set<String> normalizedKeys = new LinkedHashSet<>();
-    Arrays.stream(keys).map(this::normalizeKey).forEach(normalizedKeys::add);
-    return findText(node, normalizedKeys);
-  }
-
-  private String findText(JsonNode node, Set<String> normalizedKeys) {
-    if (node == null || node.isNull() || node.isMissingNode()) {
-      return null;
-    }
-    if (node.isObject()) {
-      Iterator<Map.Entry<String, JsonNode>> fields = node.fields();
-      while (fields.hasNext()) {
-        Map.Entry<String, JsonNode> entry = fields.next();
-        JsonNode value = entry.getValue();
-        if (normalizedKeys.contains(normalizeKey(entry.getKey())) && value.isValueNode()) {
-          return value.isNull() ? null : value.asText();
-        }
-      }
-      fields = node.fields();
-      while (fields.hasNext()) {
-        String value = findText(fields.next().getValue(), normalizedKeys);
-        if (value != null) {
-          return value;
-        }
-      }
-    } else if (node.isArray()) {
-      for (JsonNode item : node) {
-        String value = findText(item, normalizedKeys);
-        if (value != null) {
-          return value;
-        }
-      }
-    }
-    return null;
-  }
-
-  private String defaultDriver(String url, String dbType) {
-    String normalized = (url + " " + (dbType == null ? "" : dbType)).toLowerCase(Locale.ROOT);
-    if (normalized.contains("mariadb")) {
-      return "org.mariadb.jdbc.Driver";
-    }
-    if (normalized.contains("mysql") || normalized.contains("doris")) {
-      return "com.mysql.cj.jdbc.Driver";
-    }
-    if (normalized.contains("postgres")) {
-      return "org.postgresql.Driver";
-    }
-    if (normalized.contains("oracle")) {
-      return "oracle.jdbc.OracleDriver";
-    }
-    if (normalized.contains("kingbase")) {
-      return "com.kingbase8.Driver";
-    }
-    if (normalized.contains("dm:") || normalized.contains("dameng")) {
-      return "dm.jdbc.driver.DmDriver";
-    }
-    return null;
-  }
-
-  private List<String> splitValues(String value) {
-    if (!StringUtils.hasText(value)) {
-      return new ArrayList<>();
-    }
-    return Arrays.stream(value.split(","))
-        .map(String::trim)
-        .filter(StringUtils::hasText)
-        .distinct()
-        .toList();
-  }
-
-  private boolean containsWildcard(String value) {
-    return value.contains("*") || value.contains("?") || value.contains("[");
-  }
-
-  private String safeIdentifier(String value) {
-    String normalized = value.replaceAll("[^A-Za-z0-9_]", "_");
-    return normalized.isBlank() ? "dataset" : normalized;
   }
 
   private String requiredText(JsonNode node, String field, String message) {
@@ -761,10 +451,6 @@ public class LinkUpJobSpecFactory {
     }
   }
 
-  private String normalizeKey(String value) {
-    return value.replace("_", "").replace("-", "").toLowerCase(Locale.ROOT);
-  }
-
   private static final class Endpoint {
     private final JsonNode root;
     private final JsonNode config;
@@ -772,27 +458,6 @@ public class LinkUpJobSpecFactory {
     private Endpoint(JsonNode root, JsonNode config) {
       this.root = root;
       this.config = config;
-    }
-  }
-
-  private static final class ConnectionDetails {
-    private final String url;
-    private final String driver;
-    private final String username;
-    private final String password;
-    private final String schema;
-
-    private ConnectionDetails(
-        String url,
-        String driver,
-        String username,
-        String password,
-        String schema) {
-      this.url = url;
-      this.driver = driver;
-      this.username = username;
-      this.password = password;
-      this.schema = schema;
     }
   }
 

--- a/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-offline/src/main/java/io/yak/ops/business/sync/offline/engine/connector/adapter/JdbcOfflineSyncConnectorAdapter.java
+++ b/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-offline/src/main/java/io/yak/ops/business/sync/offline/engine/connector/adapter/JdbcOfflineSyncConnectorAdapter.java
@@ -1,0 +1,495 @@
+package io.yak.ops.business.sync.offline.engine.connector.adapter;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ArrayNode;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import io.yak.ops.business.sync.offline.config.ConditionalOnOfflineSyncEnabled;
+import io.yak.ops.business.sync.offline.engine.connector.adapter.OfflineSyncConnectorAdapter.BuildContext;
+import io.yak.ops.business.sync.offline.engine.connector.adapter.OfflineSyncConnectorAdapter.BuildResult;
+import io.yak.ops.business.sync.offline.engine.connector.adapter.OfflineSyncConnectorAdapter.ExecutionContext;
+import io.yak.ops.business.sync.offline.engine.connector.adapter.OfflineSyncConnectorAdapter.Role;
+import io.yak.ops.common.bean.po.datasource.DataSourcePO;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Iterator;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+import java.util.Set;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.stereotype.Component;
+import org.springframework.util.StringUtils;
+
+/** Preserves the existing bounded JDBC source/sink JobSpec contract behind an adapter boundary. */
+@ConditionalOnOfflineSyncEnabled
+@Component
+public class JdbcOfflineSyncConnectorAdapter implements OfflineSyncConnectorAdapter {
+
+  private static final Set<String> DATASOURCE_OWNED_OPTIONS = Set.of(
+      "url",
+      "driver",
+      "username",
+      "password",
+      "schema",
+      "dialect",
+      "compatible_mode",
+      "properties",
+      "connection_check_timeout_sec",
+      "connect_timeout_ms",
+      "socket_timeout_ms");
+
+  private final ObjectMapper objectMapper;
+
+  public JdbcOfflineSyncConnectorAdapter(
+      @Qualifier("offlineSyncJsonMapper") ObjectMapper objectMapper) {
+    this.objectMapper = objectMapper;
+  }
+
+  @Override
+  public boolean supports(String connectorId, Role role) {
+    return "jdbc".equalsIgnoreCase(connectorId);
+  }
+
+  @Override
+  public boolean requiresDataSource(String connectorId, Role role) {
+    return true;
+  }
+
+  @Override
+  public BuildResult build(BuildContext context) {
+    removeDatasourceOwnedOptions(context.options());
+    return context.role() == Role.SOURCE ? buildSource(context) : buildSink(context);
+  }
+
+  @Override
+  public void resolveForExecution(ExecutionContext context) {
+    if (context.dataSource() == null) {
+      throw new IllegalArgumentException("JDBC Connector 必须选择数据源");
+    }
+    removeDatasourceOwnedOptions(context.options());
+    appendConnection(context.options(), connection(context.dataSource()));
+  }
+
+  private BuildResult buildSource(BuildContext context) {
+    List<String> sourceTables =
+        sourceTables(context.config(), context.mode(), context.jobName());
+    String sourceQuery = sourceQuery(context.config());
+    ObjectNode options = context.options();
+
+    options.put("fetch_size", context.fetchSize());
+    if ("GUIDE_MULTI".equals(context.mode())) {
+      ArrayNode tableList = objectMapper.createArrayNode();
+      for (String table : sourceTables) {
+        tableList.addObject().put("table_path", table);
+      }
+      options.set("table_list", tableList);
+      options.remove("table_path");
+    } else {
+      options.put("table_path", sourceTables.get(0));
+      options.remove("table_list");
+      if (StringUtils.hasText(sourceQuery)) {
+        options.put("query", sourceQuery);
+      } else {
+        options.remove("query");
+      }
+    }
+
+    String whereCondition = text(context.config(), "whereCondition", null);
+    if (StringUtils.hasText(whereCondition)) {
+      options.put("where_condition", whereCondition.trim());
+    }
+
+    return new BuildResult(options, tableView(sourceTables, context.mode()), sourceTables);
+  }
+
+  private BuildResult buildSink(BuildContext context) {
+    ObjectNode options = context.options();
+    List<String> sourceTables = context.sourceTables();
+
+    String sinkTableTemplate;
+    String sinkTableView;
+    if (!sourceTables.isEmpty()) {
+      sinkTableTemplate = sinkTable(context.config(), context.mode());
+      sinkTableView = sinkTableView(sinkTableTemplate, sourceTables, context.mode());
+    } else {
+      sinkTableTemplate =
+          text(
+              context.config(),
+              "targetTableName",
+              text(context.config(), "table", text(options, "table_path", null)));
+      if (!StringUtils.hasText(sinkTableTemplate)) {
+        throw new IllegalArgumentException("请选择或填写目标表");
+      }
+      sinkTableTemplate = sinkTableTemplate.trim();
+      sinkTableView = sinkTableTemplate;
+    }
+
+    options.put("table_path", sinkTableTemplate);
+    options.put(
+        "schema_save_mode",
+        context.config().path("autoCreateTable").asBoolean(false)
+            ? "CREATE_SCHEMA_WHEN_NOT_EXIST"
+            : "ERROR_WHEN_SCHEMA_NOT_EXIST");
+
+    String writeMode =
+        text(context.config(), "writeMode", "append").toLowerCase(Locale.ROOT);
+    options.put(
+        "data_save_mode",
+        "overwrite".equals(writeMode) ? "DROP_DATA" : "APPEND_DATA");
+    options.put("write_mode", "upsert".equals(writeMode) ? "UPSERT" : "INSERT");
+
+    if ("upsert".equals(writeMode)) {
+      List<String> primaryKeys = splitValues(text(context.config(), "primaryKey", null));
+      if (primaryKeys.isEmpty()) {
+        throw new IllegalArgumentException("UPSERT 写入模式必须配置主键字段");
+      }
+      options.set("primary_keys", objectMapper.valueToTree(primaryKeys));
+    } else {
+      options.remove("primary_keys");
+    }
+
+    String customSql = text(context.config(), "sql", null);
+    if (StringUtils.hasText(customSql)) {
+      options.put("custom_sql", customSql.trim());
+    }
+
+    options.put("batch_size", context.batchSize());
+    String dirtyPolicy = text(context.channel(), "dirtyDataPolicy", "stop");
+    options.put(
+        "dirty_data_policy",
+        "skip".equalsIgnoreCase(dirtyPolicy) ? "SKIP" : "FAIL_FAST");
+    if ("skip".equalsIgnoreCase(dirtyPolicy)) {
+      options.put(
+          "dirty_data_max_count",
+          Math.max(0L, longValue(context.channel(), "dirtyDataLimit", 0L)));
+    } else {
+      options.remove("dirty_data_max_count");
+    }
+
+    return new BuildResult(options, sinkTableView, List.of());
+  }
+
+  private void removeDatasourceOwnedOptions(ObjectNode options) {
+    DATASOURCE_OWNED_OPTIONS.forEach(options::remove);
+  }
+
+  private void appendConnection(ObjectNode options, ConnectionDetails connection) {
+    options.put("url", connection.url());
+    options.put("driver", connection.driver());
+    if (connection.username() != null) {
+      options.put("username", connection.username());
+    }
+    if (connection.password() != null) {
+      options.put("password", connection.password());
+    }
+    if (StringUtils.hasText(connection.schema())) {
+      options.put("schema", connection.schema());
+    }
+  }
+
+  private ConnectionDetails connection(DataSourcePO dataSource) {
+    JsonNode parameters = parseJson(dataSource.getConnectionParams());
+    String url = firstText(parameters, "url", "jdbcUrl", "jdbc_url", "jdbc-url");
+    if (!StringUtils.hasText(url)) {
+      url = dataSource.getJdbcUrl();
+    }
+    if (!StringUtils.hasText(url)) {
+      throw new IllegalArgumentException("数据源 " + dataSource.getName() + " 缺少 JDBC URL");
+    }
+
+    String driver =
+        firstText(
+            parameters,
+            "driver",
+            "driverClassName",
+            "driver_class_name",
+            "driver-class-name");
+    if (!StringUtils.hasText(driver)) {
+      driver =
+          defaultDriver(
+              url,
+              dataSource.getDbType() == null ? null : dataSource.getDbType().name());
+    }
+    if (!StringUtils.hasText(driver)) {
+      throw new IllegalArgumentException("数据源 " + dataSource.getName() + " 缺少 JDBC Driver");
+    }
+
+    return new ConnectionDetails(
+        url.trim(),
+        driver.trim(),
+        firstTextAllowEmpty(parameters, "username", "user"),
+        firstTextAllowEmpty(parameters, "password", "passwd"),
+        firstText(parameters, "schema", "schemaName", "schema_name"));
+  }
+
+  private JsonNode parseJson(String value) {
+    if (!StringUtils.hasText(value)) {
+      return objectMapper.createObjectNode();
+    }
+    try {
+      return objectMapper.readTree(value);
+    } catch (JsonProcessingException exception) {
+      throw new IllegalArgumentException("数据源连接参数不是有效 JSON", exception);
+    }
+  }
+
+  private List<String> sourceTables(JsonNode config, String mode, String jobName) {
+    if ("GUIDE_MULTI".equals(mode)) {
+      List<String> tables = flattenTables(config.path("tables"));
+      if (tables.isEmpty()) {
+        String pattern = text(config, "tablePattern", null);
+        if (StringUtils.hasText(pattern) && !containsWildcard(pattern)) {
+          tables.add(pattern.trim());
+        }
+      }
+      if (tables.isEmpty()) {
+        throw new IllegalArgumentException(
+            "多表同步必须选择至少一张来源表，Link-Up 暂不直接执行通配符表名");
+      }
+      return tables;
+    }
+
+    String table = text(config, "table", null);
+    String query = sourceQuery(config);
+    if (!StringUtils.hasText(table) && StringUtils.hasText(query)) {
+      table = "yak_query." + safeIdentifier(jobName);
+    }
+    if (!StringUtils.hasText(table)) {
+      throw new IllegalArgumentException("请选择来源表");
+    }
+    return new ArrayList<>(List.of(table.trim()));
+  }
+
+  private String sourceQuery(JsonNode config) {
+    if (!"sql".equalsIgnoreCase(text(config, "readMode", "table"))) {
+      return null;
+    }
+    String query = text(config, "sql", null);
+    if (!StringUtils.hasText(query)) {
+      throw new IllegalArgumentException("SQL 读取模式必须填写来源查询 SQL");
+    }
+    return query.trim();
+  }
+
+  private String sinkTable(JsonNode config, String mode) {
+    String explicit = text(config, "targetTableName", text(config, "table", null));
+    if ("GUIDE_SINGLE".equals(mode)) {
+      if (!StringUtils.hasText(explicit)) {
+        throw new IllegalArgumentException("请选择或填写目标表");
+      }
+      return explicit.trim();
+    }
+    if (StringUtils.hasText(explicit)) {
+      return explicit.trim();
+    }
+
+    String rule = text(config, "tableNamingRule", "same_name");
+    String affix = text(config, "tableNameAffix", "");
+    if ("prefix".equalsIgnoreCase(rule)) {
+      return affix + "${table_name}";
+    }
+    if ("suffix".equalsIgnoreCase(rule)) {
+      return "${table_name}" + affix;
+    }
+    if (!"same_name".equalsIgnoreCase(rule) && StringUtils.hasText(affix)) {
+      return affix + "${table_name}";
+    }
+    return "${table_name}";
+  }
+
+  private String sinkTableView(
+      String template,
+      List<String> sourceTables,
+      String mode) {
+    if ("GUIDE_SINGLE".equals(mode)) {
+      return template;
+    }
+
+    List<String> targetTables = new ArrayList<>();
+    for (String sourceTable : sourceTables) {
+      String schemaName = "";
+      String tableName = sourceTable;
+      int separator = sourceTable.lastIndexOf('.');
+      if (separator >= 0) {
+        schemaName = sourceTable.substring(0, separator);
+        tableName = sourceTable.substring(separator + 1);
+      }
+      targetTables.add(
+          template
+              .replace("${schema_name}", schemaName)
+              .replace("${table_name}", tableName));
+    }
+    return writeJson(targetTables);
+  }
+
+  private String tableView(List<String> tables, String mode) {
+    return "GUIDE_MULTI".equals(mode) ? writeJson(tables) : tables.get(0);
+  }
+
+  private String writeJson(Object value) {
+    try {
+      return objectMapper.writeValueAsString(value);
+    } catch (JsonProcessingException exception) {
+      throw new IllegalStateException("序列化表信息失败", exception);
+    }
+  }
+
+  private List<String> flattenTables(JsonNode value) {
+    LinkedHashSet<String> result = new LinkedHashSet<>();
+    flattenTables(value, null, result);
+    return new ArrayList<>(result);
+  }
+
+  private void flattenTables(JsonNode value, String schema, Set<String> result) {
+    if (value == null || value.isNull() || value.isMissingNode()) {
+      return;
+    }
+    if (value.isTextual()) {
+      String table = value.asText().trim();
+      if (StringUtils.hasText(table)) {
+        result.add(
+            StringUtils.hasText(schema) && !table.contains(".")
+                ? schema + "." + table
+                : table);
+      }
+      return;
+    }
+    if (value.isArray()) {
+      for (JsonNode item : value) {
+        flattenTables(item, schema, result);
+      }
+      return;
+    }
+    if (value.isObject()) {
+      value.fields().forEachRemaining(
+          entry -> flattenTables(entry.getValue(), entry.getKey(), result));
+    }
+  }
+
+  private String firstText(JsonNode node, String... keys) {
+    String value = firstTextAllowEmpty(node, keys);
+    return StringUtils.hasText(value) ? value.trim() : null;
+  }
+
+  private String firstTextAllowEmpty(JsonNode node, String... keys) {
+    Set<String> normalizedKeys = new LinkedHashSet<>();
+    Arrays.stream(keys).map(this::normalizeKey).forEach(normalizedKeys::add);
+    return findText(node, normalizedKeys);
+  }
+
+  private String findText(JsonNode node, Set<String> normalizedKeys) {
+    if (node == null || node.isNull() || node.isMissingNode()) {
+      return null;
+    }
+    if (node.isObject()) {
+      Iterator<Map.Entry<String, JsonNode>> fields = node.fields();
+      while (fields.hasNext()) {
+        Map.Entry<String, JsonNode> entry = fields.next();
+        JsonNode value = entry.getValue();
+        if (normalizedKeys.contains(normalizeKey(entry.getKey())) && value.isValueNode()) {
+          return value.isNull() ? null : value.asText();
+        }
+      }
+      fields = node.fields();
+      while (fields.hasNext()) {
+        String value = findText(fields.next().getValue(), normalizedKeys);
+        if (value != null) {
+          return value;
+        }
+      }
+    } else if (node.isArray()) {
+      for (JsonNode item : node) {
+        String value = findText(item, normalizedKeys);
+        if (value != null) {
+          return value;
+        }
+      }
+    }
+    return null;
+  }
+
+  private String defaultDriver(String url, String dbType) {
+    String normalized =
+        (url + " " + (dbType == null ? "" : dbType)).toLowerCase(Locale.ROOT);
+    if (normalized.contains("mariadb")) {
+      return "org.mariadb.jdbc.Driver";
+    }
+    if (normalized.contains("mysql") || normalized.contains("doris")) {
+      return "com.mysql.cj.jdbc.Driver";
+    }
+    if (normalized.contains("postgres")) {
+      return "org.postgresql.Driver";
+    }
+    if (normalized.contains("oracle")) {
+      return "oracle.jdbc.OracleDriver";
+    }
+    if (normalized.contains("kingbase")) {
+      return "com.kingbase8.Driver";
+    }
+    if (normalized.contains("dm:") || normalized.contains("dameng")) {
+      return "dm.jdbc.driver.DmDriver";
+    }
+    return null;
+  }
+
+  private List<String> splitValues(String value) {
+    if (!StringUtils.hasText(value)) {
+      return new ArrayList<>();
+    }
+    return Arrays.stream(value.split(","))
+        .map(String::trim)
+        .filter(StringUtils::hasText)
+        .distinct()
+        .toList();
+  }
+
+  private boolean containsWildcard(String value) {
+    return value.contains("*") || value.contains("?") || value.contains("[");
+  }
+
+  private String safeIdentifier(String value) {
+    String normalized = value.replaceAll("[^A-Za-z0-9_]", "_");
+    return normalized.isBlank() ? "dataset" : normalized;
+  }
+
+  private String text(JsonNode node, String field, String fallback) {
+    JsonNode value = node == null ? null : node.get(field);
+    if (value == null || value.isNull() || !value.isValueNode()) {
+      return fallback;
+    }
+    return value.asText(fallback);
+  }
+
+  private long longValue(JsonNode node, String field, long fallback) {
+    JsonNode value = node == null ? null : node.get(field);
+    if (value == null || value.isNull() || !value.isValueNode()) {
+      return fallback;
+    }
+    if (value.isNumber()) {
+      return value.asLong(fallback);
+    }
+    String text = value.asText("").trim();
+    if (!StringUtils.hasText(text)) {
+      return fallback;
+    }
+    try {
+      return Long.parseLong(text);
+    } catch (NumberFormatException ignored) {
+      return fallback;
+    }
+  }
+
+  private String normalizeKey(String value) {
+    return value.replace("_", "").replace("-", "").toLowerCase(Locale.ROOT);
+  }
+
+  private record ConnectionDetails(
+      String url,
+      String driver,
+      String username,
+      String password,
+      String schema) {}
+}

--- a/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-offline/src/main/java/io/yak/ops/business/sync/offline/engine/connector/adapter/OfflineSyncConnectorAdapter.java
+++ b/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-offline/src/main/java/io/yak/ops/business/sync/offline/engine/connector/adapter/OfflineSyncConnectorAdapter.java
@@ -1,0 +1,80 @@
+package io.yak.ops.business.sync.offline.engine.connector.adapter;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import io.yak.ops.common.bean.po.datasource.DataSourcePO;
+import java.util.List;
+import java.util.Objects;
+
+/**
+ * Connector-specific boundary between Yak Ops offline definitions and Link-Up endpoint options.
+ *
+ * <p>The factory owns job-level orchestration. Implementations own connector option semantics and
+ * execution-time datasource translation. Logical JobSpec construction cannot access DataSourcePO;
+ * datasource credentials are only available during {@link #resolveForExecution(ExecutionContext)}.</p>
+ */
+public interface OfflineSyncConnectorAdapter {
+
+  boolean supports(String connectorId, Role role);
+
+  boolean requiresDataSource(String connectorId, Role role);
+
+  BuildResult build(BuildContext context);
+
+  void resolveForExecution(ExecutionContext context);
+
+  enum Role {
+    SOURCE,
+    SINK
+  }
+
+  record BuildContext(
+      String connectorId,
+      Role role,
+      String mode,
+      String jobName,
+      JsonNode config,
+      JsonNode channel,
+      ObjectNode options,
+      int batchSize,
+      int fetchSize,
+      List<String> sourceTables) {
+
+    public BuildContext {
+      Objects.requireNonNull(connectorId, "connectorId");
+      Objects.requireNonNull(role, "role");
+      Objects.requireNonNull(mode, "mode");
+      Objects.requireNonNull(jobName, "jobName");
+      Objects.requireNonNull(config, "config");
+      Objects.requireNonNull(channel, "channel");
+      Objects.requireNonNull(options, "options");
+      sourceTables = sourceTables == null ? List.of() : List.copyOf(sourceTables);
+    }
+  }
+
+  record BuildResult(
+      ObjectNode options,
+      String tableView,
+      List<String> sourceTables) {
+
+    public BuildResult {
+      Objects.requireNonNull(options, "options");
+      sourceTables = sourceTables == null ? List.of() : List.copyOf(sourceTables);
+    }
+  }
+
+  record ExecutionContext(
+      String connectorId,
+      Role role,
+      String endpointLabel,
+      DataSourcePO dataSource,
+      ObjectNode options) {
+
+    public ExecutionContext {
+      Objects.requireNonNull(connectorId, "connectorId");
+      Objects.requireNonNull(role, "role");
+      Objects.requireNonNull(endpointLabel, "endpointLabel");
+      Objects.requireNonNull(options, "options");
+    }
+  }
+}

--- a/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-offline/src/main/java/io/yak/ops/business/sync/offline/engine/connector/adapter/OfflineSyncConnectorAdapterRegistry.java
+++ b/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-offline/src/main/java/io/yak/ops/business/sync/offline/engine/connector/adapter/OfflineSyncConnectorAdapterRegistry.java
@@ -1,0 +1,63 @@
+package io.yak.ops.business.sync.offline.engine.connector.adapter;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.yak.ops.business.sync.offline.config.ConditionalOnOfflineSyncEnabled;
+import io.yak.ops.business.sync.offline.engine.connector.adapter.OfflineSyncConnectorAdapter.Role;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Objects;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Component;
+import org.springframework.util.StringUtils;
+
+/** Selects exactly one connector adapter, falling back to transparent option passthrough. */
+@ConditionalOnOfflineSyncEnabled
+@Component
+public class OfflineSyncConnectorAdapterRegistry {
+
+  private final List<OfflineSyncConnectorAdapter> adapters;
+  private final OfflineSyncConnectorAdapter fallback;
+
+  @Autowired
+  public OfflineSyncConnectorAdapterRegistry(List<OfflineSyncConnectorAdapter> adapters) {
+    this(adapters, new PassthroughOfflineSyncConnectorAdapter());
+  }
+
+  OfflineSyncConnectorAdapterRegistry(
+      List<OfflineSyncConnectorAdapter> adapters,
+      OfflineSyncConnectorAdapter fallback) {
+    this.adapters = adapters == null ? List.of() : List.copyOf(adapters);
+    this.fallback = Objects.requireNonNull(fallback, "fallback");
+  }
+
+  /** Convenience registry used by focused unit tests and legacy direct constructors. */
+  public static OfflineSyncConnectorAdapterRegistry standard(ObjectMapper objectMapper) {
+    return new OfflineSyncConnectorAdapterRegistry(
+        List.of(new JdbcOfflineSyncConnectorAdapter(objectMapper)));
+  }
+
+  public OfflineSyncConnectorAdapter resolve(String connectorId, Role role) {
+    if (!StringUtils.hasText(connectorId)) {
+      throw new IllegalArgumentException("connectorId 不能为空");
+    }
+    Objects.requireNonNull(role, "role");
+
+    List<OfflineSyncConnectorAdapter> matches = new ArrayList<>();
+    for (OfflineSyncConnectorAdapter adapter : adapters) {
+      if (adapter.supports(connectorId, role)) {
+        matches.add(adapter);
+      }
+    }
+
+    if (matches.size() > 1) {
+      throw new IllegalStateException(
+          "存在多个离线同步 Connector Adapter："
+              + role
+              + "/"
+              + connectorId
+              + " -> "
+              + matches.stream().map(value -> value.getClass().getName()).toList());
+    }
+    return matches.isEmpty() ? fallback : matches.get(0);
+  }
+}

--- a/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-offline/src/main/java/io/yak/ops/business/sync/offline/engine/connector/adapter/PassthroughOfflineSyncConnectorAdapter.java
+++ b/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-offline/src/main/java/io/yak/ops/business/sync/offline/engine/connector/adapter/PassthroughOfflineSyncConnectorAdapter.java
@@ -1,0 +1,47 @@
+package io.yak.ops.business.sync.offline.engine.connector.adapter;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import io.yak.ops.business.sync.offline.engine.connector.adapter.OfflineSyncConnectorAdapter.BuildContext;
+import io.yak.ops.business.sync.offline.engine.connector.adapter.OfflineSyncConnectorAdapter.BuildResult;
+import io.yak.ops.business.sync.offline.engine.connector.adapter.OfflineSyncConnectorAdapter.ExecutionContext;
+import io.yak.ops.business.sync.offline.engine.connector.adapter.OfflineSyncConnectorAdapter.Role;
+import java.util.List;
+import org.springframework.util.StringUtils;
+
+/**
+ * Compatibility adapter for framework-neutral Connector IDs that Yak Ops does not yet understand.
+ *
+ * <p>It deliberately does not resolve datasource credentials. Existing inline connector options
+ * continue to pass through unchanged until a dedicated adapter is introduced.</p>
+ */
+final class PassthroughOfflineSyncConnectorAdapter implements OfflineSyncConnectorAdapter {
+
+  @Override
+  public boolean supports(String connectorId, Role role) {
+    return false;
+  }
+
+  @Override
+  public boolean requiresDataSource(String connectorId, Role role) {
+    return false;
+  }
+
+  @Override
+  public BuildResult build(BuildContext context) {
+    String tableView = text(context.options().get("table_path"));
+    return new BuildResult(context.options(), tableView, List.of());
+  }
+
+  @Override
+  public void resolveForExecution(ExecutionContext context) {
+    // Intentionally empty: unknown connectors retain their inline options only.
+  }
+
+  private String text(JsonNode value) {
+    if (value == null || value.isNull() || !value.isValueNode()) {
+      return null;
+    }
+    String text = value.asText(null);
+    return StringUtils.hasText(text) ? text.trim() : null;
+  }
+}

--- a/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-offline/src/test/java/io/yak/ops/business/sync/offline/engine/LinkUpJobSpecFactoryAdapterDelegationTest.java
+++ b/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-offline/src/test/java/io/yak/ops/business/sync/offline/engine/LinkUpJobSpecFactoryAdapterDelegationTest.java
@@ -1,0 +1,116 @@
+package io.yak.ops.business.sync.offline.engine;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.yak.ops.business.datasource.dao.DataSourceDao;
+import io.yak.ops.business.sync.offline.engine.connector.adapter.OfflineSyncConnectorAdapter;
+import io.yak.ops.business.sync.offline.engine.connector.adapter.OfflineSyncConnectorAdapter.BuildContext;
+import io.yak.ops.business.sync.offline.engine.connector.adapter.OfflineSyncConnectorAdapter.BuildResult;
+import io.yak.ops.business.sync.offline.engine.connector.adapter.OfflineSyncConnectorAdapter.ExecutionContext;
+import io.yak.ops.business.sync.offline.engine.connector.adapter.OfflineSyncConnectorAdapter.Role;
+import io.yak.ops.business.sync.offline.engine.connector.adapter.OfflineSyncConnectorAdapterRegistry;
+import io.yak.ops.common.bean.po.datasource.DataSourcePO;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+
+class LinkUpJobSpecFactoryAdapterDelegationTest {
+
+  private final ObjectMapper mapper = new ObjectMapper();
+
+  @Test
+  void dedicatedAdapterOwnsBuildAndExecutionDatasourceTranslation() throws Exception {
+    DataSourceDao dao = mock(DataSourceDao.class);
+    when(dao.selectById(7L)).thenReturn(dataSource(7L, "native-source"));
+    when(dao.selectById(8L)).thenReturn(dataSource(8L, "native-sink"));
+
+    OfflineSyncConnectorAdapter adapter = new NativeDemoAdapter();
+    OfflineSyncConnectorAdapterRegistry registry =
+        new OfflineSyncConnectorAdapterRegistry(List.of(adapter));
+
+    LinkUpJobSpecFactory factory = new LinkUpJobSpecFactory(dao, mapper, registry);
+    JsonNode definition =
+        mapper.readTree(
+            """
+            {
+              "basic": {"jobName": "native-demo", "mode": "GUIDE_SINGLE"},
+              "source": {
+                "connectorId": "native-demo",
+                "dataSourceId": 7,
+                "config": {
+                  "connectorOptions": {"table_path": "src.orders"}
+                }
+              },
+              "sink": {
+                "connectorId": "native-demo",
+                "dataSourceId": 8,
+                "config": {
+                  "connectorOptions": {"table_path": "dst.orders"}
+                }
+              },
+              "channel": {"parallelism": 1}
+            }
+            """);
+
+    LinkUpJobSpecFactory.BuildResult built = factory.build(definition);
+    JsonNode logical = built.getJobSpec();
+
+    assertThat(logical.path("source").path("dataSourceRef").path("id").asLong())
+        .isEqualTo(7L);
+    assertThat(logical.path("sink").path("dataSourceRef").path("id").asLong())
+        .isEqualTo(8L);
+    assertThat(logical.path("source").path("options").path("built_by_adapter").asText())
+        .isEqualTo("SOURCE");
+    assertThat(logical.path("sink").path("options").path("built_by_adapter").asText())
+        .isEqualTo("SINK");
+    assertThat(logical.toString()).doesNotContain("native-source", "native-sink");
+
+    JsonNode resolved = factory.resolveForExecution(logical);
+
+    assertThat(resolved.path("source").has("dataSourceRef")).isFalse();
+    assertThat(resolved.path("sink").has("dataSourceRef")).isFalse();
+    assertThat(resolved.path("source").path("options").path("resolved_from").asText())
+        .isEqualTo("native-source");
+    assertThat(resolved.path("sink").path("options").path("resolved_from").asText())
+        .isEqualTo("native-sink");
+  }
+
+  private DataSourcePO dataSource(Long id, String name) {
+    DataSourcePO value = new DataSourcePO();
+    value.setId(id);
+    value.setName(name);
+    return value;
+  }
+
+  private static final class NativeDemoAdapter implements OfflineSyncConnectorAdapter {
+
+    @Override
+    public boolean supports(String connectorId, Role role) {
+      return "native-demo".equals(connectorId);
+    }
+
+    @Override
+    public boolean requiresDataSource(String connectorId, Role role) {
+      return true;
+    }
+
+    @Override
+    public BuildResult build(BuildContext context) {
+      context.options().put("built_by_adapter", context.role().name());
+      List<String> sourceTables =
+          context.role() == Role.SOURCE ? List.of("src.orders") : List.of();
+      return new BuildResult(
+          context.options(),
+          context.role() == Role.SOURCE ? "src.orders" : "dst.orders",
+          sourceTables);
+    }
+
+    @Override
+    public void resolveForExecution(ExecutionContext context) {
+      context.options().put("resolved_from", context.dataSource().getName());
+    }
+  }
+}

--- a/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-offline/src/test/java/io/yak/ops/business/sync/offline/engine/connector/adapter/OfflineSyncConnectorAdapterRegistryTest.java
+++ b/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-offline/src/test/java/io/yak/ops/business/sync/offline/engine/connector/adapter/OfflineSyncConnectorAdapterRegistryTest.java
@@ -1,0 +1,76 @@
+package io.yak.ops.business.sync.offline.engine.connector.adapter;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.yak.ops.business.sync.offline.engine.connector.adapter.OfflineSyncConnectorAdapter.BuildContext;
+import io.yak.ops.business.sync.offline.engine.connector.adapter.OfflineSyncConnectorAdapter.BuildResult;
+import io.yak.ops.business.sync.offline.engine.connector.adapter.OfflineSyncConnectorAdapter.ExecutionContext;
+import io.yak.ops.business.sync.offline.engine.connector.adapter.OfflineSyncConnectorAdapter.Role;
+import java.util.Arrays;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+
+class OfflineSyncConnectorAdapterRegistryTest {
+
+  @Test
+  void standardRegistrySelectsJdbcAndFallsBackForUnknownConnector() {
+    OfflineSyncConnectorAdapterRegistry registry =
+        OfflineSyncConnectorAdapterRegistry.standard(new ObjectMapper());
+
+    assertThat(registry.resolve("jdbc", Role.SOURCE))
+        .isInstanceOf(JdbcOfflineSyncConnectorAdapter.class);
+    assertThat(registry.resolve("jdbc", Role.SINK))
+        .isInstanceOf(JdbcOfflineSyncConnectorAdapter.class);
+    assertThat(registry.resolve("future-native", Role.SOURCE).getClass().getSimpleName())
+        .isEqualTo("PassthroughOfflineSyncConnectorAdapter");
+  }
+
+  @Test
+  void duplicateAdapterMatchesFailFast() {
+    OfflineSyncConnectorAdapter first = adapter("demo");
+    OfflineSyncConnectorAdapter second = adapter("demo");
+    OfflineSyncConnectorAdapterRegistry registry =
+        new OfflineSyncConnectorAdapterRegistry(List.of(first, second));
+
+    assertThatThrownBy(() -> registry.resolve("demo", Role.SOURCE))
+        .isInstanceOf(IllegalStateException.class)
+        .hasMessageContaining("多个离线同步 Connector Adapter");
+  }
+
+  @Test
+  void datasourceIsAvailableOnlyAtExecutionBoundary() {
+    assertThat(
+            Arrays.stream(BuildContext.class.getRecordComponents())
+                .map(component -> component.getName()))
+        .doesNotContain("dataSource");
+    assertThat(
+            Arrays.stream(ExecutionContext.class.getRecordComponents())
+                .map(component -> component.getName()))
+        .contains("dataSource");
+  }
+
+  private OfflineSyncConnectorAdapter adapter(String id) {
+    return new OfflineSyncConnectorAdapter() {
+      @Override
+      public boolean supports(String connectorId, Role role) {
+        return id.equals(connectorId);
+      }
+
+      @Override
+      public boolean requiresDataSource(String connectorId, Role role) {
+        return false;
+      }
+
+      @Override
+      public BuildResult build(BuildContext context) {
+        return new BuildResult(context.options(), null, List.of());
+      }
+
+      @Override
+      public void resolveForExecution(ExecutionContext context) {
+      }
+    };
+  }
+}


### PR DESCRIPTION
## Summary

PR 3 of the Yak Ops control-plane connector adaptation plan.

PR #1023 established the product-side Offline Sync Connector Profile / Registry and PR #1024 connected those profiles to the actual Connector Schemas loaded by the configured Link-Up Worker. This PR removes connector-specific JobSpec translation from `LinkUpJobSpecFactory` and introduces a dedicated **Offline Sync Connector Adapter** boundary.

The scope is intentionally a refactor: **existing JDBC behavior stays the same, unknown connectors keep the previous passthrough behavior, and no Doris / StarRocks / ClickHouse / Elasticsearch native execution is enabled yet.**

## Why this is needed

Before this PR, `LinkUpJobSpecFactory` owned several unrelated responsibilities at once:

- definition parsing and legacy workflow compatibility
- JDBC source table / custom SQL translation
- JDBC sink table naming, auto-create, write mode and UPSERT translation
- dirty-data and batch options
- JDBC URL / driver / username / password injection from Yak Ops DataSource
- final runtime / JobSpec assembly

That made every future native connector adaptation require another `if (jdbcSource)` / `if (jdbcSink)` style branch inside the central factory.

This PR turns the factory into orchestration only.

## What changed

### 1. `OfflineSyncConnectorAdapter`

Add a connector execution contract under `engine.connector.adapter`.

Each adapter controls four things:

- whether it supports a `connectorId + role`
- whether that role requires a Yak Ops DataSource reference
- how logical connector options are built
- how the selected DataSource is translated into execution-time Worker options

The security boundary is structural rather than convention-only:

- `BuildContext` does **not** expose `DataSourcePO`
- adapter-side logical option construction can only use definition/config/task options
- `ExecutionContext` is the only adapter context that receives `DataSourcePO`
- connection credentials therefore enter connector options only immediately before Worker submission

### 2. `OfflineSyncConnectorAdapterRegistry`

Add a Spring-managed registry that resolves one adapter for a `connectorId + role`.

The registry:

- supports role-specific adapters
- explicitly marks the production constructor for Spring injection
- fails fast if multiple adapters claim the same connector role
- uses a compatibility passthrough adapter when Yak Ops does not yet have a dedicated implementation

This lets future connector support land as additional adapter beans instead of editing the central factory.

### 3. `JdbcOfflineSyncConnectorAdapter`

Move the existing JDBC-specific behavior out of `LinkUpJobSpecFactory` without changing its intended semantics.

Source behavior moved behind the adapter:

- single-table `table_path`
- multi-table `table_list`
- custom SQL read mode
- `where_condition`
- `fetch_size`
- source table display metadata

Sink behavior moved behind the adapter:

- target table / multi-table template handling
- auto-create schema mode
- append / overwrite / upsert modes
- primary keys
- custom sink SQL
- batch size
- dirty-data policy / limit
- sink table display metadata

Execution-time DataSource translation moved behind the adapter:

- JDBC URL
- driver
- username / password
- schema
- historical driver inference and connection parameter aliases

Datasource-owned connector options are still removed from the logical JobSpec before persistence.

### 4. Passthrough compatibility adapter

Unknown/framework-neutral connectors continue to keep inline `connectorOptions` unchanged, matching the old fallback behavior.

The fallback deliberately does **not** consume datasource credentials or invent connection translation. A connector that needs Yak Ops DataSource credentials must provide a dedicated adapter and declare `requiresDataSource=true`.

### 5. `LinkUpJobSpecFactory` becomes orchestration-only

The factory now owns:

- definition / legacy endpoint parsing
- connector ID resolution
- adapter selection
- DataSource reference lookup only when required by an adapter
- source -> sink table metadata handoff
- runtime configuration
- canonical JobSpec assembly
- final execution endpoint orchestration

It no longer contains JDBC option-building or JDBC connection parsing logic, and it no longer branches on `jdbcSource` / `jdbcSink`.

### 6. Column mapping factory follows the production registry

`ColumnMappingLinkUpJobSpecFactory` now receives the same adapter registry in its Spring constructor.

The existing two-argument constructors remain available for focused unit tests / direct construction and build a standard JDBC + passthrough registry, so current tests do not need broad fixture rewrites.

## Compatibility / non-goals

This PR deliberately does **not**:

- add new `DataSourceDbType` values
- change any existing profile from `jdbc` to a native connector
- add Doris / StarRocks / ClickHouse adapters yet
- add Elasticsearch adapters
- change single-table or multi-table UI behavior
- enforce runtime Connector capabilities during task creation
- refactor `OfflineDefinitionModelAdapter.sanitizeForPersistence()`; persistence-input sanitization stays a separate static boundary in this stage
- change scoped Batch V1's explicit JDBC-only contract

Existing JDBC logical JobSpecs must remain credential-free and execution-time JDBC connection injection must remain compatible.

## Tests

This PR keeps the existing `LinkUpJobSpecFactoryTest` and `ColumnMappingLinkUpJobSpecFactoryTest` behavior as regression coverage and adds:

- registry selects JDBC for SOURCE/SINK
- unknown connectors use passthrough fallback
- duplicate adapter claims fail fast
- `BuildContext` cannot expose DataSource while `ExecutionContext` must expose it
- a synthetic native adapter can require DataSource, build logical options and translate DataSource values at execution time without any factory changes
- logical JobSpec retains `dataSourceRef` but not DataSource contents
- execution removes `dataSourceRef` after adapter translation

## Validation status

- based directly on current `main` after PR #1024 merge (`fc891cd1b688dccb08ba383ec0dc2f89d5377b8b`)
- branch is ahead by 1 commit and behind by 0
- final diff is limited to the JobSpec connector adapter boundary, JDBC behavior migration and focused tests
- GitHub CI #219 completed successfully
- frontend dependency installation and production build completed successfully
- Java / Maven packaging was **not executed**: the workflow detected that `YAK_FRAMEWORK_READ_TOKEN` is not configured and deliberately skipped Java setup, private `yak-framework` checkout/install and `Package Yak Ops`
- therefore this PR does not claim a Java compile/test pass from CI; the green workflow currently validates frontend/release metadata only

## Next stage

Once this adapter boundary is merged, native database support can be added incrementally without changing `LinkUpJobSpecFactory` again. Doris remains the best first native adapter candidate because Yak Ops already has a dedicated Doris datasource plugin; capability-driven editor behavior can then consume PR #1024's runtime schema contract without duplicating Link-Up knowledge.