### PR TITLE
feat(sync): drive offline editor from connector capabilities

### DIFF
--- a/yak-ops-ui/src/pages/integration/batch-link-up/detail/capabilities.test.ts
+++ b/yak-ops-ui/src/pages/integration/batch-link-up/detail/capabilities.test.ts
@@ -1,0 +1,150 @@
+import type { OfflineConnectorRuntimeSnapshot } from '@/services/batch-link-up';
+
+import {
+  allowsCapability,
+  CONNECTOR_CAPABILITY,
+  resolveEndpointCapability,
+  validateEditorCapabilities,
+} from './capabilities';
+import type { SyncEditorState } from './model';
+
+const editor = (): SyncEditorState => ({
+  id: '1',
+  mode: 'GUIDE_SINGLE',
+  basic: { jobName: 'demo', jobDesc: '', mode: 'GUIDE_SINGLE' },
+  source: {
+    connectorId: 'jdbc',
+    pluginName: 'JDBC-MYSQL',
+    dbType: 'MYSQL',
+    dataSourceId: '1',
+    config: { readMode: 'table', table: 'a.orders' },
+  },
+  sink: {
+    connectorId: 'jdbc',
+    pluginName: 'JDBC-MYSQL',
+    dbType: 'MYSQL',
+    dataSourceId: '2',
+    config: { table: 'b.orders', writeMode: 'append' },
+  },
+  channel: {
+    parallelism: 1,
+    speedLimitEnabled: false,
+    recordsPerSecond: 10000,
+    dirtyDataPolicy: 'stop',
+    dirtyDataLimit: 0,
+  },
+  mapping: { columns: [] },
+  schedule: { cron: '', enabled: false, retryOnFailure: false },
+  notification: {
+    enabled: true,
+    triggers: ['FINAL_FAILURE'],
+    recipientType: 'PROJECT_OWNER',
+    recipientUserIds: [],
+    inAppEnabled: true,
+    alertEnabled: false,
+    alertChannelIds: [],
+  },
+});
+
+const snapshot = (
+  sourceCapabilities: string[],
+  sinkCapabilities: string[],
+): OfflineConnectorRuntimeSnapshot => ({
+  reachable: true,
+  stale: false,
+  connectors: [
+    {
+      connectorId: 'jdbc',
+      role: 'SOURCE',
+      available: true,
+      capabilities: sourceCapabilities,
+    },
+    {
+      connectorId: 'jdbc',
+      role: 'SINK',
+      available: true,
+      capabilities: sinkCapabilities,
+    },
+  ],
+  profiles: [],
+});
+
+describe('offline connector capabilities', () => {
+  it('keeps legacy controls visible before runtime metadata is known', () => {
+    const state = resolveEndpointCapability(null, 'jdbc', 'SOURCE');
+
+    expect(state.metadataKnown).toBe(false);
+    expect(allowsCapability(state, CONNECTOR_CAPABILITY.CUSTOM_SQL)).toBe(true);
+  });
+
+  it('accepts a configuration covered by the live connector capabilities', () => {
+    const value = editor();
+    value.mode = 'GUIDE_MULTI';
+    value.basic.mode = 'GUIDE_MULTI';
+    value.sink.config = {
+      database: 'ods',
+      writeMode: 'upsert',
+      primaryKey: 'id',
+      autoCreateTable: true,
+    };
+    value.channel.dirtyDataPolicy = 'skip';
+
+    const errors = validateEditorCapabilities(
+      value,
+      snapshot(
+        ['MULTI_TABLE', 'CUSTOM_SQL'],
+        ['MULTI_TABLE', 'UPSERT', 'AUTO_CREATE_TABLE', 'DIRTY_DATA_HANDLING'],
+      ),
+    );
+
+    expect(errors).toEqual([]);
+  });
+
+  it('requires both connector roles to advertise MULTI_TABLE', () => {
+    const value = editor();
+    value.mode = 'GUIDE_MULTI';
+    value.basic.mode = 'GUIDE_MULTI';
+
+    const errors = validateEditorCapabilities(
+      value,
+      snapshot(['MULTI_TABLE'], ['UPSERT']),
+    );
+
+    expect(errors).toContain(
+      'Sink Connector jdbc 不支持多表同步（MULTI_TABLE）',
+    );
+  });
+
+  it('rejects active SQL, auto-create, upsert and dirty-data features when absent', () => {
+    const value = editor();
+    value.source.config = { readMode: 'sql', sql: 'select 1' };
+    value.sink.config = {
+      autoCreateTable: true,
+      targetTableName: 'orders',
+      writeMode: 'upsert',
+      primaryKey: 'id',
+    };
+    value.channel.dirtyDataPolicy = 'skip';
+
+    const errors = validateEditorCapabilities(value, snapshot([], []));
+
+    expect(errors).toEqual(
+      expect.arrayContaining([
+        'Source Connector jdbc 不支持自定义 SQL（CUSTOM_SQL）',
+        'Sink Connector jdbc 不支持自动建表（AUTO_CREATE_TABLE）',
+        'Sink Connector jdbc 不支持 Upsert（UPSERT）',
+        'Sink Connector jdbc 不支持跳过脏数据（DIRTY_DATA_HANDLING）',
+      ]),
+    );
+  });
+
+  it('does not treat an unreachable stale snapshot as authoritative', () => {
+    const value = editor();
+    value.source.config = { readMode: 'sql', sql: 'select 1' };
+    const stale = snapshot([], []);
+    stale.reachable = false;
+    stale.stale = true;
+
+    expect(validateEditorCapabilities(value, stale)).toEqual([]);
+  });
+});

--- a/yak-ops-ui/src/pages/integration/batch-link-up/detail/capabilities.ts
+++ b/yak-ops-ui/src/pages/integration/batch-link-up/detail/capabilities.ts
@@ -1,0 +1,178 @@
+import type {
+  OfflineConnectorRole,
+  OfflineConnectorRoleRuntime,
+  OfflineConnectorRuntimeSnapshot,
+} from '@/services/batch-link-up';
+
+import type { SyncEditorState } from './model';
+
+export const CONNECTOR_CAPABILITY = {
+  TABLE_SCHEMA_DISCOVERY: 'TABLE_SCHEMA_DISCOVERY',
+  MULTI_TABLE: 'MULTI_TABLE',
+  CUSTOM_SQL: 'CUSTOM_SQL',
+  PARTITION_SPLIT: 'PARTITION_SPLIT',
+  UPSERT: 'UPSERT',
+  AUTO_CREATE_TABLE: 'AUTO_CREATE_TABLE',
+  DIRTY_DATA_HANDLING: 'DIRTY_DATA_HANDLING',
+  TWO_PHASE_COMMIT: 'TWO_PHASE_COMMIT',
+} as const;
+
+export type ConnectorCapability =
+  (typeof CONNECTOR_CAPABILITY)[keyof typeof CONNECTOR_CAPABILITY];
+
+export interface EndpointCapabilityState {
+  connectorId: string;
+  role: OfflineConnectorRole;
+  runtimeChecked: boolean;
+  workerReachable: boolean;
+  stale: boolean;
+  metadataKnown: boolean;
+  available: boolean;
+  capabilities: string[];
+  runtime?: OfflineConnectorRoleRuntime;
+}
+
+const normalizeConnectorId = (value: string) =>
+  String(value || '').trim().toLowerCase();
+
+const normalizeCapability = (value: string) =>
+  String(value || '').trim().toUpperCase();
+
+export const resolveEndpointCapability = (
+  snapshot: OfflineConnectorRuntimeSnapshot | null | undefined,
+  connectorId: string,
+  role: OfflineConnectorRole,
+): EndpointCapabilityState => {
+  const normalizedId = normalizeConnectorId(connectorId);
+  const runtime = snapshot?.connectors?.find(
+    (item) =>
+      normalizeConnectorId(item.connectorId) === normalizedId &&
+      item.role === role,
+  );
+  const capabilities = Array.from(
+    new Set(
+      (runtime?.capabilities || [])
+        .map(normalizeCapability)
+        .filter(Boolean),
+    ),
+  ).sort();
+
+  return {
+    connectorId: normalizedId,
+    role,
+    runtimeChecked: Boolean(snapshot),
+    workerReachable: snapshot?.reachable === true,
+    stale: snapshot?.stale === true,
+    metadataKnown: Boolean(runtime),
+    available: Boolean(snapshot?.reachable && runtime?.available),
+    capabilities,
+    runtime,
+  };
+};
+
+export const hasCapability = (
+  state: EndpointCapabilityState,
+  capability: ConnectorCapability | string,
+) => state.capabilities.includes(normalizeCapability(capability));
+
+/**
+ * UI compatibility rule: before runtime metadata is known, keep the historical controls visible.
+ * Once the Worker has described a connector role, the capability list becomes authoritative.
+ */
+export const allowsCapability = (
+  state: EndpointCapabilityState,
+  capability: ConnectorCapability | string,
+) => !state.metadataKnown || hasCapability(state, capability);
+
+export const isDefinitivelyUnavailable = (
+  state: EndpointCapabilityState,
+) => state.runtimeChecked && state.workerReachable && !state.available;
+
+export const validateEditorCapabilities = (
+  editor: SyncEditorState,
+  snapshot: OfflineConnectorRuntimeSnapshot | null | undefined,
+): string[] => {
+  if (!snapshot || !snapshot.reachable) {
+    return [];
+  }
+
+  const source = resolveEndpointCapability(
+    snapshot,
+    editor.source.connectorId,
+    'SOURCE',
+  );
+  const sink = resolveEndpointCapability(
+    snapshot,
+    editor.sink.connectorId,
+    'SINK',
+  );
+  const errors: string[] = [];
+
+  if (!source.available) {
+    errors.push(
+      `当前 Link-Up Worker 未加载 Source Connector：${editor.source.connectorId || 'UNKNOWN'}`,
+    );
+  }
+  if (!sink.available) {
+    errors.push(
+      `当前 Link-Up Worker 未加载 Sink Connector：${editor.sink.connectorId || 'UNKNOWN'}`,
+    );
+  }
+  if (errors.length > 0) {
+    return errors;
+  }
+
+  if (editor.mode === 'GUIDE_MULTI') {
+    if (!hasCapability(source, CONNECTOR_CAPABILITY.MULTI_TABLE)) {
+      errors.push(
+        `Source Connector ${source.connectorId} 不支持多表同步（MULTI_TABLE）`,
+      );
+    }
+    if (!hasCapability(sink, CONNECTOR_CAPABILITY.MULTI_TABLE)) {
+      errors.push(
+        `Sink Connector ${sink.connectorId} 不支持多表同步（MULTI_TABLE）`,
+      );
+    }
+  }
+
+  const sourceConfig = editor.source.config || {};
+  const sinkConfig = editor.sink.config || {};
+
+  if (
+    String(sourceConfig.readMode || '').toLowerCase() === 'sql' &&
+    !hasCapability(source, CONNECTOR_CAPABILITY.CUSTOM_SQL)
+  ) {
+    errors.push(
+      `Source Connector ${source.connectorId} 不支持自定义 SQL（CUSTOM_SQL）`,
+    );
+  }
+
+  if (
+    Boolean(sinkConfig.autoCreateTable) &&
+    !hasCapability(sink, CONNECTOR_CAPABILITY.AUTO_CREATE_TABLE)
+  ) {
+    errors.push(
+      `Sink Connector ${sink.connectorId} 不支持自动建表（AUTO_CREATE_TABLE）`,
+    );
+  }
+
+  if (
+    String(sinkConfig.writeMode || '').toLowerCase() === 'upsert' &&
+    !hasCapability(sink, CONNECTOR_CAPABILITY.UPSERT)
+  ) {
+    errors.push(
+      `Sink Connector ${sink.connectorId} 不支持 Upsert（UPSERT）`,
+    );
+  }
+
+  if (
+    editor.channel.dirtyDataPolicy === 'skip' &&
+    !hasCapability(sink, CONNECTOR_CAPABILITY.DIRTY_DATA_HANDLING)
+  ) {
+    errors.push(
+      `Sink Connector ${sink.connectorId} 不支持跳过脏数据（DIRTY_DATA_HANDLING）`,
+    );
+  }
+
+  return errors;
+};

--- a/yak-ops-ui/src/pages/integration/batch-link-up/detail/components/ChannelConfigSection.tsx
+++ b/yak-ops-ui/src/pages/integration/batch-link-up/detail/components/ChannelConfigSection.tsx
@@ -1,12 +1,18 @@
 import { InputNumber, Select } from 'antd';
 import type { ReactNode } from 'react';
 
+import {
+  allowsCapability,
+  CONNECTOR_CAPABILITY,
+  type EndpointCapabilityState,
+} from '../capabilities';
 import type { SyncEditorState } from '../model';
 import EditorSection from './EditorSection';
 
 interface ChannelConfigSectionProps {
   editor: SyncEditorState;
   sinkConfig: Record<string, any>;
+  sinkCapability: EndpointCapabilityState;
   onChange: (value: SyncEditorState) => void;
   onSinkChange: (patch: Record<string, any>) => void;
 }
@@ -31,9 +37,24 @@ function Field({
 export default function ChannelConfigSection({
   editor,
   sinkConfig,
+  sinkCapability,
   onChange,
   onSinkChange,
 }: ChannelConfigSectionProps) {
+  const supportsDirtyDataHandling = allowsCapability(
+    sinkCapability,
+    CONNECTOR_CAPABILITY.DIRTY_DATA_HANDLING,
+  );
+  const currentDirtyPolicy = editor.channel.dirtyDataPolicy;
+  const dirtyPolicyOptions = [
+    { label: '遇错停止', value: 'stop' },
+    ...(supportsDirtyDataHandling
+      ? [{ label: '跳过并继续', value: 'skip' }]
+      : currentDirtyPolicy === 'skip'
+        ? [{ label: '跳过并继续（当前不支持）', value: 'skip', disabled: true }]
+        : []),
+  ];
+
   const updateChannel = (patch: Partial<SyncEditorState['channel']>) => {
     onChange({
       ...editor,
@@ -115,16 +136,23 @@ export default function ChannelConfigSection({
         <Field label="脏数据策略">
           <Select
             variant="filled"
-            value={editor.channel.dirtyDataPolicy}
-            options={[
-              { label: '遇错停止', value: 'stop' },
-              { label: '跳过并继续', value: 'skip' },
-            ]}
+            value={currentDirtyPolicy}
+            options={dirtyPolicyOptions}
             className="w-full"
             onChange={(dirtyDataPolicy) =>
-              updateChannel({ dirtyDataPolicy })
+              updateChannel({
+                dirtyDataPolicy,
+                ...(dirtyDataPolicy === 'skip'
+                  ? {}
+                  : { dirtyDataLimit: 0 }),
+              })
             }
           />
+          {!supportsDirtyDataHandling && currentDirtyPolicy === 'skip' ? (
+            <div className="mt-1.5 text-[11px] leading-5 text-[#b54708]">
+              当前 Sink Connector 未声明 DIRTY_DATA_HANDLING，请改为遇错停止。
+            </div>
+          ) : null}
         </Field>
 
         <Field label="脏数据上限">
@@ -132,7 +160,7 @@ export default function ChannelConfigSection({
             min={0}
             max={10000000}
             variant="filled"
-            disabled={editor.channel.dirtyDataPolicy !== 'skip'}
+            disabled={currentDirtyPolicy !== 'skip'}
             className="!w-full"
             value={Number(editor.channel.dirtyDataLimit || 0)}
             onChange={(dirtyDataLimit) =>

--- a/yak-ops-ui/src/pages/integration/batch-link-up/detail/components/ConnectorExtraParameters.tsx
+++ b/yak-ops-ui/src/pages/integration/batch-link-up/detail/components/ConnectorExtraParameters.tsx
@@ -1,0 +1,224 @@
+import { Alert, Input, InputNumber, Select, Spin, Switch } from 'antd';
+import type { ReactNode } from 'react';
+
+import type {
+  LinkUpConnectorSchema,
+  OfflineConnectorRole,
+} from '@/services/batch-link-up';
+
+import {
+  connectorTaskOptionFields,
+  type ConnectorTaskOptionField,
+} from '../form-schema/connectorTaskOptions';
+
+interface ConnectorExtraParametersProps {
+  role: OfflineConnectorRole;
+  schema: LinkUpConnectorSchema | null;
+  loading: boolean;
+  error: string;
+  config: Record<string, any>;
+  onChange: (patch: Record<string, any>) => void;
+}
+
+function FieldLabel({
+  label,
+  required,
+}: {
+  label: string;
+  required: boolean;
+}) {
+  return (
+    <div className="mb-2 text-[12px] font-medium text-[#475467]">
+      {label}
+      {required ? (
+        <span className="ml-1 text-[var(--yak-brand-color)]">*</span>
+      ) : null}
+    </div>
+  );
+}
+
+const labelFor = (key: string) =>
+  key
+    .replace(/[._-]+/g, ' ')
+    .replace(/\b\w/g, (value) => value.toUpperCase());
+
+const optionValues = (value: unknown): Array<string | number> => {
+  if (!Array.isArray(value)) return [];
+  return value.filter(
+    (item): item is string | number =>
+      typeof item === 'string' || typeof item === 'number',
+  );
+};
+
+const currentValue = (
+  field: ConnectorTaskOptionField,
+  values: Record<string, any>,
+) => {
+  const { option } = field;
+  return values[option.key] !== undefined
+    ? values[option.key]
+    : option.defaultValue;
+};
+
+export default function ConnectorExtraParameters({
+  role,
+  schema,
+  loading,
+  error,
+  config,
+  onChange,
+}: ConnectorExtraParametersProps) {
+  if (loading) {
+    return (
+      <div className="flex items-center gap-2 rounded-lg bg-[#f7f8fa] px-3 py-2.5 text-[11px] text-[#667085]">
+        <Spin size="small" />
+        正在读取 Connector 扩展参数
+      </div>
+    );
+  }
+
+  if (error) {
+    return (
+      <Alert
+        type="warning"
+        showIcon
+        message="Connector 扩展参数暂不可用"
+        description={error}
+      />
+    );
+  }
+
+  const fields = connectorTaskOptionFields(schema, role);
+  if (fields.length === 0) return null;
+
+  const values =
+    config.connectorOptions && typeof config.connectorOptions === 'object'
+      ? config.connectorOptions
+      : {};
+
+  const update = (key: string, value: unknown) => {
+    const next = { ...values };
+    const empty =
+      value === undefined ||
+      value === null ||
+      value === '' ||
+      (Array.isArray(value) && value.length === 0);
+
+    if (empty) {
+      delete next[key];
+    } else {
+      next[key] = value;
+    }
+
+    onChange({ connectorOptions: next });
+  };
+
+  const renderField = (field: ConnectorTaskOptionField): ReactNode => {
+    const { option, kind } = field;
+    const value = currentValue(field, values);
+    const allowedValues = optionValues(option.allowedValues);
+
+    if (kind === 'boolean') {
+      return (
+        <Switch
+          checked={Boolean(value)}
+          onChange={(checked) => update(option.key, checked)}
+        />
+      );
+    }
+
+    if (kind === 'number') {
+      return (
+        <InputNumber
+          variant="filled"
+          className="!w-full"
+          value={
+            value === undefined || value === null || value === ''
+              ? undefined
+              : Number(value)
+          }
+          onChange={(next) => update(option.key, next)}
+        />
+      );
+    }
+
+    if (kind === 'enum') {
+      return (
+        <Select
+          allowClear={!option.required}
+          variant="filled"
+          className="w-full"
+          value={value as string | number | undefined}
+          options={allowedValues.map((item) => ({
+            label: String(item),
+            value: item,
+          }))}
+          onChange={(next) => update(option.key, next)}
+        />
+      );
+    }
+
+    if (kind === 'tags') {
+      const selected = Array.isArray(value)
+        ? value.map(String)
+        : value === undefined || value === null || value === ''
+          ? []
+          : [String(value)];
+      const options = allowedValues.map((item) => ({
+        label: String(item),
+        value: String(item),
+      }));
+
+      return (
+        <Select
+          mode="tags"
+          allowClear
+          variant="filled"
+          className="w-full"
+          value={selected}
+          options={options}
+          onChange={(next) => update(option.key, next)}
+        />
+      );
+    }
+
+    return (
+      <Input
+        variant="filled"
+        value={value === undefined || value === null ? '' : String(value)}
+        placeholder={option.description || `请输入 ${option.key}`}
+        onChange={(event) => update(option.key, event.target.value)}
+      />
+    );
+  };
+
+  return (
+    <div className="rounded-lg border border-[#eaecf0] bg-white p-3.5">
+      <div className="mb-3">
+        <div className="text-[12px] font-semibold text-[#344054]">
+          Connector 扩展参数
+        </div>
+        <div className="mt-1 text-[11px] leading-5 text-[#98a2b3]">
+          来自当前 Link-Up Worker 的任务级 Schema；连接和凭据字段由数据源管理。
+        </div>
+      </div>
+
+      <div className="space-y-3.5">
+        {fields.map((field) => (
+          <div key={field.option.key}>
+            <FieldLabel
+              label={labelFor(field.option.key)}
+              required={field.option.required === true}
+            />
+            {renderField(field)}
+            {field.option.description ? (
+              <div className="mt-1.5 text-[11px] leading-5 text-[#98a2b3]">
+                {field.option.description}
+              </div>
+            ) : null}
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/yak-ops-ui/src/pages/integration/batch-link-up/detail/components/MultiTableConfigSection.tsx
+++ b/yak-ops-ui/src/pages/integration/batch-link-up/detail/components/MultiTableConfigSection.tsx
@@ -12,11 +12,17 @@ import {
 } from 'antd';
 import { useMemo, type ReactNode } from 'react';
 
+import {
+  allowsCapability,
+  CONNECTOR_CAPABILITY,
+  type EndpointCapabilityState,
+} from '../capabilities';
 import EditorSection from './EditorSection';
 
 interface MultiTableConfigSectionProps {
   sourceConfig: Record<string, any>;
   sinkConfig: Record<string, any>;
+  sinkCapability: EndpointCapabilityState;
   sourceTables: string[];
   sourceLoading: boolean;
   sourceReady: boolean;
@@ -91,6 +97,7 @@ function FieldLabel({
 export default function MultiTableConfigSection({
   sourceConfig,
   sinkConfig,
+  sinkCapability,
   sourceTables,
   sourceLoading,
   sourceReady,
@@ -103,6 +110,17 @@ export default function MultiTableConfigSection({
 }: MultiTableConfigSectionProps) {
   const tableNamingRule = String(
     sinkConfig.tableNamingRule || 'same_name',
+  ).toLowerCase();
+  const supportsAutoCreate = allowsCapability(
+    sinkCapability,
+    CONNECTOR_CAPABILITY.AUTO_CREATE_TABLE,
+  );
+  const supportsUpsert = allowsCapability(
+    sinkCapability,
+    CONNECTOR_CAPABILITY.UPSERT,
+  );
+  const currentWriteMode = String(
+    sinkConfig.writeMode || 'append',
   ).toLowerCase();
 
   const selectedTables = useMemo(
@@ -126,9 +144,19 @@ export default function MultiTableConfigSection({
     [selectedTables, sourceTables],
   );
 
+  const writeModeOptions = [
+    { label: '追加写入 Append', value: 'append' },
+    { label: '覆盖写入 Overwrite', value: 'overwrite' },
+    ...(supportsUpsert
+      ? [{ label: '主键更新 Upsert', value: 'upsert' }]
+      : currentWriteMode === 'upsert'
+        ? [{ label: '主键更新 Upsert（当前不支持）', value: 'upsert', disabled: true }]
+        : []),
+  ];
+
   return (
     <EditorSection title="多表同步配置">
-      <div className="grid grid-cols-2 items-start gap-5 max-lg:grid-cols-1" style={{height: 500}}>
+      <div className="grid grid-cols-2 items-start gap-5 max-lg:grid-cols-1">
         <EndpointPanel
           icon={<DatabaseOutlined />}
           title="Source 来源配置"
@@ -154,9 +182,7 @@ export default function MultiTableConfigSection({
             <div className="mb-2 flex items-center justify-between gap-3">
               <div className="text-[12px] font-medium text-[#475467]">
                 来源表
-                <span className="ml-1 text-[var(--yak-brand-color)]">
-                  *
-                </span>
+                <span className="ml-1 text-[var(--yak-brand-color)]">*</span>
               </div>
 
               <span className="text-[11px] text-[#98a2b3]">
@@ -254,18 +280,27 @@ export default function MultiTableConfigSection({
             />
           </div>
 
-          <div className="flex items-center justify-between rounded-lg bg-[#f5f5f6] px-3.5 py-3">
-            <div className="text-[12px] font-medium text-[#475467]">
-              自动创建目标表
-            </div>
+          {supportsAutoCreate || sinkConfig.autoCreateTable ? (
+            <div className="rounded-lg bg-[#f5f5f6] px-3.5 py-3">
+              <div className="flex items-center justify-between">
+                <div className="text-[12px] font-medium text-[#475467]">
+                  自动创建目标表
+                </div>
 
-            <Switch
-              checked={Boolean(sinkConfig.autoCreateTable)}
-              onChange={(autoCreateTable) =>
-                onSinkChange({ autoCreateTable })
-              }
-            />
-          </div>
+                <Switch
+                  checked={Boolean(sinkConfig.autoCreateTable)}
+                  onChange={(autoCreateTable) =>
+                    onSinkChange({ autoCreateTable })
+                  }
+                />
+              </div>
+              {!supportsAutoCreate && sinkConfig.autoCreateTable ? (
+                <div className="mt-2 text-[11px] leading-5 text-[#b54708]">
+                  当前 Sink Connector 未声明 AUTO_CREATE_TABLE，请关闭后再保存。
+                </div>
+              ) : null}
+            </div>
+          ) : null}
 
           <div>
             <FieldLabel required>目标表命名</FieldLabel>
@@ -319,20 +354,24 @@ export default function MultiTableConfigSection({
             <FieldLabel required>写入模式</FieldLabel>
             <Select
               variant="filled"
-              value={String(sinkConfig.writeMode || 'append').toLowerCase()}
-              options={[
-                { label: '追加写入 Append', value: 'append' },
-                { label: '覆盖写入 Overwrite', value: 'overwrite' },
-                { label: '主键更新 Upsert', value: 'upsert' },
-              ]}
+              value={currentWriteMode}
+              options={writeModeOptions}
               className="w-full"
               onChange={(writeMode) =>
-                onSinkChange({ writeMode })
+                onSinkChange({
+                  writeMode,
+                  ...(writeMode === 'upsert' ? {} : { primaryKey: '' }),
+                })
               }
             />
+            {!supportsUpsert && currentWriteMode === 'upsert' ? (
+              <div className="mt-1.5 text-[11px] leading-5 text-[#b54708]">
+                当前 Sink Connector 未声明 UPSERT，请选择其他写入模式。
+              </div>
+            ) : null}
           </div>
 
-          {String(sinkConfig.writeMode || '').toLowerCase() === 'upsert' ? (
+          {currentWriteMode === 'upsert' ? (
             <div>
               <FieldLabel required>主键字段</FieldLabel>
               <Input

--- a/yak-ops-ui/src/pages/integration/batch-link-up/detail/components/SingleTableConfigSection.tsx
+++ b/yak-ops-ui/src/pages/integration/batch-link-up/detail/components/SingleTableConfigSection.tsx
@@ -13,6 +13,11 @@ import {
 } from 'antd';
 import { useState, type ChangeEvent, type ReactNode } from 'react';
 
+import {
+  allowsCapability,
+  CONNECTOR_CAPABILITY,
+  type EndpointCapabilityState,
+} from '../capabilities';
 import type { DataSourceColumnOption } from '../hooks/useDataSourceColumns';
 import EditorSection from './EditorSection';
 import SingleTablePreviewModal from './SingleTablePreviewModal';
@@ -21,6 +26,8 @@ interface SingleTableConfigSectionProps {
   sourceDataSourceId?: string | number;
   sourceConfig: Record<string, any>;
   sinkConfig: Record<string, any>;
+  sourceCapability: EndpointCapabilityState;
+  sinkCapability: EndpointCapabilityState;
   sourceTables: string[];
   targetTables: string[];
   sourceLoading: boolean;
@@ -76,6 +83,8 @@ export default function SingleTableConfigSection({
   sourceDataSourceId,
   sourceConfig,
   sinkConfig,
+  sourceCapability,
+  sinkCapability,
   sourceTables,
   targetTables,
   sourceLoading,
@@ -93,11 +102,43 @@ export default function SingleTableConfigSection({
 }: SingleTableConfigSectionProps) {
   const [previewOpen, setPreviewOpen] = useState(false);
   const sourceReadMode = sourceConfig.readMode === 'sql' ? 'sql' : 'table';
+  const supportsCustomSql = allowsCapability(
+    sourceCapability,
+    CONNECTOR_CAPABILITY.CUSTOM_SQL,
+  );
+  const supportsAutoCreate = allowsCapability(
+    sinkCapability,
+    CONNECTOR_CAPABILITY.AUTO_CREATE_TABLE,
+  );
+  const supportsUpsert = allowsCapability(
+    sinkCapability,
+    CONNECTOR_CAPABILITY.UPSERT,
+  );
   const previewDisabled =
     !sourceDataSourceId ||
     (sourceReadMode === 'sql'
       ? !String(sourceConfig.sql || '').trim()
       : !String(sourceConfig.table || '').trim());
+
+  const readModeOptions = [
+    { label: '选择数据表', value: 'table' },
+    ...(supportsCustomSql
+      ? [{ label: '自定义 SQL', value: 'sql' }]
+      : sourceReadMode === 'sql'
+        ? [{ label: '自定义 SQL（当前不支持）', value: 'sql', disabled: true }]
+        : []),
+  ];
+
+  const currentWriteMode = String(sinkConfig.writeMode || 'append').toLowerCase();
+  const writeModeOptions = [
+    { label: '追加写入 Append', value: 'append' },
+    { label: '覆盖写入 Overwrite', value: 'overwrite' },
+    ...(supportsUpsert
+      ? [{ label: '主键更新 Upsert', value: 'upsert' }]
+      : currentWriteMode === 'upsert'
+        ? [{ label: '主键更新 Upsert（当前不支持）', value: 'upsert', disabled: true }]
+        : []),
+  ];
 
   return (
     <EditorSection title="单表同步配置">
@@ -107,11 +148,8 @@ export default function SingleTableConfigSection({
             <FieldLabel>读取方式</FieldLabel>
             <Segmented
               block
-              value={sourceConfig.readMode || 'table'}
-              options={[
-                { label: '选择数据表', value: 'table' },
-                { label: '自定义 SQL', value: 'sql' },
-              ]}
+              value={sourceReadMode}
+              options={readModeOptions}
               onChange={(readMode: string | number) =>
                 onSourceChange({
                   readMode,
@@ -121,7 +159,7 @@ export default function SingleTableConfigSection({
             />
           </div>
 
-          {sourceConfig.readMode === 'sql' ? (
+          {sourceReadMode === 'sql' ? (
             <div>
               <FieldLabel required>查询 SQL</FieldLabel>
               <Input.TextArea
@@ -132,6 +170,11 @@ export default function SingleTableConfigSection({
                 className="font-mono"
                 onChange={(event: ChangeEvent<HTMLTextAreaElement>) => onSourceChange({ sql: event.target.value })}
               />
+              {!supportsCustomSql ? (
+                <div className="mt-1.5 text-[11px] leading-5 text-[#b54708]">
+                  当前 Source Connector 未声明 CUSTOM_SQL，请切换为数据表读取后再保存。
+                </div>
+              ) : null}
             </div>
           ) : (
             <div>
@@ -169,20 +212,29 @@ export default function SingleTableConfigSection({
         </EndpointPanel>
 
         <EndpointPanel icon={<ExportOutlined />} title="Sink 目标配置">
-          <div className="flex items-center justify-between rounded-lg bg-[#f5f5f6] px-3.5 py-3">
-            <div className="text-[12px] font-medium text-[#475467]">自动创建目标表</div>
-            <Switch
-              checked={Boolean(sinkConfig.autoCreateTable)}
-              onChange={(autoCreateTable: boolean) =>
-                onSinkChange({
-                  autoCreateTable,
-                  table: '',
-                  targetTableName: '',
-                  primaryKey: '',
-                })
-              }
-            />
-          </div>
+          {supportsAutoCreate || sinkConfig.autoCreateTable ? (
+            <div className="rounded-lg bg-[#f5f5f6] px-3.5 py-3">
+              <div className="flex items-center justify-between">
+                <div className="text-[12px] font-medium text-[#475467]">自动创建目标表</div>
+                <Switch
+                  checked={Boolean(sinkConfig.autoCreateTable)}
+                  onChange={(autoCreateTable: boolean) =>
+                    onSinkChange({
+                      autoCreateTable,
+                      table: '',
+                      targetTableName: '',
+                      primaryKey: '',
+                    })
+                  }
+                />
+              </div>
+              {!supportsAutoCreate && sinkConfig.autoCreateTable ? (
+                <div className="mt-2 text-[11px] leading-5 text-[#b54708]">
+                  当前 Sink Connector 未声明 AUTO_CREATE_TABLE，请关闭后选择已有目标表。
+                </div>
+              ) : null}
+            </div>
+          ) : null}
 
           {sinkConfig.autoCreateTable ? (
             <div>
@@ -222,12 +274,8 @@ export default function SingleTableConfigSection({
             <FieldLabel required>写入模式</FieldLabel>
             <Select
               variant="filled"
-              value={sinkConfig.writeMode || 'append'}
-              options={[
-                { label: '追加写入 Append', value: 'append' },
-                { label: '覆盖写入 Overwrite', value: 'overwrite' },
-                { label: '主键更新 Upsert', value: 'upsert' },
-              ]}
+              value={currentWriteMode}
+              options={writeModeOptions}
               className="w-full"
               onChange={(writeMode: string) =>
                 onSinkChange({
@@ -236,9 +284,14 @@ export default function SingleTableConfigSection({
                 })
               }
             />
+            {!supportsUpsert && currentWriteMode === 'upsert' ? (
+              <div className="mt-1.5 text-[11px] leading-5 text-[#b54708]">
+                当前 Sink Connector 未声明 UPSERT，请选择其他写入模式。
+              </div>
+            ) : null}
           </div>
 
-          {sinkConfig.writeMode === 'upsert' ? (
+          {currentWriteMode === 'upsert' ? (
             <div>
               <FieldLabel required>主键字段</FieldLabel>
               <Select

--- a/yak-ops-ui/src/pages/integration/batch-link-up/detail/components/SyncTaskEditor.tsx
+++ b/yak-ops-ui/src/pages/integration/batch-link-up/detail/components/SyncTaskEditor.tsx
@@ -1,9 +1,17 @@
+import { Alert } from 'antd';
 import type { DataSourceRecord } from '@/services/data-source';
 
+import {
+  resolveEndpointCapability,
+  validateEditorCapabilities,
+} from '../capabilities';
+import useConnectorSchema from '../hooks/useConnectorSchema';
 import useDataSourceColumns from '../hooks/useDataSourceColumns';
 import useDataSourceTables from '../hooks/useDataSourceTables';
+import useOfflineConnectorRuntime from '../hooks/useOfflineConnectorRuntime';
 import { updateEndpointConfig, type SyncEditorState } from '../model';
 import ChannelConfigSection from './ChannelConfigSection';
+import ConnectorExtraParameters from './ConnectorExtraParameters';
 import FieldMappingSection, { type FieldMappingValue } from './FieldMappingSection';
 import MultiTableConfigSection from './MultiTableConfigSection';
 import NotificationConfigSection from './NotificationConfigSection';
@@ -40,6 +48,33 @@ export default function SyncTaskEditor({
   const targetId = editor.sink.dataSourceId;
   const mappingColumns = normalizeMappings(editor.mapping?.columns);
 
+  const connectorRuntime = useOfflineConnectorRuntime();
+  const sourceCapability = resolveEndpointCapability(
+    connectorRuntime.snapshot,
+    editor.source.connectorId,
+    'SOURCE',
+  );
+  const sinkCapability = resolveEndpointCapability(
+    connectorRuntime.snapshot,
+    editor.sink.connectorId,
+    'SINK',
+  );
+  const capabilityErrors = validateEditorCapabilities(
+    editor,
+    connectorRuntime.snapshot,
+  );
+
+  const sourceSchema = useConnectorSchema(
+    editor.source.connectorId,
+    'SOURCE',
+    sourceCapability.available,
+  );
+  const sinkSchema = useConnectorSchema(
+    editor.sink.connectorId,
+    'SINK',
+    sinkCapability.available,
+  );
+
   const sourceCatalog = useDataSourceTables(sourceId);
   const targetCatalog = useDataSourceTables(targetId);
   const sourceColumnRequest = sourceConfig.readMode === 'sql'
@@ -67,8 +102,82 @@ export default function SyncTaskEditor({
   const updateMapping = (columns: FieldMappingValue[]) =>
     onChange({ ...editor, mapping: { columns } });
 
+  const runtimeNotice = (() => {
+    if (connectorRuntime.loading && !connectorRuntime.snapshot) {
+      return (
+        <Alert
+          type="info"
+          showIcon
+          message="正在读取 Link-Up Connector 能力"
+          description="能力确认完成前保留兼容表单，不会提前隐藏现有配置。"
+        />
+      );
+    }
+
+    if (connectorRuntime.error && !connectorRuntime.snapshot) {
+      return (
+        <Alert
+          type="warning"
+          showIcon
+          message="暂时无法读取 Link-Up Connector 能力"
+          description={`${connectorRuntime.error}。编辑器将保留兼容字段，保存时会再次校验。`}
+        />
+      );
+    }
+
+    if (connectorRuntime.snapshot && !connectorRuntime.snapshot.reachable) {
+      return (
+        <Alert
+          type="warning"
+          showIcon
+          message="Link-Up Worker 当前不可达"
+          description={
+            connectorRuntime.snapshot.errorMessage ||
+            '如果存在上次同步的 Schema，编辑器仅将其作为表单参考，不会把它视为当前可执行状态。'
+          }
+        />
+      );
+    }
+
+    if (capabilityErrors.length > 0) {
+      return (
+        <Alert
+          type="error"
+          showIcon
+          message="当前 Connector 能力与任务配置不匹配"
+          description={capabilityErrors.join('；')}
+        />
+      );
+    }
+
+    return null;
+  })();
+
+  const sourceExtraParameters = (
+    <ConnectorExtraParameters
+      role="SOURCE"
+      schema={sourceSchema.schema}
+      loading={sourceSchema.loading}
+      error={sourceSchema.error}
+      config={sourceConfig}
+      onChange={updateSource}
+    />
+  );
+  const sinkExtraParameters = (
+    <ConnectorExtraParameters
+      role="SINK"
+      schema={sinkSchema.schema}
+      loading={sinkSchema.loading}
+      error={sinkSchema.error}
+      config={sinkConfig}
+      onChange={updateSink}
+    />
+  );
+
   return (
     <div className="space-y-5">
+      {runtimeNotice}
+
       <div id="task-basic" className="scroll-mt-6">
         <TaskBasicSection
           editor={editor}
@@ -83,12 +192,13 @@ export default function SyncTaskEditor({
           <MultiTableConfigSection
             sourceConfig={sourceConfig}
             sinkConfig={sinkConfig}
+            sinkCapability={sinkCapability}
             sourceTables={sourceCatalog.tables}
             sourceLoading={sourceCatalog.loading}
             sourceReady={Boolean(sourceId)}
             targetReady={Boolean(targetId)}
-            sourceExtraParameters={null}
-            sinkExtraParameters={null}
+            sourceExtraParameters={sourceExtraParameters}
+            sinkExtraParameters={sinkExtraParameters}
             onSourceTableSearch={sourceCatalog.search}
             onSourceChange={updateSource}
             onSinkChange={updateSink}
@@ -98,6 +208,8 @@ export default function SyncTaskEditor({
             sourceDataSourceId={sourceId}
             sourceConfig={sourceConfig}
             sinkConfig={sinkConfig}
+            sourceCapability={sourceCapability}
+            sinkCapability={sinkCapability}
             sourceTables={sourceCatalog.tables}
             targetTables={targetCatalog.tables}
             sourceLoading={sourceCatalog.loading}
@@ -106,8 +218,8 @@ export default function SyncTaskEditor({
             primaryKeyLoading={primaryKeyCatalog.loading}
             sourceReady={Boolean(sourceId)}
             targetReady={Boolean(targetId)}
-            sourceExtraParameters={null}
-            sinkExtraParameters={null}
+            sourceExtraParameters={sourceExtraParameters}
+            sinkExtraParameters={sinkExtraParameters}
             onSourceTableSearch={sourceCatalog.search}
             onTargetTableSearch={targetCatalog.search}
             onSourceChange={updateSource}
@@ -120,6 +232,7 @@ export default function SyncTaskEditor({
         <ChannelConfigSection
           editor={editor}
           sinkConfig={sinkConfig}
+          sinkCapability={sinkCapability}
           onChange={onChange}
           onSinkChange={updateSink}
         />

--- a/yak-ops-ui/src/pages/integration/batch-link-up/detail/form-schema/connectorTaskOptions.test.ts
+++ b/yak-ops-ui/src/pages/integration/batch-link-up/detail/form-schema/connectorTaskOptions.test.ts
@@ -1,0 +1,91 @@
+import type { LinkUpConnectorSchema } from '@/services/batch-link-up';
+
+import {
+  connectorTaskOptionFields,
+  validateRequiredConnectorTaskOptions,
+} from './connectorTaskOptions';
+
+const schema = (): LinkUpConnectorSchema => ({
+  connectorId: 'demo',
+  role: 'SOURCE',
+  options: [
+    {
+      key: 'url',
+      valueType: 'STRING',
+      required: true,
+      description: 'Datasource-owned URL',
+    },
+    {
+      key: 'password',
+      valueType: 'STRING',
+      required: true,
+      sensitive: true,
+    },
+    {
+      key: 'table_path',
+      valueType: 'STRING',
+      required: true,
+    },
+    {
+      key: 'partition_column',
+      valueType: 'STRING',
+      required: false,
+      description: 'Optional split column',
+    },
+    {
+      key: 'partition_num',
+      valueType: 'INT',
+      defaultValue: 4,
+      required: true,
+    },
+    {
+      key: 'required_task_flag',
+      valueType: 'STRING',
+      required: true,
+      fallbackKeys: ['legacy_task_flag'],
+    },
+    {
+      key: 'complex_object',
+      valueType: 'MAP',
+      required: false,
+    },
+  ],
+});
+
+describe('connectorTaskOptions', () => {
+  it('excludes datasource-owned, sensitive, product-managed and unsupported complex options', () => {
+    const fields = connectorTaskOptionFields(schema(), 'SOURCE');
+
+    expect(fields.map((item) => item.option.key)).toEqual([
+      'partition_column',
+      'partition_num',
+      'required_task_flag',
+    ]);
+  });
+
+  it('validates only visible task-owned required options', () => {
+    const errors = validateRequiredConnectorTaskOptions(
+      schema(),
+      'SOURCE',
+      { connectorOptions: {} },
+    );
+
+    expect(errors).toEqual([
+      'Source Connector 参数 required_task_flag 不能为空',
+    ]);
+  });
+
+  it('accepts a fallback key and ignores required options with defaults', () => {
+    const errors = validateRequiredConnectorTaskOptions(
+      schema(),
+      'SOURCE',
+      {
+        connectorOptions: {
+          legacy_task_flag: 'enabled',
+        },
+      },
+    );
+
+    expect(errors).toEqual([]);
+  });
+});

--- a/yak-ops-ui/src/pages/integration/batch-link-up/detail/form-schema/connectorTaskOptions.ts
+++ b/yak-ops-ui/src/pages/integration/batch-link-up/detail/form-schema/connectorTaskOptions.ts
@@ -1,0 +1,223 @@
+import type {
+  LinkUpConnectorOptionSchema,
+  LinkUpConnectorSchema,
+  OfflineConnectorRole,
+} from '@/services/batch-link-up';
+
+const normalizeLoose = (value: string) =>
+  String(value || '')
+    .trim()
+    .toLowerCase()
+    .replace(/[._-]/g, '');
+
+const DATASOURCE_OWNED_KEYS = new Set(
+  [
+    'url',
+    'jdbcUrl',
+    'jdbc_url',
+    'driver',
+    'driverClassName',
+    'driver_class_name',
+    'username',
+    'user',
+    'password',
+    'passwd',
+    'pwd',
+    'schema',
+    'schemaName',
+    'database',
+    'catalog',
+    'host',
+    'hosts',
+    'hostname',
+    'port',
+    'node_urls',
+    'nodeUrls',
+    'fenodes',
+    'http_urls',
+    'jdbc_urls',
+    'dialect',
+    'compatible_mode',
+    'properties',
+    'connectionParams',
+    'connection_params',
+    'connection_check_timeout_sec',
+    'connect_timeout_ms',
+    'socket_timeout_ms',
+  ].map(normalizeLoose),
+);
+
+const SOURCE_MANAGED_KEYS = new Set(
+  [
+    'table_path',
+    'table_list',
+    'query',
+    'where_condition',
+    'fetch_size',
+  ].map(normalizeLoose),
+);
+
+const SINK_MANAGED_KEYS = new Set(
+  [
+    'table_path',
+    'schema_save_mode',
+    'data_save_mode',
+    'write_mode',
+    'primary_keys',
+    'custom_sql',
+    'batch_size',
+    'dirty_data_policy',
+    'dirty_data_max_count',
+  ].map(normalizeLoose),
+);
+
+const CONNECTION_SCOPE_MARKERS = [
+  'CONNECTION',
+  'DATASOURCE',
+  'CREDENTIAL',
+  'SECURITY',
+  'SECRET',
+];
+
+const CONNECTION_SEMANTIC_MARKERS = [
+  'PASSWORD',
+  'USERNAME',
+  'HOST',
+  'PORT',
+  'URL',
+  'DATABASE',
+  'SCHEMA',
+  'CREDENTIAL',
+  'SECRET',
+];
+
+const valueKind = (option: LinkUpConnectorOptionSchema) =>
+  `${option.valueType || ''} ${option.javaType || ''}`.toUpperCase();
+
+export type ConnectorTaskOptionKind =
+  | 'boolean'
+  | 'number'
+  | 'enum'
+  | 'tags'
+  | 'text';
+
+export interface ConnectorTaskOptionField {
+  option: LinkUpConnectorOptionSchema;
+  kind: ConnectorTaskOptionKind;
+}
+
+const isConnectionOwned = (option: LinkUpConnectorOptionSchema) => {
+  const key = normalizeLoose(option.key);
+  if (DATASOURCE_OWNED_KEYS.has(key)) return true;
+
+  const scope = String(option.scope || '').toUpperCase();
+  if (CONNECTION_SCOPE_MARKERS.some((marker) => scope.includes(marker))) {
+    return true;
+  }
+
+  const semanticType = String(option.semanticType || '').toUpperCase();
+  return CONNECTION_SEMANTIC_MARKERS.some((marker) =>
+    semanticType.includes(marker),
+  );
+};
+
+const isProductManaged = (
+  option: LinkUpConnectorOptionSchema,
+  role: OfflineConnectorRole,
+) => {
+  const key = normalizeLoose(option.key);
+  return role === 'SOURCE'
+    ? SOURCE_MANAGED_KEYS.has(key)
+    : SINK_MANAGED_KEYS.has(key);
+};
+
+export const connectorTaskOptionKind = (
+  option: LinkUpConnectorOptionSchema,
+): ConnectorTaskOptionKind | null => {
+  const kind = valueKind(option);
+  const allowedValues = Array.isArray(option.allowedValues)
+    ? option.allowedValues
+    : [];
+
+  if (kind.includes('BOOLEAN') || kind.includes('BOOL')) {
+    return 'boolean';
+  }
+  if (
+    kind.includes('LIST') ||
+    kind.includes('ARRAY') ||
+    kind.includes('SET') ||
+    kind.includes('COLLECTION')
+  ) {
+    return 'tags';
+  }
+  if (
+    kind.includes('INT') ||
+    kind.includes('LONG') ||
+    kind.includes('DOUBLE') ||
+    kind.includes('FLOAT') ||
+    kind.includes('DECIMAL') ||
+    kind.includes('NUMBER')
+  ) {
+    return 'number';
+  }
+  if (allowedValues.length > 0) {
+    return 'enum';
+  }
+  if (kind.includes('MAP') || kind.includes('OBJECT')) {
+    return null;
+  }
+  return 'text';
+};
+
+export const connectorTaskOptionFields = (
+  schema: LinkUpConnectorSchema | null | undefined,
+  role: OfflineConnectorRole,
+): ConnectorTaskOptionField[] => {
+  const options = Array.isArray(schema?.options) ? schema.options : [];
+
+  return options
+    .filter((option) => Boolean(option?.key?.trim()))
+    .filter((option) => option.sensitive !== true)
+    .filter((option) => !isConnectionOwned(option))
+    .filter((option) => !isProductManaged(option, role))
+    .map((option) => ({ option, kind: connectorTaskOptionKind(option) }))
+    .filter(
+      (item): item is ConnectorTaskOptionField => item.kind !== null,
+    )
+    .sort((left, right) => left.option.key.localeCompare(right.option.key));
+};
+
+const hasValue = (value: unknown) => {
+  if (value === undefined || value === null) return false;
+  if (typeof value === 'string') return value.trim().length > 0;
+  if (Array.isArray(value)) return value.length > 0;
+  return true;
+};
+
+export const validateRequiredConnectorTaskOptions = (
+  schema: LinkUpConnectorSchema | null | undefined,
+  role: OfflineConnectorRole,
+  config: Record<string, any> | null | undefined,
+): string[] => {
+  const values =
+    config?.connectorOptions && typeof config.connectorOptions === 'object'
+      ? config.connectorOptions
+      : {};
+  const errors: string[] = [];
+
+  for (const { option } of connectorTaskOptionFields(schema, role)) {
+    if (option.required !== true || hasValue(option.defaultValue)) {
+      continue;
+    }
+
+    const candidates = [option.key, ...(option.fallbackKeys || [])];
+    const satisfied = candidates.some((key) => hasValue(values[key]));
+    if (!satisfied) {
+      errors.push(
+        `${role === 'SOURCE' ? 'Source' : 'Sink'} Connector 参数 ${option.key} 不能为空`,
+      );
+    }
+  }
+
+  return errors;
+};

--- a/yak-ops-ui/src/pages/integration/batch-link-up/detail/form-schema/validateEditorConnectorForms.ts
+++ b/yak-ops-ui/src/pages/integration/batch-link-up/detail/form-schema/validateEditorConnectorForms.ts
@@ -1,11 +1,75 @@
+import {
+  getOfflineSyncConnectorRuntime,
+  getOfflineSyncConnectorSchema,
+} from '@/services/batch-link-up';
+
+import { validateEditorCapabilities } from '../capabilities';
 import type { SyncEditorState } from '../model';
+import { validateRequiredConnectorTaskOptions } from './connectorTaskOptions';
 
 /**
- * 一期不再维护远程 Connector Form Schema。
- * Link-Up 在任务提交时完成最终 JobSpec 校验。
+ * Save-time Connector validation uses the same runtime truth as the editor.
+ *
+ * A temporarily unreachable Worker does not prevent saving a draft/config update: Yak Ops may keep
+ * stale capability metadata for display, but it is not authoritative while unreachable. When the
+ * Worker is reachable, role availability and declared capabilities are strict and full schemas are
+ * fetched live before validating task-owned required options.
  */
 export default async function validateEditorConnectorForms(
-  _editor: SyncEditorState,
+  editor: SyncEditorState,
 ): Promise<string[]> {
-  return [];
+  let runtime;
+
+  try {
+    runtime = await getOfflineSyncConnectorRuntime();
+  } catch (error: any) {
+    return [
+      error?.message || '无法读取 Link-Up Connector 能力，请稍后重试',
+    ];
+  }
+
+  const capabilityErrors = validateEditorCapabilities(editor, runtime);
+  if (capabilityErrors.length > 0) {
+    return capabilityErrors;
+  }
+
+  if (!runtime.reachable) {
+    return [];
+  }
+
+  const [sourceSchema, sinkSchema] = await Promise.allSettled([
+    getOfflineSyncConnectorSchema(editor.source.connectorId, 'SOURCE'),
+    getOfflineSyncConnectorSchema(editor.sink.connectorId, 'SINK'),
+  ]);
+  const errors: string[] = [];
+
+  if (sourceSchema.status === 'rejected') {
+    errors.push(
+      sourceSchema.reason?.message || '无法读取 Source Connector Schema',
+    );
+  } else {
+    errors.push(
+      ...validateRequiredConnectorTaskOptions(
+        sourceSchema.value,
+        'SOURCE',
+        editor.source.config,
+      ),
+    );
+  }
+
+  if (sinkSchema.status === 'rejected') {
+    errors.push(
+      sinkSchema.reason?.message || '无法读取 Sink Connector Schema',
+    );
+  } else {
+    errors.push(
+      ...validateRequiredConnectorTaskOptions(
+        sinkSchema.value,
+        'SINK',
+        editor.sink.config,
+      ),
+    );
+  }
+
+  return errors;
 }

--- a/yak-ops-ui/src/pages/integration/batch-link-up/detail/hooks/useConnectorSchema.ts
+++ b/yak-ops-ui/src/pages/integration/batch-link-up/detail/hooks/useConnectorSchema.ts
@@ -1,0 +1,59 @@
+import { useEffect, useState } from 'react';
+
+import {
+  getOfflineSyncConnectorSchema,
+  type LinkUpConnectorSchema,
+  type OfflineConnectorRole,
+} from '@/services/batch-link-up';
+
+export interface ConnectorSchemaState {
+  schema: LinkUpConnectorSchema | null;
+  loading: boolean;
+  error: string;
+}
+
+export default function useConnectorSchema(
+  connectorId: string,
+  role: OfflineConnectorRole,
+  enabled: boolean,
+): ConnectorSchemaState {
+  const [schema, setSchema] = useState<LinkUpConnectorSchema | null>(null);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState('');
+
+  useEffect(() => {
+    let active = true;
+
+    if (!enabled || !connectorId?.trim()) {
+      setSchema(null);
+      setLoading(false);
+      setError('');
+      return () => {
+        active = false;
+      };
+    }
+
+    setLoading(true);
+    setError('');
+
+    void getOfflineSyncConnectorSchema(connectorId, role)
+      .then((value) => {
+        if (!active) return;
+        setSchema(value);
+      })
+      .catch((cause: any) => {
+        if (!active) return;
+        setSchema(null);
+        setError(cause?.message || `无法读取 ${role} Connector Schema`);
+      })
+      .finally(() => {
+        if (active) setLoading(false);
+      });
+
+    return () => {
+      active = false;
+    };
+  }, [connectorId, enabled, role]);
+
+  return { schema, loading, error };
+}

--- a/yak-ops-ui/src/pages/integration/batch-link-up/detail/hooks/useOfflineConnectorRuntime.ts
+++ b/yak-ops-ui/src/pages/integration/batch-link-up/detail/hooks/useOfflineConnectorRuntime.ts
@@ -1,0 +1,59 @@
+import { useCallback, useEffect, useState } from 'react';
+
+import {
+  getOfflineSyncConnectorRuntime,
+  type OfflineConnectorRuntimeSnapshot,
+} from '@/services/batch-link-up';
+
+export interface OfflineConnectorRuntimeState {
+  snapshot: OfflineConnectorRuntimeSnapshot | null;
+  loading: boolean;
+  error: string;
+  reload: () => Promise<void>;
+}
+
+export default function useOfflineConnectorRuntime(): OfflineConnectorRuntimeState {
+  const [snapshot, setSnapshot] =
+    useState<OfflineConnectorRuntimeSnapshot | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState('');
+
+  const reload = useCallback(async () => {
+    try {
+      setLoading(true);
+      const next = await getOfflineSyncConnectorRuntime();
+      setSnapshot(next);
+      setError('');
+    } catch (cause: any) {
+      setError(cause?.message || '无法读取 Link-Up Connector 运行时能力');
+    } finally {
+      setLoading(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    let active = true;
+
+    const load = async () => {
+      try {
+        const next = await getOfflineSyncConnectorRuntime();
+        if (!active) return;
+        setSnapshot(next);
+        setError('');
+      } catch (cause: any) {
+        if (!active) return;
+        setError(cause?.message || '无法读取 Link-Up Connector 运行时能力');
+      } finally {
+        if (active) setLoading(false);
+      }
+    };
+
+    void load();
+
+    return () => {
+      active = false;
+    };
+  }, []);
+
+  return { snapshot, loading, error, reload };
+}

--- a/yak-ops-ui/src/services/batch-link-up/connectors.ts
+++ b/yak-ops-ui/src/services/batch-link-up/connectors.ts
@@ -34,6 +34,21 @@ export interface OfflineConnectorRuntimeSnapshot {
   profiles: OfflineConnectorRuntimeProfile[];
 }
 
+export interface LinkUpConnectorOptionSchema {
+  key: string;
+  valueType?: string;
+  javaType?: string;
+  elementJavaType?: string;
+  defaultValue?: unknown;
+  allowedValues?: unknown[];
+  description?: string;
+  fallbackKeys?: string[];
+  required?: boolean;
+  sensitive?: boolean;
+  semanticType?: string;
+  scope?: string;
+}
+
 export type LinkUpConnectorSchema = Record<string, unknown> & {
   connectorId: string;
   role: OfflineConnectorRole;
@@ -42,7 +57,7 @@ export type LinkUpConnectorSchema = Record<string, unknown> & {
   implementationClass?: string;
   implementationVersion?: string;
   capabilities?: string[];
-  options?: unknown[];
+  options?: LinkUpConnectorOptionSchema[];
   rules?: unknown[];
 };
 


### PR DESCRIPTION
## Summary

PR 4 of the Yak Ops control-plane connector adaptation plan.

PR #1024 made the configured Link-Up Worker's Connector runtime/schema available to Yak Ops, and PR #1025 moved JobSpec translation behind connector adapters. This PR makes the **single-table and multi-table offline editor capability-driven** instead of assuming every connector has JDBC's feature set.

The scope stays on the control-plane editor: no datasource type is added, no profile is switched from JDBC to a native connector, and no new execution adapter is introduced.

## What changed

### 1. Runtime capability model in the editor

Add a pure `detail/capabilities.ts` layer that resolves the selected `connectorId + role` against PR #1024's runtime snapshot.

The editor distinguishes:

- runtime not checked yet
- Worker reachable and role available
- Worker reachable but connector role not loaded
- Worker unreachable / stale metadata
- capability metadata known vs unknown

Unknown capability metadata keeps historical controls visible for compatibility. Once a reachable Worker describes a connector role, its capability list becomes authoritative.

### 2. Capability-driven single-table controls

`SingleTableConfigSection` now follows Link-Up capabilities:

- `CUSTOM_SQL` controls whether Custom SQL can be selected
- `AUTO_CREATE_TABLE` controls the automatic target-table creation switch
- `UPSERT` controls whether Upsert is offered as a write mode

Existing tasks that already contain an unsupported value are not silently rewritten. The current value remains visible with a warning so the user can explicitly switch back to a supported mode.

### 3. Capability-driven multi-table controls

Multi-table tasks require **both SOURCE and SINK** to advertise `MULTI_TABLE`.

If the current connector pair does not satisfy that contract, the editor shows an explicit capability mismatch and save-time validation rejects the configuration. This intentionally does not introduce FAN_OUT yet; that remains a later multi-table orchestration stage.

Sink Auto Create and Upsert controls are gated by the same `AUTO_CREATE_TABLE` / `UPSERT` capabilities used by the single-table editor.

The previous fixed 500px multi-table panel height was removed so connector-specific extra parameters can expand naturally without overlapping following sections.

### 4. Dirty-data behavior follows Sink capabilities

`ChannelConfigSection` now gates the `skip and continue` dirty-data policy behind `DIRTY_DATA_HANDLING`.

A historical task that already uses `skip` remains visible and can be changed back to `stop`; it is not silently mutated.

### 5. Worker capability status is visible in the editor

`SyncTaskEditor` loads the configured Worker runtime snapshot and shows a compact status notice when:

- Connector capabilities are still loading
- capability discovery cannot be read
- the Worker is currently unreachable
- the selected connector roles/configuration conflict with live capabilities

A stale runtime snapshot is never treated as current execution availability.

### 6. Link-Up full schema fills the existing Extra Parameters slots

The previously empty `sourceExtraParameters` / `sinkExtraParameters` slots now consume the live full Connector Schema exposed by PR #1024.

A generic `ConnectorExtraParameters` renderer supports common task-level option types:

- boolean
- numeric
- enum
- list/tags
- text

The renderer deliberately excludes:

- sensitive options
- connection / datasource / credential scopes
- known connection fields such as URL, host, port, username, password and database
- options already owned by Yak Ops product controls such as table/query/fetch/write/upsert/batch/dirty-data keys
- unsupported complex object/map values

This keeps connection credentials inside DataSource management / PR #1025's execution-time adapter boundary rather than reintroducing them into task definitions.

### 7. Save-time capability + schema validation

The existing `validateEditorConnectorForms()` call sites remain unchanged, but the function is no longer a no-op.

On save it now:

1. refreshes the runtime summary
2. rejects unavailable connector roles when the Worker is reachable
3. validates `MULTI_TABLE`, `CUSTOM_SQL`, `AUTO_CREATE_TABLE`, `UPSERT`, and `DIRTY_DATA_HANDLING`
4. fetches current SOURCE/SINK full schemas when the Worker is reachable
5. validates required task-owned dynamic options

If the Worker is temporarily unreachable, Yak Ops still allows saving a draft/config update; stale metadata is not treated as authoritative execution truth.

## Compatibility / non-goals

This PR deliberately does **not**:

- add new `DataSourceDbType` values
- switch Doris / StarRocks / ClickHouse to native execution
- add native connector adapters
- implement multi-table FAN_OUT
- infer capabilities from `dbType`
- remove or rewrite existing unsupported task values automatically
- render passwords or other datasource-owned connection fields
- implement every Link-Up cross-field `rules` interaction in the UI; Worker validation remains the final protocol authority

Current six Yak Ops datasource profiles still resolve to JDBC, so their current editor behavior remains available when the Worker exposes the existing JDBC capabilities.

## Tests

Added focused pure-function coverage for:

- compatibility behavior before runtime metadata is known
- both roles requiring `MULTI_TABLE`
- SQL / Auto Create / Upsert / Dirty-data capability rejection
- unreachable stale snapshots not becoming authoritative
- task-option schema filtering for datasource-owned, sensitive, product-managed and complex values
- required task-option validation including fallback keys and defaults

## Validation status

- based directly on current `main` after PR #1025 merge (`a6676fce95a3258bba06f721903029fe2c07dc20`)
- final branch is ahead by 1 commit and behind by 0
- final head: `003de20e41f8449b9f9a4397ccb3d1e9736e75a7`
- GitHub CI #223 completed successfully
- `yarn install --frozen-lockfile` completed successfully
- frontend production `yarn build` / `max build` completed successfully
- this repository workflow does not run the newly added Jest tests or a standalone `yarn tsc`, so no separate Jest/tsc pass is claimed
- Java / Maven packaging was skipped by the existing workflow because `YAK_FRAMEWORK_READ_TOKEN` is not configured; this PR contains no Java changes

## Next stage

Once this capability-driven UI is merged, the next connector adaptation can add actual datasource types/adapters without teaching the editor another database-specific condition. Doris remains a strong first native candidate because Yak Ops already has a dedicated Doris datasource plugin.