### PR TITLE
feat(sync): enable native OLAP single-table connectors

### DIFF
--- a/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-offline/src/main/java/io/yak/ops/business/sync/offline/engine/connector/OfflineSyncConnectorRegistry.java
+++ b/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-offline/src/main/java/io/yak/ops/business/sync/offline/engine/connector/OfflineSyncConnectorRegistry.java
@@ -12,32 +12,36 @@ import java.util.Set;
 /**
  * 离线同步 Connector Profile 注册表。
  *
- * <p>这里是 Yak Ops 控制面默认 {@code dbType -> connectorId} 关系的单一后端来源。
- * Resolver 只负责兼容输入优先级与标识规范化。</p>
- *
- * <p>当前产品数据源默认仍走 JDBC；是否切换到 native Connector 必须由独立 Profile
- * 变更显式完成，不能因为新增 DataSourceDbType 而改变执行语义。</p>
+ * <p>Profile 描述新建任务的默认执行身份；{@link #defaultConnectorId(String)} 则只服务于
+ * 没有固化 connectorId 的历史定义兼容解析。两者刻意分开，避免 Profile 切换到 native
+ * 后静默改变旧任务的执行语义。</p>
  */
 public final class OfflineSyncConnectorRegistry {
 
   private static final String JDBC = "jdbc";
 
   private static final List<OfflineSyncConnectorProfile> PROFILES = List.of(
-      profile("mysql-jdbc", DataSourceDbType.MYSQL, "JDBC-MYSQL"),
-      profile("oracle-jdbc", DataSourceDbType.ORACLE, "JDBC-ORACLE"),
-      profile("postgresql-jdbc", DataSourceDbType.POSTGRE_SQL, "JDBC-POSTGRESQL"),
-      profile("db2-jdbc", DataSourceDbType.DB2, "JDBC-DB2"),
-      profile("opengauss-jdbc", DataSourceDbType.OPEN_GAUSS, "JDBC-OPENGAUSS"),
-      profile("sqlserver-jdbc", DataSourceDbType.SQL_SERVER, "JDBC-SQLSERVER"),
-      profile("oceanbase-jdbc", DataSourceDbType.OCEANBASE, "JDBC-OCEANBASE"),
-      profile("doris-jdbc", DataSourceDbType.DORIS, "DORIS"),
-      profile("kingbase-jdbc", DataSourceDbType.KINGBASE, "JDBC-KINGBASE"),
-      profile("dameng-jdbc", DataSourceDbType.DAMENG, "JDBC-DAMENG"));
+      jdbcProfile("mysql-jdbc", DataSourceDbType.MYSQL, "JDBC-MYSQL"),
+      jdbcProfile("oracle-jdbc", DataSourceDbType.ORACLE, "JDBC-ORACLE"),
+      jdbcProfile("postgresql-jdbc", DataSourceDbType.POSTGRE_SQL, "JDBC-POSTGRESQL"),
+      jdbcProfile("db2-jdbc", DataSourceDbType.DB2, "JDBC-DB2"),
+      jdbcProfile("opengauss-jdbc", DataSourceDbType.OPEN_GAUSS, "JDBC-OPENGAUSS"),
+      jdbcProfile("sqlserver-jdbc", DataSourceDbType.SQL_SERVER, "JDBC-SQLSERVER"),
+      jdbcProfile("oceanbase-jdbc", DataSourceDbType.OCEANBASE, "JDBC-OCEANBASE"),
+      nativeProfile("doris-native", DataSourceDbType.DORIS, "doris", "DORIS"),
+      nativeProfile("starrocks-native", DataSourceDbType.STARROCKS, "starrocks", "STARROCKS"),
+      nativeProfile("clickhouse-native", DataSourceDbType.CLICKHOUSE, "clickhouse", "CLICKHOUSE"),
+      jdbcProfile("kingbase-jdbc", DataSourceDbType.KINGBASE, "JDBC-KINGBASE"),
+      jdbcProfile("dameng-jdbc", DataSourceDbType.DAMENG, "JDBC-DAMENG"));
 
-  /** Historical datasource labels that remain JDBC even without a product profile. */
+  /**
+   * Historical labels accepted before connectorId became durable execution identity.
+   * Native-capable OLAP labels intentionally stay JDBC here so old definitions are not upgraded.
+   */
   private static final Set<String> LEGACY_JDBC_LABELS = Set.of(
       "JDBC",
       "MARIADB",
+      "DORIS",
       "STARROCKS",
       "CLICKHOUSE",
       "HIVE",
@@ -64,11 +68,17 @@ public final class OfflineSyncConnectorRegistry {
     return dbType == null ? Optional.empty() : Optional.ofNullable(DEFAULTS.get(dbType));
   }
 
-  /** Resolves a product/legacy datasource label to its historical default Connector ID. */
+  /**
+   * Compatibility resolver for definitions that predate durable connectorId.
+   * New definitions must use {@link #defaultProfile(String)} and persist its connector IDs.
+   */
   public static Optional<String> defaultConnectorId(String value) {
     String normalized = normalize(value);
     if (normalized == null) {
       return Optional.empty();
+    }
+    if (LEGACY_JDBC_LABELS.contains(normalized)) {
+      return Optional.of(JDBC);
     }
 
     Optional<OfflineSyncConnectorProfile> profile = defaultProfile(normalized);
@@ -80,25 +90,39 @@ public final class OfflineSyncConnectorRegistry {
       }
       return Optional.of(selected.sourceConnectorId());
     }
-
-    return LEGACY_JDBC_LABELS.contains(normalized)
-        ? Optional.of(JDBC)
-        : Optional.empty();
+    return Optional.empty();
   }
 
   public static boolean isLegacyDatasourceLabel(String value) {
     return defaultConnectorId(value).isPresent();
   }
 
+  private static OfflineSyncConnectorProfile jdbcProfile(
+      String profileId,
+      DataSourceDbType dbType,
+      String pluginName) {
+    return profile(profileId, dbType, JDBC, JDBC, pluginName);
+  }
+
+  private static OfflineSyncConnectorProfile nativeProfile(
+      String profileId,
+      DataSourceDbType dbType,
+      String connectorId,
+      String pluginName) {
+    return profile(profileId, dbType, connectorId, connectorId, pluginName);
+  }
+
   private static OfflineSyncConnectorProfile profile(
       String profileId,
       DataSourceDbType dbType,
+      String sourceConnectorId,
+      String sinkConnectorId,
       String pluginName) {
     return new OfflineSyncConnectorProfile(
         profileId,
         dbType,
-        JDBC,
-        JDBC,
+        sourceConnectorId,
+        sinkConnectorId,
         pluginName,
         true);
   }

--- a/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-offline/src/main/java/io/yak/ops/business/sync/offline/engine/connector/adapter/ClickHouseOfflineSyncConnectorAdapter.java
+++ b/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-offline/src/main/java/io/yak/ops/business/sync/offline/engine/connector/adapter/ClickHouseOfflineSyncConnectorAdapter.java
@@ -1,0 +1,112 @@
+package io.yak.ops.business.sync.offline.engine.connector.adapter;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import io.yak.ops.business.sync.offline.config.ConditionalOnOfflineSyncEnabled;
+import io.yak.ops.business.sync.offline.engine.connector.adapter.NativeSingleTableSupport.TableRef;
+import java.util.List;
+import java.util.Locale;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.stereotype.Component;
+import org.springframework.util.StringUtils;
+
+/** Translates GUIDE_SINGLE tasks to the Link-Up ClickHouse native Source / Sink. */
+@ConditionalOnOfflineSyncEnabled
+@Component
+public class ClickHouseOfflineSyncConnectorAdapter implements OfflineSyncConnectorAdapter {
+
+  private final ObjectMapper objectMapper;
+
+  public ClickHouseOfflineSyncConnectorAdapter(
+      @Qualifier("offlineSyncJsonMapper") ObjectMapper objectMapper) {
+    this.objectMapper = objectMapper;
+  }
+
+  @Override
+  public boolean supports(String connectorId, Role role) {
+    return "clickhouse".equalsIgnoreCase(connectorId);
+  }
+
+  @Override
+  public boolean requiresDataSource(String connectorId, Role role) {
+    return true;
+  }
+
+  @Override
+  public BuildResult build(BuildContext context) {
+    NativeSingleTableSupport.requireSingle(context);
+    ObjectNode options = context.options();
+    removeDatasourceOwned(options);
+
+    if (context.role() == Role.SOURCE) {
+      String sourceTable = NativeSingleTableSupport.sourceTable(context.config());
+      options.put("table_path", sourceTable);
+      String filter = NativeSingleTableSupport.stripWhere(
+          NativeSingleTableSupport.text(context.config(), "whereCondition", null));
+      if (StringUtils.hasText(filter)) options.put("filter_query", filter);
+      options.put("batch_size", context.fetchSize());
+      return new BuildResult(options, sourceTable, List.of(sourceTable));
+    }
+
+    String sinkTable = NativeSingleTableSupport.sinkTable(context.config());
+    TableRef table = NativeSingleTableSupport.tableRef(sinkTable);
+    if (StringUtils.hasText(table.database())) options.put("database", table.database());
+    options.put("table", table.table());
+    options.put("sink.batch_size", context.batchSize());
+
+    String writeMode =
+        NativeSingleTableSupport.text(context.config(), "writeMode", "append").toLowerCase(Locale.ROOT);
+    if (!"append".equals(writeMode)) {
+      throw new IllegalArgumentException("ClickHouse Native Sink 当前仅支持追加写入 Append");
+    }
+    return new BuildResult(options, sinkTable, List.of());
+  }
+
+  @Override
+  public void resolveForExecution(ExecutionContext context) {
+    JsonNode dataSource = NativeSingleTableSupport.dataSource(objectMapper, context.dataSource());
+    ObjectNode options = context.options();
+    removeDatasourceOwned(options);
+
+    String host = NativeSingleTableSupport.clickHouseHost(dataSource);
+    if (!StringUtils.hasText(host)) {
+      throw new IllegalArgumentException("ClickHouse Native Connector 无法从数据源解析 HTTP host");
+    }
+    options.put("host", host);
+    options.put("username", NativeSingleTableSupport.username(dataSource));
+    options.put("password", NativeSingleTableSupport.password(dataSource));
+
+    String serverTimeZone =
+        NativeSingleTableSupport.firstText(dataSource, "serverTimeZone", "server_time_zone");
+    if (StringUtils.hasText(serverTimeZone)) options.put("server_time_zone", serverTimeZone);
+    ObjectNode properties = NativeSingleTableSupport.object(objectMapper, dataSource, "properties");
+    if (!properties.isEmpty()) options.set("clickhouse.config", properties);
+
+    String database = NativeSingleTableSupport.database(dataSource);
+    if (context.role() == Role.SOURCE) {
+      String tablePath = options.path("table_path").asText();
+      if (!tablePath.contains(".")) {
+        options.put(
+            "table_path",
+            NativeSingleTableSupport.requireText(database, "ClickHouse 数据源缺少 database")
+                + "."
+                + tablePath);
+      }
+    } else if (!StringUtils.hasText(options.path("database").asText(null))) {
+      options.put(
+          "database",
+          NativeSingleTableSupport.requireText(database, "ClickHouse 数据源缺少 database"));
+    }
+  }
+
+  private void removeDatasourceOwned(ObjectNode options) {
+    options.remove(
+        List.of(
+            "host",
+            "username",
+            "password",
+            "server_time_zone",
+            "clickhouse.config"));
+  }
+}

--- a/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-offline/src/main/java/io/yak/ops/business/sync/offline/engine/connector/adapter/DorisOfflineSyncConnectorAdapter.java
+++ b/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-offline/src/main/java/io/yak/ops/business/sync/offline/engine/connector/adapter/DorisOfflineSyncConnectorAdapter.java
@@ -1,0 +1,135 @@
+package io.yak.ops.business.sync.offline.engine.connector.adapter;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import io.yak.ops.business.datasource.catalog.DataSourceCatalogReader;
+import io.yak.ops.business.sync.offline.config.ConditionalOnOfflineSyncEnabled;
+import io.yak.ops.business.sync.offline.engine.connector.adapter.NativeSingleTableSupport.TableRef;
+import io.yak.ops.common.bean.po.datasource.DataSourcePO;
+import java.util.List;
+import org.springframework.beans.factory.ObjectProvider;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.stereotype.Component;
+import org.springframework.util.StringUtils;
+
+/** Translates GUIDE_SINGLE tasks to the Link-Up Doris native Source / Stream Load Sink. */
+@ConditionalOnOfflineSyncEnabled
+@Component
+public class DorisOfflineSyncConnectorAdapter implements OfflineSyncConnectorAdapter {
+
+  private static final String INTERNAL_AUTO_CREATE = "_yak_ops_auto_create_table";
+  private final ObjectMapper objectMapper;
+  private final ObjectProvider<DataSourceCatalogReader> catalogReaderProvider;
+
+  public DorisOfflineSyncConnectorAdapter(
+      @Qualifier("offlineSyncJsonMapper") ObjectMapper objectMapper,
+      ObjectProvider<DataSourceCatalogReader> catalogReaderProvider) {
+    this.objectMapper = objectMapper;
+    this.catalogReaderProvider = catalogReaderProvider;
+  }
+
+  @Override
+  public boolean supports(String connectorId, Role role) {
+    return "doris".equalsIgnoreCase(connectorId);
+  }
+
+  @Override
+  public boolean requiresDataSource(String connectorId, Role role) {
+    return true;
+  }
+
+  @Override
+  public BuildResult build(BuildContext context) {
+    NativeSingleTableSupport.requireSingle(context);
+    ObjectNode options = context.options();
+    removeDatasourceOwned(options);
+
+    if (context.role() == Role.SOURCE) {
+      String sourceTable = NativeSingleTableSupport.sourceTable(context.config());
+      TableRef table = NativeSingleTableSupport.tableRef(sourceTable);
+      if (StringUtils.hasText(table.database())) options.put("database", table.database());
+      options.put("table", table.table());
+      String filter = NativeSingleTableSupport.stripWhere(
+          NativeSingleTableSupport.text(context.config(), "whereCondition", null));
+      if (StringUtils.hasText(filter)) options.put("doris.filter.query", filter);
+      options.put("doris.batch.size", context.fetchSize());
+      return new BuildResult(options, sourceTable, List.of(sourceTable));
+    }
+
+    String sinkTable = NativeSingleTableSupport.sinkTable(context.config());
+    TableRef table = NativeSingleTableSupport.tableRef(sinkTable);
+    if (StringUtils.hasText(table.database())) options.put("database", table.database());
+    options.put("table", table.table());
+    options.put("doris.batch.size", context.batchSize());
+    options.put(
+        INTERNAL_AUTO_CREATE,
+        context.config().path("autoCreateTable").asBoolean(false));
+
+    String writeMode =
+        NativeSingleTableSupport.text(context.config(), "writeMode", "append").toLowerCase();
+    if ("overwrite".equals(writeMode)) {
+      throw new IllegalArgumentException("Doris Native Sink 当前不支持覆盖写入，请使用 Append 或 Upsert");
+    }
+    options.put("sink.key-type", "upsert".equals(writeMode) ? "UNIQUE" : "DUPLICATE");
+    return new BuildResult(options, sinkTable, List.of());
+  }
+
+  @Override
+  public void resolveForExecution(ExecutionContext context) {
+    JsonNode dataSource = NativeSingleTableSupport.dataSource(objectMapper, context.dataSource());
+    ObjectNode options = context.options();
+    removeDatasourceOwned(options);
+
+    String fenodes = NativeSingleTableSupport.firstText(dataSource, "fenodes");
+    if (!StringUtils.hasText(fenodes)) {
+      String host = NativeSingleTableSupport.firstText(dataSource, "host", "hostname");
+      if (StringUtils.hasText(host)) {
+        fenodes = host + ":8030";
+      }
+    }
+    if (!StringUtils.hasText(fenodes)) {
+      throw new IllegalArgumentException(
+          "Doris Native Connector 无法解析 FE HTTP 节点，请在数据源配置 fenodes");
+    }
+    options.put("fenodes", fenodes);
+    options.put("query-port", NativeSingleTableSupport.firstInt(dataSource, 9030, "port"));
+    options.put("username", NativeSingleTableSupport.username(dataSource));
+    options.put("password", NativeSingleTableSupport.password(dataSource));
+    if (!StringUtils.hasText(options.path("database").asText(null))) {
+      options.put(
+          "database",
+          NativeSingleTableSupport.requireText(
+              NativeSingleTableSupport.database(dataSource), "Doris 数据源缺少 database"));
+    }
+
+    if (context.role() == Role.SINK) {
+      boolean autoCreate = options.path(INTERNAL_AUTO_CREATE).asBoolean(false);
+      options.remove(INTERNAL_AUTO_CREATE);
+      if (!autoCreate) {
+        verifyExistingTarget(context.dataSource(), options);
+      }
+    } else {
+      options.remove(INTERNAL_AUTO_CREATE);
+    }
+  }
+
+  private void verifyExistingTarget(DataSourcePO dataSource, ObjectNode options) {
+    DataSourceCatalogReader catalogReader = catalogReaderProvider.getIfAvailable();
+    if (catalogReader == null) {
+      throw new IllegalStateException("Doris Native Sink 无法校验目标表是否存在：DataSource Catalog 未启用");
+    }
+    String database = options.path("database").asText();
+    String table = options.path("table").asText();
+    boolean exists = catalogReader.listTables(dataSource.getId(), database, null, table).stream()
+        .anyMatch(value -> table.equalsIgnoreCase(value.name()));
+    if (!exists) {
+      throw new IllegalArgumentException(
+          "目标表 " + database + "." + table + " 不存在；请开启自动创建目标表或先创建该表");
+    }
+  }
+
+  private void removeDatasourceOwned(ObjectNode options) {
+    options.remove(List.of("fenodes", "benodes", "query-port", "username", "password"));
+  }
+}

--- a/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-offline/src/main/java/io/yak/ops/business/sync/offline/engine/connector/adapter/NativeSingleTableSupport.java
+++ b/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-offline/src/main/java/io/yak/ops/business/sync/offline/engine/connector/adapter/NativeSingleTableSupport.java
@@ -1,0 +1,247 @@
+package io.yak.ops.business.sync.offline.engine.connector.adapter;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ArrayNode;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import io.yak.ops.business.sync.offline.engine.connector.adapter.OfflineSyncConnectorAdapter.BuildContext;
+import io.yak.ops.common.bean.po.datasource.DataSourcePO;
+import java.util.ArrayList;
+import java.util.Iterator;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+import java.util.Set;
+import org.springframework.util.StringUtils;
+
+/** Small shared helpers for the native single-table adapters. */
+final class NativeSingleTableSupport {
+
+  private NativeSingleTableSupport() {}
+
+  static void requireSingle(BuildContext context) {
+    if (!"GUIDE_SINGLE".equals(context.mode())) {
+      throw new IllegalArgumentException(
+          context.connectorId() + " Native Connector 当前阶段仅支持单表离线同步");
+    }
+  }
+
+  static String sourceTable(JsonNode config) {
+    if ("sql".equalsIgnoreCase(text(config, "readMode", "table"))) {
+      throw new IllegalArgumentException("当前 Native Source 未声明 CUSTOM_SQL，请使用数据表读取");
+    }
+    return requireText(text(config, "table", null), "请选择来源表");
+  }
+
+  static String sinkTable(JsonNode config) {
+    String value = text(config, "targetTableName", text(config, "table", null));
+    return requireText(value, "请选择或填写目标表");
+  }
+
+  static TableRef tableRef(String value) {
+    String normalized = requireText(value, "表名不能为空");
+    String[] parts = normalized.split("\\.");
+    if (parts.length == 1) {
+      return new TableRef(null, requireText(parts[0], "表名不能为空"), normalized);
+    }
+    if (parts.length == 2) {
+      return new TableRef(
+          requireText(parts[0], "数据库名不能为空"),
+          requireText(parts[1], "表名不能为空"),
+          normalized);
+    }
+    throw new IllegalArgumentException("Native Connector 表路径仅支持 table 或 database.table：" + value);
+  }
+
+  static JsonNode dataSource(ObjectMapper objectMapper, DataSourcePO dataSource) {
+    if (dataSource == null) {
+      throw new IllegalArgumentException("Native Connector 必须选择数据源");
+    }
+    String value = dataSource.getConnectionParams();
+    if (!StringUtils.hasText(value)) {
+      return objectMapper.createObjectNode();
+    }
+    try {
+      JsonNode root = objectMapper.readTree(value);
+      return root != null && root.isObject() ? root : objectMapper.createObjectNode();
+    } catch (JsonProcessingException exception) {
+      throw new IllegalArgumentException("数据源连接参数不是有效 JSON", exception);
+    }
+  }
+
+  static String text(JsonNode node, String field, String fallback) {
+    JsonNode value = node == null ? null : node.get(field);
+    if (value == null || value.isNull() || !value.isValueNode()) {
+      return fallback;
+    }
+    return value.asText(fallback);
+  }
+
+  static String firstText(JsonNode node, String... keys) {
+    String value = firstTextAllowEmpty(node, keys);
+    return StringUtils.hasText(value) ? value.trim() : null;
+  }
+
+  static String firstTextAllowEmpty(JsonNode node, String... keys) {
+    Set<String> normalizedKeys = new LinkedHashSet<>();
+    for (String key : keys) {
+      normalizedKeys.add(normalizeKey(key));
+    }
+    return findText(node, normalizedKeys);
+  }
+
+  private static String findText(JsonNode node, Set<String> normalizedKeys) {
+    if (node == null || node.isNull() || node.isMissingNode()) {
+      return null;
+    }
+    if (node.isObject()) {
+      Iterator<Map.Entry<String, JsonNode>> fields = node.fields();
+      while (fields.hasNext()) {
+        Map.Entry<String, JsonNode> entry = fields.next();
+        JsonNode value = entry.getValue();
+        if (normalizedKeys.contains(normalizeKey(entry.getKey())) && value.isValueNode()) {
+          return value.isNull() ? null : value.asText();
+        }
+      }
+      fields = node.fields();
+      while (fields.hasNext()) {
+        String value = findText(fields.next().getValue(), normalizedKeys);
+        if (value != null) return value;
+      }
+    } else if (node.isArray()) {
+      for (JsonNode item : node) {
+        String value = findText(item, normalizedKeys);
+        if (value != null) return value;
+      }
+    }
+    return null;
+  }
+
+  static int firstInt(JsonNode node, int fallback, String... keys) {
+    String value = firstText(node, keys);
+    if (!StringUtils.hasText(value)) return fallback;
+    try {
+      return Integer.parseInt(value);
+    } catch (NumberFormatException ignored) {
+      return fallback;
+    }
+  }
+
+  static ArrayNode nodes(ObjectMapper objectMapper, JsonNode dataSource, String... keys) {
+    for (String key : keys) {
+      JsonNode direct = directValue(dataSource, key);
+      if (direct != null && direct.isArray()) {
+        ArrayNode result = objectMapper.createArrayNode();
+        for (JsonNode item : direct) {
+          if (item != null && item.isValueNode() && StringUtils.hasText(item.asText())) {
+            result.add(trimNode(item.asText()));
+          }
+        }
+        if (!result.isEmpty()) return result;
+      }
+    }
+
+    String value = firstText(dataSource, keys);
+    ArrayNode result = objectMapper.createArrayNode();
+    if (!StringUtils.hasText(value)) return result;
+    for (String part : value.split(",")) {
+      if (StringUtils.hasText(part)) result.add(trimNode(part));
+    }
+    return result;
+  }
+
+  static ObjectNode object(ObjectMapper objectMapper, JsonNode node, String... keys) {
+    for (String key : keys) {
+      JsonNode direct = directValue(node, key);
+      if (direct != null && direct.isObject()) {
+        return (ObjectNode) direct.deepCopy();
+      }
+    }
+    return objectMapper.createObjectNode();
+  }
+
+  static String database(JsonNode dataSource) {
+    return firstText(dataSource, "database", "databaseName");
+  }
+
+  static String username(JsonNode dataSource) {
+    String value = firstTextAllowEmpty(dataSource, "username", "user");
+    return value == null ? "" : value;
+  }
+
+  static String password(JsonNode dataSource) {
+    String value = firstTextAllowEmpty(dataSource, "password", "passwd");
+    return value == null ? "" : value;
+  }
+
+  static String stripWhere(String value) {
+    if (!StringUtils.hasText(value)) return null;
+    String normalized = value.trim();
+    if (normalized.toLowerCase(Locale.ROOT).startsWith("where ")) {
+      normalized = normalized.substring(6).trim();
+    }
+    return StringUtils.hasText(normalized) ? normalized : null;
+  }
+
+  static String requireText(String value, String message) {
+    if (!StringUtils.hasText(value)) throw new IllegalArgumentException(message);
+    return value.trim();
+  }
+
+  static String clickHouseHost(JsonNode dataSource) {
+    String host = firstText(dataSource, "host", "hostname");
+    int port = firstInt(dataSource, 8123, "port");
+    if (StringUtils.hasText(host)) {
+      String normalized = host.trim();
+      return normalized.contains(":") ? normalized : normalized + ":" + port;
+    }
+
+    String jdbcUrl = firstText(dataSource, "jdbcUrl", "url");
+    if (StringUtils.hasText(jdbcUrl)) {
+      String lower = jdbcUrl.toLowerCase(Locale.ROOT);
+      int scheme = lower.indexOf("jdbc:clickhouse://");
+      if (scheme >= 0) {
+        int start = scheme + "jdbc:clickhouse://".length();
+        int end = jdbcUrl.length();
+        int slash = jdbcUrl.indexOf('/', start);
+        if (slash >= 0) end = Math.min(end, slash);
+        int question = jdbcUrl.indexOf('?', start);
+        if (question >= 0) end = Math.min(end, question);
+        String authority = jdbcUrl.substring(start, end).trim();
+        if (StringUtils.hasText(authority)) return authority;
+      }
+    }
+    return null;
+  }
+
+  private static JsonNode directValue(JsonNode node, String key) {
+    if (node == null || !node.isObject()) return null;
+    JsonNode value = node.get(key);
+    if (value != null) return value;
+    String normalized = normalizeKey(key);
+    Iterator<Map.Entry<String, JsonNode>> fields = node.fields();
+    while (fields.hasNext()) {
+      Map.Entry<String, JsonNode> entry = fields.next();
+      if (normalizeKey(entry.getKey()).equals(normalized)) return entry.getValue();
+    }
+    return null;
+  }
+
+  private static String trimNode(String value) {
+    String normalized = value.trim();
+    while (normalized.endsWith("/")) {
+      normalized = normalized.substring(0, normalized.length() - 1);
+    }
+    return normalized;
+  }
+
+  private static String normalizeKey(String value) {
+    return value == null
+        ? ""
+        : value.replace("_", "").replace("-", "").replace(".", "").toLowerCase(Locale.ROOT);
+  }
+
+  record TableRef(String database, String table, String path) {}
+}

--- a/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-offline/src/main/java/io/yak/ops/business/sync/offline/engine/connector/adapter/StarRocksOfflineSyncConnectorAdapter.java
+++ b/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-offline/src/main/java/io/yak/ops/business/sync/offline/engine/connector/adapter/StarRocksOfflineSyncConnectorAdapter.java
@@ -1,0 +1,146 @@
+package io.yak.ops.business.sync.offline.engine.connector.adapter;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ArrayNode;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import io.yak.ops.business.datasource.catalog.DataSourceCatalogReader;
+import io.yak.ops.business.datasource.domain.catalog.CatalogColumn;
+import io.yak.ops.business.sync.offline.config.ConditionalOnOfflineSyncEnabled;
+import io.yak.ops.business.sync.offline.engine.connector.adapter.NativeSingleTableSupport.TableRef;
+import java.util.List;
+import java.util.Locale;
+import org.springframework.beans.factory.ObjectProvider;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.stereotype.Component;
+import org.springframework.util.StringUtils;
+
+/** Translates GUIDE_SINGLE tasks to Link-Up StarRocks Native Source / bounded Stream Load Sink. */
+@ConditionalOnOfflineSyncEnabled
+@Component
+public class StarRocksOfflineSyncConnectorAdapter implements OfflineSyncConnectorAdapter {
+
+  private final ObjectMapper objectMapper;
+  private final ObjectProvider<DataSourceCatalogReader> catalogReaderProvider;
+
+  public StarRocksOfflineSyncConnectorAdapter(
+      @Qualifier("offlineSyncJsonMapper") ObjectMapper objectMapper,
+      ObjectProvider<DataSourceCatalogReader> catalogReaderProvider) {
+    this.objectMapper = objectMapper;
+    this.catalogReaderProvider = catalogReaderProvider;
+  }
+
+  @Override
+  public boolean supports(String connectorId, Role role) {
+    return "starrocks".equalsIgnoreCase(connectorId);
+  }
+
+  @Override
+  public boolean requiresDataSource(String connectorId, Role role) {
+    return true;
+  }
+
+  @Override
+  public BuildResult build(BuildContext context) {
+    NativeSingleTableSupport.requireSingle(context);
+    ObjectNode options = context.options();
+    removeDatasourceOwned(options);
+
+    if (context.role() == Role.SOURCE) {
+      String sourceTable = NativeSingleTableSupport.sourceTable(context.config());
+      TableRef table = NativeSingleTableSupport.tableRef(sourceTable);
+      if (StringUtils.hasText(table.database())) options.put("database", table.database());
+      options.put("table", table.table());
+      String filter = NativeSingleTableSupport.stripWhere(
+          NativeSingleTableSupport.text(context.config(), "whereCondition", null));
+      if (StringUtils.hasText(filter)) options.put("scan_filter", filter);
+      options.put("scan_batch_rows", context.fetchSize());
+      return new BuildResult(options, sourceTable, List.of(sourceTable));
+    }
+
+    String sinkTable = NativeSingleTableSupport.sinkTable(context.config());
+    TableRef table = NativeSingleTableSupport.tableRef(sinkTable);
+    if (StringUtils.hasText(table.database())) options.put("database", table.database());
+    options.put("table", table.table());
+    options.put("batch_max_rows", context.batchSize());
+
+    String writeMode =
+        NativeSingleTableSupport.text(context.config(), "writeMode", "append").toLowerCase(Locale.ROOT);
+    if (!"append".equals(writeMode)) {
+      throw new IllegalArgumentException("StarRocks Native Sink 当前仅支持追加写入 Append");
+    }
+    return new BuildResult(options, sinkTable, List.of());
+  }
+
+  @Override
+  public void resolveForExecution(ExecutionContext context) {
+    JsonNode dataSource = NativeSingleTableSupport.dataSource(objectMapper, context.dataSource());
+    ObjectNode options = context.options();
+    removeDatasourceOwned(options);
+
+    ArrayNode nodes =
+        NativeSingleTableSupport.nodes(objectMapper, dataSource, "nodeUrls", "node_urls", "fenodes");
+    if (nodes.isEmpty()) {
+      String host = NativeSingleTableSupport.firstText(dataSource, "host", "hostname");
+      if (StringUtils.hasText(host)) {
+        nodes.add(host + ":8030");
+      }
+    }
+    if (nodes.isEmpty()) {
+      throw new IllegalArgumentException(
+          "StarRocks Native Connector 无法解析 FE HTTP 节点，请在数据源配置 nodeUrls");
+    }
+    options.set("node_urls", nodes);
+    options.put("username", NativeSingleTableSupport.username(dataSource));
+    options.put("password", NativeSingleTableSupport.password(dataSource));
+    if (!StringUtils.hasText(options.path("database").asText(null))) {
+      options.put(
+          "database",
+          NativeSingleTableSupport.requireText(
+              NativeSingleTableSupport.database(dataSource), "StarRocks 数据源缺少 database"));
+    }
+
+    if (context.role() == Role.SOURCE) {
+      options.set("schema.fields", loadSchemaFields(context, options));
+    }
+  }
+
+  private ObjectNode loadSchemaFields(ExecutionContext context, ObjectNode options) {
+    DataSourceCatalogReader catalogReader = catalogReaderProvider.getIfAvailable();
+    if (catalogReader == null) {
+      throw new IllegalStateException("StarRocks Native Source 无法读取 schema.fields：DataSource Catalog 未启用");
+    }
+    String database = options.path("database").asText();
+    String table = options.path("table").asText();
+    List<CatalogColumn> columns =
+        catalogReader.listColumns(context.dataSource().getId(), database, null, table);
+    if (columns.isEmpty()) {
+      throw new IllegalArgumentException(
+          "StarRocks Native Source 未发现字段：" + database + "." + table);
+    }
+
+    ObjectNode schemaFields = objectMapper.createObjectNode();
+    for (CatalogColumn column : columns) {
+      schemaFields.put(column.name(), starRocksType(column));
+    }
+    return schemaFields;
+  }
+
+  private String starRocksType(CatalogColumn column) {
+    String type = NativeSingleTableSupport.requireText(
+        column.typeName(), "StarRocks 字段 " + column.name() + " 缺少类型信息");
+    String normalized = type.toLowerCase(Locale.ROOT);
+    if (normalized.startsWith("array") || normalized.startsWith("map")) {
+      throw new IllegalArgumentException(
+          "StarRocks Native Source 当前不支持 ARRAY/MAP 字段：" + column.name() + " " + type);
+    }
+    if (normalized.startsWith("decimal") && !normalized.contains("(") && column.size() != null) {
+      return type + "(" + column.size() + "," + (column.scale() == null ? 0 : column.scale()) + ")";
+    }
+    return type;
+  }
+
+  private void removeDatasourceOwned(ObjectNode options) {
+    options.remove(List.of("node_urls", "nodeUrls", "username", "password"));
+  }
+}

--- a/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-offline/src/test/java/io/yak/ops/business/sync/offline/engine/connector/OfflineSyncConnectorRegistryTest.java
+++ b/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-offline/src/test/java/io/yak/ops/business/sync/offline/engine/connector/OfflineSyncConnectorRegistryTest.java
@@ -17,28 +17,21 @@ class OfflineSyncConnectorRegistryTest {
             .collect(Collectors.toMap(OfflineSyncConnectorProfile::dbType, value -> value));
 
     assertThat(profiles).containsOnlyKeys(DataSourceDbType.values());
-    assertThat(profiles.values())
-        .allSatisfy(profile -> {
-          assertThat(profile.sourceConnectorId()).isEqualTo("jdbc");
-          assertThat(profile.sinkConnectorId()).isEqualTo("jdbc");
-        });
-    assertThat(profiles.get(DataSourceDbType.DB2).pluginName()).isEqualTo("JDBC-DB2");
-    assertThat(profiles.get(DataSourceDbType.OPEN_GAUSS).pluginName())
-        .isEqualTo("JDBC-OPENGAUSS");
-    assertThat(profiles.get(DataSourceDbType.SQL_SERVER).pluginName())
-        .isEqualTo("JDBC-SQLSERVER");
-    assertThat(profiles.get(DataSourceDbType.OCEANBASE).pluginName())
-        .isEqualTo("JDBC-OCEANBASE");
+    assertThat(profiles.get(DataSourceDbType.DORIS).sourceConnectorId()).isEqualTo("doris");
+    assertThat(profiles.get(DataSourceDbType.STARROCKS).sourceConnectorId()).isEqualTo("starrocks");
+    assertThat(profiles.get(DataSourceDbType.CLICKHOUSE).sourceConnectorId()).isEqualTo("clickhouse");
+    assertThat(profiles.get(DataSourceDbType.DB2).sourceConnectorId()).isEqualTo("jdbc");
+    assertThat(profiles.get(DataSourceDbType.OPEN_GAUSS).sourceConnectorId()).isEqualTo("jdbc");
+    assertThat(profiles.get(DataSourceDbType.SQL_SERVER).sourceConnectorId()).isEqualTo("jdbc");
+    assertThat(profiles.get(DataSourceDbType.OCEANBASE).sourceConnectorId()).isEqualTo("jdbc");
   }
 
   @Test
-  void shouldKeepHistoricalAndProductAliasesOnJdbc() {
-    assertThat(OfflineSyncConnectorRegistry.defaultConnectorId("POSTGRESQL")).contains("jdbc");
-    assertThat(OfflineSyncConnectorRegistry.defaultConnectorId("DB2")).contains("jdbc");
-    assertThat(OfflineSyncConnectorRegistry.defaultConnectorId("OPENGAUSS")).contains("jdbc");
-    assertThat(OfflineSyncConnectorRegistry.defaultConnectorId("SQLSERVER")).contains("jdbc");
-    assertThat(OfflineSyncConnectorRegistry.defaultConnectorId("OCEANBASE")).contains("jdbc");
+  void shouldKeepDefinitionsWithoutDurableConnectorIdOnHistoricalJdbcPath() {
+    assertThat(OfflineSyncConnectorRegistry.defaultConnectorId("DORIS")).contains("jdbc");
     assertThat(OfflineSyncConnectorRegistry.defaultConnectorId("STARROCKS")).contains("jdbc");
+    assertThat(OfflineSyncConnectorRegistry.defaultConnectorId("CLICKHOUSE")).contains("jdbc");
+    assertThat(OfflineSyncConnectorRegistry.defaultConnectorId("POSTGRESQL")).contains("jdbc");
     assertThat(OfflineSyncConnectorRegistry.defaultConnectorId("HTTP")).isEmpty();
   }
 }

--- a/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-offline/src/test/java/io/yak/ops/business/sync/offline/engine/connector/adapter/NativeOlapConnectorAdapterTest.java
+++ b/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-offline/src/test/java/io/yak/ops/business/sync/offline/engine/connector/adapter/NativeOlapConnectorAdapterTest.java
@@ -1,0 +1,139 @@
+package io.yak.ops.business.sync.offline.engine.connector.adapter;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import io.yak.ops.business.datasource.catalog.DataSourceCatalogReader;
+import io.yak.ops.business.datasource.domain.catalog.CatalogColumn;
+import io.yak.ops.business.sync.offline.engine.connector.adapter.OfflineSyncConnectorAdapter.BuildContext;
+import io.yak.ops.business.sync.offline.engine.connector.adapter.OfflineSyncConnectorAdapter.BuildResult;
+import io.yak.ops.business.sync.offline.engine.connector.adapter.OfflineSyncConnectorAdapter.ExecutionContext;
+import io.yak.ops.business.sync.offline.engine.connector.adapter.OfflineSyncConnectorAdapter.Role;
+import io.yak.ops.common.bean.po.datasource.DataSourcePO;
+import io.yak.ops.common.enums.datasource.DataSourceDbType;
+import java.sql.Types;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.ObjectProvider;
+
+class NativeOlapConnectorAdapterTest {
+
+  private final ObjectMapper mapper = new ObjectMapper();
+
+  @Test
+  void clickHouseBuildAndExecutionTranslateSingleTableDatasource() {
+    ClickHouseOfflineSyncConnectorAdapter adapter = new ClickHouseOfflineSyncConnectorAdapter(mapper);
+    ObjectNode config = mapper.createObjectNode();
+    config.put("table", "orders");
+    ObjectNode options = mapper.createObjectNode();
+
+    BuildResult built = adapter.build(
+        new BuildContext(
+            "clickhouse",
+            Role.SOURCE,
+            "GUIDE_SINGLE",
+            "orders-sync",
+            config,
+            mapper.createObjectNode(),
+            options,
+            5000,
+            2000,
+            List.of()));
+
+    DataSourcePO dataSource = dataSource(
+        10L,
+        DataSourceDbType.CLICKHOUSE,
+        "{\"host\":\"clickhouse.internal\",\"port\":8123,\"database\":\"analytics\","
+            + "\"username\":\"default\",\"password\":\"secret\","
+            + "\"serverTimeZone\":\"Asia/Shanghai\"}");
+    adapter.resolveForExecution(
+        new ExecutionContext("clickhouse", Role.SOURCE, "来源端", dataSource, built.options()));
+
+    assertThat(built.options().path("table_path").asText()).isEqualTo("analytics.orders");
+    assertThat(built.options().path("host").asText()).isEqualTo("clickhouse.internal:8123");
+    assertThat(built.options().path("batch_size").asInt()).isEqualTo(2000);
+    assertThat(built.options().path("server_time_zone").asText()).isEqualTo("Asia/Shanghai");
+    assertThat(built.options().path("password").asText()).isEqualTo("secret");
+  }
+
+  @Test
+  void starRocksSourceInjectsSchemaFromDatasourceCatalogAtExecutionTime() {
+    DataSourceCatalogReader catalogReader = mock(DataSourceCatalogReader.class);
+    @SuppressWarnings("unchecked")
+    ObjectProvider<DataSourceCatalogReader> provider = mock(ObjectProvider.class);
+    when(provider.getIfAvailable()).thenReturn(catalogReader);
+    when(catalogReader.listColumns(20L, "analytics", null, "orders"))
+        .thenReturn(
+            List.of(
+                new CatalogColumn("id", "BIGINT", Types.BIGINT, 19, 0, false, 1, true, null),
+                new CatalogColumn("amount", "DECIMAL", Types.DECIMAL, 18, 2, true, 2, false, null)));
+
+    StarRocksOfflineSyncConnectorAdapter adapter =
+        new StarRocksOfflineSyncConnectorAdapter(mapper, provider);
+    ObjectNode config = mapper.createObjectNode();
+    config.put("table", "analytics.orders");
+    BuildResult built = adapter.build(
+        new BuildContext(
+            "starrocks",
+            Role.SOURCE,
+            "GUIDE_SINGLE",
+            "orders-sync",
+            config,
+            mapper.createObjectNode(),
+            mapper.createObjectNode(),
+            1000,
+            4096,
+            List.of()));
+
+    DataSourcePO dataSource = dataSource(
+        20L,
+        DataSourceDbType.STARROCKS,
+        "{\"database\":\"analytics\",\"username\":\"root\",\"password\":\"secret\","
+            + "\"nodeUrls\":\"fe-a:8030,fe-b:8030\"}");
+    adapter.resolveForExecution(
+        new ExecutionContext("starrocks", Role.SOURCE, "来源端", dataSource, built.options()));
+
+    assertThat(built.options().path("node_urls").size()).isEqualTo(2);
+    assertThat(built.options().path("scan_batch_rows").asInt()).isEqualTo(4096);
+    assertThat(built.options().path("schema.fields").path("id").asText()).isEqualTo("BIGINT");
+    assertThat(built.options().path("schema.fields").path("amount").asText())
+        .isEqualTo("DECIMAL(18,2)");
+  }
+
+  @Test
+  void nativeAdaptersRejectMultiTableUntilFanOutStage() {
+    ClickHouseOfflineSyncConnectorAdapter adapter = new ClickHouseOfflineSyncConnectorAdapter(mapper);
+    ObjectNode config = mapper.createObjectNode();
+    config.put("table", "analytics.orders");
+
+    assertThatThrownBy(
+            () ->
+                adapter.build(
+                    new BuildContext(
+                        "clickhouse",
+                        Role.SOURCE,
+                        "GUIDE_MULTI",
+                        "orders-sync",
+                        config,
+                        mapper.createObjectNode(),
+                        mapper.createObjectNode(),
+                        1000,
+                        1000,
+                        List.of())))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining("仅支持单表离线同步");
+  }
+
+  private DataSourcePO dataSource(Long id, DataSourceDbType dbType, String connectionParams) {
+    DataSourcePO dataSource = new DataSourcePO();
+    dataSource.setId(id);
+    dataSource.setName(dbType.getDisplayName());
+    dataSource.setDbType(dbType);
+    dataSource.setConnectionParams(connectionParams);
+    return dataSource;
+  }
+}

--- a/yak-ops-common/src/main/java/io/yak/ops/common/enums/datasource/DataSourceDbType.java
+++ b/yak-ops-common/src/main/java/io/yak/ops/common/enums/datasource/DataSourceDbType.java
@@ -17,6 +17,8 @@ public enum DataSourceDbType {
   SQL_SERVER("SQL Server"),
   OCEANBASE("OceanBase"),
   DORIS("Doris"),
+  STARROCKS("StarRocks"),
+  CLICKHOUSE("ClickHouse"),
   KINGBASE("KingbaseES"),
   DAMENG("达梦");
 

--- a/yak-ops-common/src/test/java/io/yak/ops/common/enums/datasource/DataSourceDbTypeTest.java
+++ b/yak-ops-common/src/test/java/io/yak/ops/common/enums/datasource/DataSourceDbTypeTest.java
@@ -22,15 +22,18 @@ class DataSourceDbTypeTest {
   }
 
   @Test
-  void shouldExposeJdbcWaveOneAsFirstClassTypes() {
+  void shouldExposeJdbcAndNativeOlapTypesAsFirstClassTypes() {
     assertThat(DataSourceDbType.values())
         .contains(
             DataSourceDbType.DB2,
             DataSourceDbType.OPEN_GAUSS,
             DataSourceDbType.SQL_SERVER,
-            DataSourceDbType.OCEANBASE);
-    assertThat(DataSourceDbType.OPEN_GAUSS.getDisplayName()).isEqualTo("openGauss");
-    assertThat(DataSourceDbType.SQL_SERVER.getDisplayName()).isEqualTo("SQL Server");
+            DataSourceDbType.OCEANBASE,
+            DataSourceDbType.DORIS,
+            DataSourceDbType.STARROCKS,
+            DataSourceDbType.CLICKHOUSE);
+    assertThat(DataSourceDbType.STARROCKS.getDisplayName()).isEqualTo("StarRocks");
+    assertThat(DataSourceDbType.CLICKHOUSE.getDisplayName()).isEqualTo("ClickHouse");
   }
 
   @Test

--- a/yak-ops-plugins/yak-ops-plugin-datasource/yak-ops-plugin-datasource-all/src/test/java/io/yak/ops/plugin/datasource/AllDataSourcePluginsTest.java
+++ b/yak-ops-plugins/yak-ops-plugin-datasource/yak-ops-plugin-datasource-all/src/test/java/io/yak/ops/plugin/datasource/AllDataSourcePluginsTest.java
@@ -29,6 +29,8 @@ class AllDataSourcePluginsTest {
             DataSourceDbType.OPEN_GAUSS,
             DataSourceDbType.SQL_SERVER,
             DataSourceDbType.OCEANBASE,
-            DataSourceDbType.DORIS);
+            DataSourceDbType.DORIS,
+            DataSourceDbType.STARROCKS,
+            DataSourceDbType.CLICKHOUSE);
   }
 }

--- a/yak-ops-plugins/yak-ops-plugin-datasource/yak-ops-plugin-datasource-jdbc/pom.xml
+++ b/yak-ops-plugins/yak-ops-plugin-datasource/yak-ops-plugin-datasource-jdbc/pom.xml
@@ -65,6 +65,18 @@
             <scope>runtime</scope>
         </dependency>
         <dependency>
+            <groupId>com.clickhouse</groupId>
+            <artifactId>clickhouse-jdbc</artifactId>
+            <version>0.3.2-patch11</version>
+            <scope>runtime</scope>
+        </dependency>
+        <dependency>
+            <groupId>com.clickhouse</groupId>
+            <artifactId>clickhouse-http-client</artifactId>
+            <version>0.3.2-patch11</version>
+            <scope>runtime</scope>
+        </dependency>
+        <dependency>
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-test</artifactId>
             <scope>test</scope>

--- a/yak-ops-plugins/yak-ops-plugin-datasource/yak-ops-plugin-datasource-jdbc/src/main/java/io/yak/ops/plugin/database/jdbc/GenericJdbcCatalog.java
+++ b/yak-ops-plugins/yak-ops-plugin-datasource/yak-ops-plugin-datasource-jdbc/src/main/java/io/yak/ops/plugin/database/jdbc/GenericJdbcCatalog.java
@@ -341,7 +341,8 @@ public class GenericJdbcCatalog implements DataSourceCatalog {
             oceanBaseOracleMode()
                 ? query + " WHERE ROWNUM <= " + limit
                 : query + " LIMIT " + limit;
-        case MYSQL, POSTGRE_SQL, DORIS, KINGBASE, OPEN_GAUSS -> query + " LIMIT " + limit;
+        case MYSQL, POSTGRE_SQL, DORIS, STARROCKS, CLICKHOUSE, KINGBASE, OPEN_GAUSS ->
+            query + " LIMIT " + limit;
       };
     }
 
@@ -356,7 +357,7 @@ public class GenericJdbcCatalog implements DataSourceCatalog {
           oceanBaseOracleMode()
               ? "SELECT * FROM (" + query + ") yak_ops_preview WHERE ROWNUM <= " + limit
               : "SELECT * FROM (" + query + ") yak_ops_preview LIMIT " + limit;
-      case MYSQL, POSTGRE_SQL, DORIS, KINGBASE, OPEN_GAUSS ->
+      case MYSQL, POSTGRE_SQL, DORIS, STARROCKS, CLICKHOUSE, KINGBASE, OPEN_GAUSS ->
           "SELECT * FROM (" + query + ") yak_ops_preview LIMIT " + limit;
     };
   }
@@ -516,6 +517,8 @@ public class GenericJdbcCatalog implements DataSourceCatalog {
   private boolean usesCatalogAsNamespace() {
     return connection.dbType() == DataSourceDbType.MYSQL
         || connection.dbType() == DataSourceDbType.DORIS
+        || connection.dbType() == DataSourceDbType.STARROCKS
+        || connection.dbType() == DataSourceDbType.CLICKHOUSE
         || (connection.dbType() == DataSourceDbType.OCEANBASE && !oceanBaseOracleMode());
   }
 

--- a/yak-ops-plugins/yak-ops-plugin-datasource/yak-ops-plugin-datasource-jdbc/src/main/java/io/yak/ops/plugin/database/jdbc/clickhouse/ClickHouseDataSourcePlugin.java
+++ b/yak-ops-plugins/yak-ops-plugin-datasource/yak-ops-plugin-datasource-jdbc/src/main/java/io/yak/ops/plugin/database/jdbc/clickhouse/ClickHouseDataSourcePlugin.java
@@ -1,0 +1,68 @@
+package io.yak.ops.plugin.database.jdbc.clickhouse;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import io.yak.ops.common.enums.datasource.DataSourceDbType;
+import io.yak.ops.plugin.database.jdbc.AbstractJdbcDataSourcePlugin;
+import io.yak.ops.spi.datasource.DataSourcePluginDescriptor.FormField;
+import java.util.Collections;
+import java.util.List;
+import java.util.Locale;
+
+/** ClickHouse datasource plugin used for management/catalog while offline execution can be native. */
+public final class ClickHouseDataSourcePlugin extends AbstractJdbcDataSourcePlugin {
+
+  @Override
+  public DataSourceDbType dbType() {
+    return DataSourceDbType.CLICKHOUSE;
+  }
+
+  @Override
+  protected String jdbcUrlTemplate() {
+    return "jdbc:clickhouse://{host}:{port}/{database}";
+  }
+
+  @Override
+  protected int defaultPort() {
+    return 8123;
+  }
+
+  @Override
+  protected String defaultDriverClassName() {
+    return "com.clickhouse.jdbc.ClickHouseDriver";
+  }
+
+  @Override
+  protected String buildJdbcUrl(String host, int port, String database, JsonNode connectionJson) {
+    return "jdbc:clickhouse://" + host + ":" + port + "/" + database;
+  }
+
+  @Override
+  protected void appendFormFields(List<FormField> fields) {
+    fields.add(
+        field(
+            "serverTimeZone",
+            "服务端时区",
+            "INPUT",
+            "可选，例如 Asia/Shanghai",
+            null,
+            Collections.emptyList()));
+  }
+
+  @Override
+  protected void appendNormalizedFields(JsonNode source, ObjectNode normalized) {
+    JsonNode value = source == null ? null : source.get("serverTimeZone");
+    if (value == null || value.isNull()) {
+      value = source == null ? null : source.get("server_time_zone");
+    }
+    if (value != null && !value.isNull() && !value.asText().trim().isEmpty()) {
+      normalized.put("serverTimeZone", value.asText().trim());
+    }
+  }
+
+  @Override
+  public boolean acceptsUrl(String jdbcUrl) {
+    return jdbcUrl != null
+        && jdbcUrl.toLowerCase(Locale.ROOT).startsWith("jdbc:clickhouse:");
+  }
+}

--- a/yak-ops-plugins/yak-ops-plugin-datasource/yak-ops-plugin-datasource-jdbc/src/main/java/io/yak/ops/plugin/database/jdbc/starrocks/StarRocksDataSourcePlugin.java
+++ b/yak-ops-plugins/yak-ops-plugin-datasource/yak-ops-plugin-datasource-jdbc/src/main/java/io/yak/ops/plugin/database/jdbc/starrocks/StarRocksDataSourcePlugin.java
@@ -1,0 +1,73 @@
+package io.yak.ops.plugin.database.jdbc.starrocks;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import io.yak.ops.common.enums.datasource.DataSourceDbType;
+import io.yak.ops.plugin.database.jdbc.AbstractJdbcDataSourcePlugin;
+import io.yak.ops.spi.datasource.DataSourcePluginDescriptor.FormField;
+import java.util.Collections;
+import java.util.List;
+import java.util.Locale;
+
+/** StarRocks datasource management over the MySQL-compatible query port. */
+public final class StarRocksDataSourcePlugin extends AbstractJdbcDataSourcePlugin {
+
+  @Override
+  public DataSourceDbType dbType() {
+    return DataSourceDbType.STARROCKS;
+  }
+
+  @Override
+  protected String jdbcUrlTemplate() {
+    return "jdbc:mysql://{host}:{port}/{database}";
+  }
+
+  @Override
+  protected int defaultPort() {
+    return 9030;
+  }
+
+  @Override
+  protected String defaultDriverClassName() {
+    return "com.mysql.cj.jdbc.Driver";
+  }
+
+  @Override
+  protected String databaseLabel() {
+    return "StarRocks 数据库";
+  }
+
+  @Override
+  protected String buildJdbcUrl(String host, int port, String database, JsonNode connectionJson) {
+    return "jdbc:mysql://" + host + ":" + port + "/" + database;
+  }
+
+  @Override
+  protected void appendFormFields(List<FormField> fields) {
+    fields.add(
+        field(
+            "nodeUrls",
+            "FE HTTP 节点",
+            "INPUT",
+            "可选；默认使用主机地址:8030，多个自定义节点使用英文逗号分隔",
+            null,
+            Collections.emptyList()));
+  }
+
+  @Override
+  protected void appendNormalizedFields(JsonNode source, ObjectNode normalized) {
+    JsonNode value = source == null ? null : source.get("nodeUrls");
+    if (value == null || value.isNull()) {
+      value = source == null ? null : source.get("node_urls");
+    }
+    if (value != null && !value.isNull() && !value.asText().trim().isEmpty()) {
+      normalized.put("nodeUrls", value.asText().trim());
+    }
+  }
+
+  @Override
+  public boolean acceptsUrl(String jdbcUrl) {
+    return jdbcUrl != null
+        && jdbcUrl.toLowerCase(Locale.ROOT).startsWith("jdbc:mysql:");
+  }
+}

--- a/yak-ops-plugins/yak-ops-plugin-datasource/yak-ops-plugin-datasource-jdbc/src/main/resources/META-INF/services/io.yak.ops.spi.datasource.DataSourcePlugin
+++ b/yak-ops-plugins/yak-ops-plugin-datasource/yak-ops-plugin-datasource-jdbc/src/main/resources/META-INF/services/io.yak.ops.spi.datasource.DataSourcePlugin
@@ -7,3 +7,5 @@ io.yak.ops.plugin.database.jdbc.db2.Db2DataSourcePlugin
 io.yak.ops.plugin.database.jdbc.opengauss.OpenGaussDataSourcePlugin
 io.yak.ops.plugin.database.jdbc.sqlserver.SqlServerDataSourcePlugin
 io.yak.ops.plugin.database.jdbc.oceanbase.OceanBaseDataSourcePlugin
+io.yak.ops.plugin.database.jdbc.starrocks.StarRocksDataSourcePlugin
+io.yak.ops.plugin.database.jdbc.clickhouse.ClickHouseDataSourcePlugin

--- a/yak-ops-plugins/yak-ops-plugin-datasource/yak-ops-plugin-datasource-jdbc/src/test/java/io/yak/ops/plugin/database/jdbc/JdbcDatasourcePluginContractTest.java
+++ b/yak-ops-plugins/yak-ops-plugin-datasource/yak-ops-plugin-datasource-jdbc/src/test/java/io/yak/ops/plugin/database/jdbc/JdbcDatasourcePluginContractTest.java
@@ -2,6 +2,7 @@ package io.yak.ops.plugin.database.jdbc;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+import io.yak.ops.plugin.database.jdbc.clickhouse.ClickHouseDataSourcePlugin;
 import io.yak.ops.plugin.database.jdbc.dameng.DamengDataSourcePlugin;
 import io.yak.ops.plugin.database.jdbc.db2.Db2DataSourcePlugin;
 import io.yak.ops.plugin.database.jdbc.kingbase.KingbaseDataSourcePlugin;
@@ -11,6 +12,7 @@ import io.yak.ops.plugin.database.jdbc.opengauss.OpenGaussDataSourcePlugin;
 import io.yak.ops.plugin.database.jdbc.oracle.OracleDataSourcePlugin;
 import io.yak.ops.plugin.database.jdbc.postgresql.PostgreSqlDataSourcePlugin;
 import io.yak.ops.plugin.database.jdbc.sqlserver.SqlServerDataSourcePlugin;
+import io.yak.ops.plugin.database.jdbc.starrocks.StarRocksDataSourcePlugin;
 import io.yak.ops.spi.datasource.DataSourceCapability;
 import io.yak.ops.spi.datasource.DataSourcePlugin;
 import io.yak.ops.spi.datasource.DataSourcePluginDescriptor;
@@ -66,6 +68,8 @@ class JdbcDatasourcePluginContractTest {
         new Db2DataSourcePlugin(),
         new OpenGaussDataSourcePlugin(),
         new SqlServerDataSourcePlugin(),
-        new OceanBaseDataSourcePlugin());
+        new OceanBaseDataSourcePlugin(),
+        new StarRocksDataSourcePlugin(),
+        new ClickHouseDataSourcePlugin());
   }
 }

--- a/yak-ops-plugins/yak-ops-plugin-datasource/yak-ops-plugin-datasource-jdbc/src/test/java/io/yak/ops/plugin/database/jdbc/NativeOlapDataSourcePluginTest.java
+++ b/yak-ops-plugins/yak-ops-plugin-datasource/yak-ops-plugin-datasource-jdbc/src/test/java/io/yak/ops/plugin/database/jdbc/NativeOlapDataSourcePluginTest.java
@@ -1,0 +1,39 @@
+package io.yak.ops.plugin.database.jdbc;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.yak.ops.plugin.database.jdbc.clickhouse.ClickHouseDataSourcePlugin;
+import io.yak.ops.plugin.database.jdbc.starrocks.StarRocksDataSourcePlugin;
+import io.yak.ops.spi.datasource.DataSourceConnection;
+import org.junit.jupiter.api.Test;
+
+class NativeOlapDataSourcePluginTest {
+
+  @Test
+  void starRocksKeepsManagementJdbcSeparateFromNativeFeNodes() {
+    StarRocksDataSourcePlugin plugin = new StarRocksDataSourcePlugin();
+    DataSourceConnection connection =
+        plugin.parseConnection(
+            "{\"dbType\":\"STARROCKS\",\"host\":\"sr-fe\",\"port\":9030,"
+                + "\"database\":\"analytics\",\"username\":\"root\",\"password\":\"secret\","
+                + "\"nodeUrls\":\"sr-fe:8030,sr-fe-2:8030\"}");
+
+    assertThat(connection.jdbcUrl()).isEqualTo("jdbc:mysql://sr-fe:9030/analytics");
+    assertThat(connection.driverClassName()).isEqualTo("com.mysql.cj.jdbc.Driver");
+    assertThat(connection.normalizedJson()).contains("\"nodeUrls\":\"sr-fe:8030,sr-fe-2:8030\"");
+  }
+
+  @Test
+  void clickHouseUsesNativeCompatibleHttpJdbcManagementEndpoint() {
+    ClickHouseDataSourcePlugin plugin = new ClickHouseDataSourcePlugin();
+    DataSourceConnection connection =
+        plugin.parseConnection(
+            "{\"dbType\":\"CLICKHOUSE\",\"host\":\"clickhouse\",\"port\":8123,"
+                + "\"database\":\"analytics\",\"username\":\"default\",\"password\":\"secret\","
+                + "\"serverTimeZone\":\"Asia/Shanghai\"}");
+
+    assertThat(connection.jdbcUrl()).isEqualTo("jdbc:clickhouse://clickhouse:8123/analytics");
+    assertThat(connection.driverClassName()).isEqualTo("com.clickhouse.jdbc.ClickHouseDriver");
+    assertThat(connection.normalizedJson()).contains("\"serverTimeZone\":\"Asia/Shanghai\"");
+  }
+}

--- a/yak-ops-ui/src/pages/data-source/constants.tsx
+++ b/yak-ops-ui/src/pages/data-source/constants.tsx
@@ -37,6 +37,8 @@ export const COMMON_DB_OPTIONS: DataSourceOptionItem[] = [
   { label: 'SQL_SERVER', value: 'SQL_SERVER' },
   { label: 'OCEANBASE', value: 'OCEANBASE' },
   { label: 'DORIS', value: 'DORIS' },
+  { label: 'STARROCKS', value: 'STARROCKS' },
+  { label: 'CLICKHOUSE', value: 'CLICKHOUSE' },
   { label: 'KINGBASE', value: 'KINGBASE' },
   { label: 'DAMENG', value: 'DAMENG' },
 ];
@@ -52,6 +54,13 @@ const relationalDataSource = (dbType: string) => ({
   dbType,
   type: dbType,
   connectorType: 'Jdbc',
+});
+
+const olapDataSource = (dbType: string, connectorType: string) => ({
+  onlyDiScript: false,
+  dbType,
+  type: dbType,
+  connectorType,
 });
 
 export const getDataSourceGroupList = (intl: IntlFormatter): DataSourceGroup[] => [
@@ -74,12 +83,9 @@ export const getDataSourceGroupList = (intl: IntlFormatter): DataSourceGroup[] =
     groupKey: 'olap',
     groupName: intl.formatMessage({ id: 'pages.datasource.group.olap' }),
     datasourceList: [
-      {
-        onlyDiScript: false,
-        dbType: 'DORIS',
-        type: 'DORIS',
-        connectorType: 'Doris',
-      },
+      olapDataSource('DORIS', 'Doris'),
+      olapDataSource('STARROCKS', 'StarRocks'),
+      olapDataSource('CLICKHOUSE', 'ClickHouse'),
     ],
   },
 ];

--- a/yak-ops-ui/src/pages/integration/batch-link-up/DataSourceSelect.tsx
+++ b/yak-ops-ui/src/pages/integration/batch-link-up/DataSourceSelect.tsx
@@ -30,6 +30,8 @@ const DATA_SOURCE_TYPES = [
   { value: 'SQL_SERVER', displayName: 'SQL Server' },
   { value: 'OCEANBASE', displayName: 'OceanBase' },
   { value: 'DORIS', displayName: 'Doris' },
+  { value: 'STARROCKS', displayName: 'StarRocks' },
+  { value: 'CLICKHOUSE', displayName: 'ClickHouse' },
   { value: 'KINGBASE', displayName: 'KINGBASE' },
   { value: 'DAMENG', displayName: 'DAMENG' },
 ] as const;

--- a/yak-ops-ui/src/pages/integration/batch-link-up/components/CreateSyncTaskDrawer.tsx
+++ b/yak-ops-ui/src/pages/integration/batch-link-up/components/CreateSyncTaskDrawer.tsx
@@ -40,7 +40,10 @@ import {
 } from '@/styles/brand';
 
 import { generateDataSourceOptions } from '../DataSourceSelect';
-import { connectorIdForDataSourceType } from '../detail/form-schema/valueAdapter';
+import {
+  connectorIdForNewDataSourceType,
+  type OfflineSyncConnectorRole,
+} from '../connectorProfiles';
 import {
   buildCreatePayload,
   type CreateSyncEndpoint,
@@ -66,6 +69,7 @@ interface ConnectorOption {
 }
 
 const DEFAULT_DB_TYPE = 'MYSQL';
+const NATIVE_SINGLE_ONLY_CONNECTORS = new Set(['doris', 'starrocks', 'clickhouse']);
 
 const brandCssVariables = {
   '--yak-brand-color': BRAND_COLOR,
@@ -77,12 +81,13 @@ const brandCssVariables = {
 const resolveEndpoint = (
   dbType: string,
   options: ConnectorOption[],
+  role: OfflineSyncConnectorRole,
 ): CreateSyncEndpoint => {
   const option = options.find((item) => item.value === dbType);
 
   return {
     dbType,
-    connectorId: connectorIdForDataSourceType(dbType),
+    connectorId: connectorIdForNewDataSourceType(dbType, role),
     pluginName: option?.pluginName || `JDBC-${dbType}`,
   };
 };
@@ -108,11 +113,18 @@ export default function CreateSyncTaskDrawer({
 
   const sourceDbType = Form.useWatch('sourceDbType', form);
   const targetDbType = Form.useWatch('targetDbType', form);
+  const sourceConnectorId = connectorIdForNewDataSourceType(sourceDbType, 'SOURCE');
+  const targetConnectorId = connectorIdForNewDataSourceType(targetDbType, 'SINK');
+  const nativeSingleOnly =
+    NATIVE_SINGLE_ONLY_CONNECTORS.has(sourceConnectorId) ||
+    NATIVE_SINGLE_ONLY_CONNECTORS.has(targetConnectorId);
+
   const modeOptions: Array<{
     value: SyncMode;
     title: string;
     description: string;
     icon: ReactNode;
+    disabled?: boolean;
   }> = [
     {
       value: 'GUIDE_SINGLE',
@@ -125,10 +137,13 @@ export default function CreateSyncTaskDrawer({
     {
       value: 'GUIDE_MULTI',
       title: intl.formatMessage({ id: 'pages.batchLinkUp.create.mode.multi' }),
-      description: intl.formatMessage({
-        id: 'pages.batchLinkUp.create.mode.multiDescription',
-      }),
+      description: nativeSingleOnly
+        ? '当前选择的 Native Connector 本阶段仅开放单表离线同步'
+        : intl.formatMessage({
+            id: 'pages.batchLinkUp.create.mode.multiDescription',
+          }),
       icon: <DatabaseOutlined />,
+      disabled: nativeSingleOnly,
     },
   ];
 
@@ -165,6 +180,12 @@ export default function CreateSyncTaskDrawer({
     });
   }, [connectorOptions, form, open]);
 
+  useEffect(() => {
+    if (nativeSingleOnly && form.getFieldValue('mode') === 'GUIDE_MULTI') {
+      form.setFieldValue('mode', 'GUIDE_SINGLE');
+    }
+  }, [form, nativeSingleOnly]);
+
   const updateAutoJobName = (side: 'source' | 'target', value: string) => {
     const nextSourceDbType =
       side === 'source' ? value : form.getFieldValue('sourceDbType') || '';
@@ -197,13 +218,21 @@ export default function CreateSyncTaskDrawer({
   const handleSubmit = async () => {
     try {
       const values = await form.validateFields();
+      const source = resolveEndpoint(values.sourceDbType, connectorOptions, 'SOURCE');
+      const sink = resolveEndpoint(values.targetDbType, connectorOptions, 'SINK');
+      if (
+        values.mode === 'GUIDE_MULTI' &&
+        (NATIVE_SINGLE_ONLY_CONNECTORS.has(source.connectorId) ||
+          NATIVE_SINGLE_ONLY_CONNECTORS.has(sink.connectorId))
+      ) {
+        throw new Error('当前选择的 Native Connector 本阶段仅支持单表离线同步');
+      }
+
       const normalizedValues: CreateSyncTaskValues = {
         jobName: values.jobName.trim(),
         jobDesc: values.jobDesc?.trim(),
         mode: values.mode,
       };
-      const source = resolveEndpoint(values.sourceDbType, connectorOptions);
-      const sink = resolveEndpoint(values.targetDbType, connectorOptions);
 
       setSubmitting(true);
       const taskId = String(await getOfflineSyncUniqueId());
@@ -450,6 +479,7 @@ export default function CreateSyncTaskDrawer({
                 <Radio.Button
                   key={option.value}
                   value={option.value}
+                  disabled={option.disabled}
                   className={[
                     '!h-auto',
                     '!rounded-lg',

--- a/yak-ops-ui/src/pages/integration/batch-link-up/connectorProfiles.test.ts
+++ b/yak-ops-ui/src/pages/integration/batch-link-up/connectorProfiles.test.ts
@@ -1,10 +1,11 @@
 import {
   connectorIdForDataSourceType,
+  connectorIdForNewDataSourceType,
   defaultOfflineSyncConnectorProfile,
   OFFLINE_SYNC_CONNECTOR_PROFILES,
 } from './connectorProfiles';
 
-test('keeps first-class datasource profiles on their explicit jdbc execution path', () => {
+test('uses native profiles for new OLAP tasks while keeping JDBC profiles explicit', () => {
   expect(OFFLINE_SYNC_CONNECTOR_PROFILES.map((profile) => profile.dbType)).toEqual([
     'MYSQL',
     'ORACLE',
@@ -14,15 +15,34 @@ test('keeps first-class datasource profiles on their explicit jdbc execution pat
     'SQL_SERVER',
     'OCEANBASE',
     'DORIS',
+    'STARROCKS',
+    'CLICKHOUSE',
     'KINGBASE',
     'DAMENG',
   ]);
-  expect(
-    OFFLINE_SYNC_CONNECTOR_PROFILES.every(
-      (profile) =>
-        profile.sourceConnectorId === 'jdbc' && profile.sinkConnectorId === 'jdbc',
-    ),
-  ).toBe(true);
+  expect(defaultOfflineSyncConnectorProfile('DORIS')).toMatchObject({
+    profileId: 'doris-native',
+    sourceConnectorId: 'doris',
+    sinkConnectorId: 'doris',
+  });
+  expect(defaultOfflineSyncConnectorProfile('STARROCKS')).toMatchObject({
+    profileId: 'starrocks-native',
+    sourceConnectorId: 'starrocks',
+  });
+  expect(defaultOfflineSyncConnectorProfile('CLICKHOUSE')).toMatchObject({
+    profileId: 'clickhouse-native',
+    sourceConnectorId: 'clickhouse',
+  });
+  expect(defaultOfflineSyncConnectorProfile('DB2')?.sourceConnectorId).toBe('jdbc');
+});
+
+test('separates legacy inference from new-task profile selection', () => {
+  expect(connectorIdForDataSourceType('DORIS')).toBe('jdbc');
+  expect(connectorIdForDataSourceType('STARROCKS')).toBe('jdbc');
+  expect(connectorIdForDataSourceType('CLICKHOUSE')).toBe('jdbc');
+  expect(connectorIdForNewDataSourceType('DORIS')).toBe('doris');
+  expect(connectorIdForNewDataSourceType('STARROCKS')).toBe('starrocks');
+  expect(connectorIdForNewDataSourceType('CLICKHOUSE')).toBe('clickhouse');
 });
 
 test('resolves datasource aliases from one frontend registry', () => {
@@ -32,15 +52,10 @@ test('resolves datasource aliases from one frontend registry', () => {
   expect(connectorIdForDataSourceType('SQLSERVER')).toBe('jdbc');
   expect(connectorIdForDataSourceType('MSSQL')).toBe('jdbc');
   expect(connectorIdForDataSourceType('OCEANBASE')).toBe('jdbc');
-  expect(connectorIdForDataSourceType('STARROCKS')).toBe('jdbc');
   expect(connectorIdForDataSourceType('HTTP')).toBe('http');
   expect(connectorIdForDataSourceType('custom-api')).toBe('custom_api');
   expect(defaultOfflineSyncConnectorProfile('postgres')).toMatchObject({
     profileId: 'postgresql-jdbc',
     dbType: 'POSTGRE_SQL',
-  });
-  expect(defaultOfflineSyncConnectorProfile('opengauss')).toMatchObject({
-    profileId: 'opengauss-jdbc',
-    dbType: 'OPEN_GAUSS',
   });
 });

--- a/yak-ops-ui/src/pages/integration/batch-link-up/connectorProfiles.ts
+++ b/yak-ops-ui/src/pages/integration/batch-link-up/connectorProfiles.ts
@@ -42,8 +42,16 @@ export const OFFLINE_SYNC_CONNECTOR_PROFILES: readonly OfflineSyncConnectorProfi
     connectorType: 'Jdbc', pluginName: 'JDBC-OCEANBASE', defaultProfile: true,
   },
   {
-    profileId: 'doris-jdbc', dbType: 'DORIS', sourceConnectorId: 'jdbc', sinkConnectorId: 'jdbc',
+    profileId: 'doris-native', dbType: 'DORIS', sourceConnectorId: 'doris', sinkConnectorId: 'doris',
     connectorType: 'Doris', pluginName: 'DORIS', defaultProfile: true,
+  },
+  {
+    profileId: 'starrocks-native', dbType: 'STARROCKS', sourceConnectorId: 'starrocks', sinkConnectorId: 'starrocks',
+    connectorType: 'StarRocks', pluginName: 'STARROCKS', defaultProfile: true,
+  },
+  {
+    profileId: 'clickhouse-native', dbType: 'CLICKHOUSE', sourceConnectorId: 'clickhouse', sinkConnectorId: 'clickhouse',
+    connectorType: 'ClickHouse', pluginName: 'CLICKHOUSE', defaultProfile: true,
   },
   {
     profileId: 'kingbase-jdbc', dbType: 'KINGBASE', sourceConnectorId: 'jdbc', sinkConnectorId: 'jdbc',
@@ -55,8 +63,12 @@ export const OFFLINE_SYNC_CONNECTOR_PROFILES: readonly OfflineSyncConnectorProfi
   },
 ] as const;
 
+/**
+ * Records without connectorId are legacy definitions. Keep their historical JDBC inference so
+ * merely opening/saving an old task cannot silently switch its engine implementation.
+ */
 const LEGACY_JDBC_TYPES = new Set([
-  'JDBC', 'MARIADB', 'STARROCKS', 'CLICKHOUSE', 'HIVE', 'DM',
+  'JDBC', 'MARIADB', 'DORIS', 'STARROCKS', 'CLICKHOUSE', 'HIVE', 'DM',
 ]);
 
 const DB_TYPE_ALIASES: Record<string, string> = {
@@ -81,18 +93,32 @@ export const defaultOfflineSyncConnectorProfile = (
   );
 };
 
+/** Compatibility inference used only when a persisted endpoint has no durable connectorId. */
 export const connectorIdForDataSourceType = (
   value?: string,
   role: OfflineSyncConnectorRole = 'SOURCE',
 ): string => {
   const normalized = normalizeDbType(value);
   if (!normalized) return '';
+  if (LEGACY_JDBC_TYPES.has(normalized)) return 'jdbc';
 
   const profile = defaultOfflineSyncConnectorProfile(normalized);
   if (profile) {
     return role === 'SINK' ? profile.sinkConnectorId : profile.sourceConnectorId;
   }
-  return LEGACY_JDBC_TYPES.has(normalized)
-    ? 'jdbc'
-    : normalized.toLowerCase();
+  return normalized.toLowerCase();
+};
+
+/** New-task resolver: always uses the current default profile and persists its connectorId. */
+export const connectorIdForNewDataSourceType = (
+  value?: string,
+  role: OfflineSyncConnectorRole = 'SOURCE',
+): string => {
+  const normalized = normalizeDbType(value);
+  if (!normalized) return '';
+  const profile = defaultOfflineSyncConnectorProfile(normalized);
+  if (profile) {
+    return role === 'SINK' ? profile.sinkConnectorId : profile.sourceConnectorId;
+  }
+  return normalized.toLowerCase();
 };

--- a/yak-ops-ui/src/pages/integration/batch-link-up/detail/capabilities.test.ts
+++ b/yak-ops-ui/src/pages/integration/batch-link-up/detail/capabilities.test.ts
@@ -2,6 +2,7 @@ import type { OfflineConnectorRuntimeSnapshot } from '@/services/batch-link-up';
 
 import {
   allowsCapability,
+  allowsOverwrite,
   CONNECTOR_CAPABILITY,
   resolveEndpointCapability,
   validateEditorCapabilities,
@@ -49,18 +50,19 @@ const editor = (): SyncEditorState => ({
 const snapshot = (
   sourceCapabilities: string[],
   sinkCapabilities: string[],
+  connectorId = 'jdbc',
 ): OfflineConnectorRuntimeSnapshot => ({
   reachable: true,
   stale: false,
   connectors: [
     {
-      connectorId: 'jdbc',
+      connectorId,
       role: 'SOURCE',
       available: true,
       capabilities: sourceCapabilities,
     },
     {
-      connectorId: 'jdbc',
+      connectorId,
       role: 'SINK',
       available: true,
       capabilities: sinkCapabilities,
@@ -135,6 +137,21 @@ describe('offline connector capabilities', () => {
         'Sink Connector jdbc 不支持 Upsert（UPSERT）',
         'Sink Connector jdbc 不支持跳过脏数据（DIRTY_DATA_HANDLING）',
       ]),
+    );
+  });
+
+  it('treats the current native sinks as no-overwrite implementations', () => {
+    const value = editor();
+    value.source.connectorId = 'clickhouse';
+    value.sink.connectorId = 'clickhouse';
+    value.sink.config.writeMode = 'overwrite';
+    const runtime = snapshot(['TABLE_SCHEMA_DISCOVERY'], [], 'clickhouse');
+
+    expect(
+      allowsOverwrite(resolveEndpointCapability(runtime, 'clickhouse', 'SINK')),
+    ).toBe(false);
+    expect(validateEditorCapabilities(value, runtime)).toContain(
+      'Sink Connector clickhouse 当前 Native 实现不支持覆盖写入（OVERWRITE）',
     );
   });
 

--- a/yak-ops-ui/src/pages/integration/batch-link-up/detail/capabilities.ts
+++ b/yak-ops-ui/src/pages/integration/batch-link-up/detail/capabilities.ts
@@ -32,6 +32,12 @@ export interface EndpointCapabilityState {
   runtime?: OfflineConnectorRoleRuntime;
 }
 
+const NATIVE_NO_OVERWRITE_SINKS = new Set([
+  'doris',
+  'starrocks',
+  'clickhouse',
+]);
+
 const normalizeConnectorId = (value: string) =>
   String(value || '').trim().toLowerCase();
 
@@ -83,6 +89,10 @@ export const allowsCapability = (
   state: EndpointCapabilityState,
   capability: ConnectorCapability | string,
 ) => !state.metadataKnown || hasCapability(state, capability);
+
+/** Overwrite is a control-plane write-mode semantic, not a Link-Up capability enum today. */
+export const allowsOverwrite = (state: EndpointCapabilityState) =>
+  !NATIVE_NO_OVERWRITE_SINKS.has(normalizeConnectorId(state.connectorId));
 
 export const isDefinitivelyUnavailable = (
   state: EndpointCapabilityState,
@@ -137,6 +147,7 @@ export const validateEditorCapabilities = (
 
   const sourceConfig = editor.source.config || {};
   const sinkConfig = editor.sink.config || {};
+  const writeMode = String(sinkConfig.writeMode || '').toLowerCase();
 
   if (
     String(sourceConfig.readMode || '').toLowerCase() === 'sql' &&
@@ -157,11 +168,17 @@ export const validateEditorCapabilities = (
   }
 
   if (
-    String(sinkConfig.writeMode || '').toLowerCase() === 'upsert' &&
+    writeMode === 'upsert' &&
     !hasCapability(sink, CONNECTOR_CAPABILITY.UPSERT)
   ) {
     errors.push(
       `Sink Connector ${sink.connectorId} 不支持 Upsert（UPSERT）`,
+    );
+  }
+
+  if (writeMode === 'overwrite' && !allowsOverwrite(sink)) {
+    errors.push(
+      `Sink Connector ${sink.connectorId} 当前 Native 实现不支持覆盖写入（OVERWRITE）`,
     );
   }
 

--- a/yak-ops-ui/src/pages/integration/batch-link-up/detail/components/SingleTableConfigSection.tsx
+++ b/yak-ops-ui/src/pages/integration/batch-link-up/detail/components/SingleTableConfigSection.tsx
@@ -15,6 +15,7 @@ import { useState, type ChangeEvent, type ReactNode } from 'react';
 
 import {
   allowsCapability,
+  allowsOverwrite,
   CONNECTOR_CAPABILITY,
   type EndpointCapabilityState,
 } from '../capabilities';
@@ -114,6 +115,7 @@ export default function SingleTableConfigSection({
     sinkCapability,
     CONNECTOR_CAPABILITY.UPSERT,
   );
+  const supportsOverwrite = allowsOverwrite(sinkCapability);
   const previewDisabled =
     !sourceDataSourceId ||
     (sourceReadMode === 'sql'
@@ -132,7 +134,11 @@ export default function SingleTableConfigSection({
   const currentWriteMode = String(sinkConfig.writeMode || 'append').toLowerCase();
   const writeModeOptions = [
     { label: '追加写入 Append', value: 'append' },
-    { label: '覆盖写入 Overwrite', value: 'overwrite' },
+    ...(supportsOverwrite
+      ? [{ label: '覆盖写入 Overwrite', value: 'overwrite' }]
+      : currentWriteMode === 'overwrite'
+        ? [{ label: '覆盖写入 Overwrite（当前不支持）', value: 'overwrite', disabled: true }]
+        : []),
     ...(supportsUpsert
       ? [{ label: '主键更新 Upsert', value: 'upsert' }]
       : currentWriteMode === 'upsert'
@@ -284,6 +290,12 @@ export default function SingleTableConfigSection({
                 })
               }
             />
+            {!supportsOverwrite && currentWriteMode === 'overwrite' ? (
+              <div className="mt-1.5 text-[11px] leading-5 text-[#b54708]">
+                当前 Native Sink 不支持覆盖写入，请选择 Append
+                {supportsUpsert ? ' 或 Upsert' : ''}。
+              </div>
+            ) : null}
             {!supportsUpsert && currentWriteMode === 'upsert' ? (
               <div className="mt-1.5 text-[11px] leading-5 text-[#b54708]">
                 当前 Sink Connector 未声明 UPSERT，请选择其他写入模式。

--- a/yak-ops-ui/src/pages/integration/batch-link-up/detail/components/TaskBasicSection.tsx
+++ b/yak-ops-ui/src/pages/integration/batch-link-up/detail/components/TaskBasicSection.tsx
@@ -11,6 +11,7 @@ import {
   BRAND_COLOR_SOFT_HOVER,
 } from '@/styles/brand';
 
+import { connectorIdForNewDataSourceType } from '../../connectorProfiles';
 import {
   applyEndpointSelection,
   type EndpointKind,
@@ -90,7 +91,28 @@ export default function TaskBasicSection({
     );
     if (!record) return;
 
-    onChange(applyEndpointSelection(editor, kind, record));
+    const current = editor[kind];
+    const selected = applyEndpointSelection(editor, kind, record);
+    const sameDbType = normalizeType(current.dbType) === normalizeType(record.dbType);
+
+    // Datasource selection must not re-derive execution identity for an existing task. New native
+    // tasks already persist connectorId; old tasks already resolved to their compatibility path.
+    selected[kind] = {
+      ...selected[kind],
+      connectorId:
+        sameDbType && current.connectorId
+          ? current.connectorId
+          : connectorIdForNewDataSourceType(
+              String(record.dbType || ''),
+              kind === 'source' ? 'SOURCE' : 'SINK',
+            ),
+      pluginName:
+        sameDbType && current.pluginName
+          ? current.pluginName
+          : selected[kind].pluginName,
+    };
+
+    onChange(selected);
   };
 
   return (

--- a/yak-ops-ui/src/pages/integration/batch-link-up/detail/form-schema/connectorTaskOptions.test.ts
+++ b/yak-ops-ui/src/pages/integration/batch-link-up/detail/form-schema/connectorTaskOptions.test.ts
@@ -63,6 +63,25 @@ describe('connectorTaskOptions', () => {
     ]);
   });
 
+  it('filters native keys already owned by Yak Ops single-table controls', () => {
+    const nativeSchema: LinkUpConnectorSchema = {
+      connectorId: 'doris',
+      role: 'SINK',
+      options: [
+        { key: 'table', valueType: 'STRING' },
+        { key: 'sink.key-type', valueType: 'STRING' },
+        { key: 'doris.batch.size', valueType: 'INT' },
+        { key: 'sink.enable-2pc', valueType: 'BOOLEAN' },
+      ],
+    };
+
+    expect(
+      connectorTaskOptionFields(nativeSchema, 'SINK').map(
+        (item) => item.option.key,
+      ),
+    ).toEqual(['sink.enable-2pc']);
+  });
+
   it('validates only visible task-owned required options', () => {
     const errors = validateRequiredConnectorTaskOptions(
       schema(),

--- a/yak-ops-ui/src/pages/integration/batch-link-up/detail/form-schema/connectorTaskOptions.ts
+++ b/yak-ops-ui/src/pages/integration/batch-link-up/detail/form-schema/connectorTaskOptions.ts
@@ -49,16 +49,26 @@ const DATASOURCE_OWNED_KEYS = new Set(
 
 const SOURCE_MANAGED_KEYS = new Set(
   [
+    // JDBC product controls.
     'table_path',
     'table_list',
     'query',
     'where_condition',
     'fetch_size',
+    // Native product controls mapped by connector adapters.
+    'table',
+    'doris.filter.query',
+    'doris.batch.size',
+    'scan_filter',
+    'scan_batch_rows',
+    'filter_query',
+    'batch_size',
   ].map(normalizeLoose),
 );
 
 const SINK_MANAGED_KEYS = new Set(
   [
+    // JDBC product controls.
     'table_path',
     'schema_save_mode',
     'data_save_mode',
@@ -68,6 +78,12 @@ const SINK_MANAGED_KEYS = new Set(
     'batch_size',
     'dirty_data_policy',
     'dirty_data_max_count',
+    // Native product controls mapped by connector adapters.
+    'table',
+    'doris.batch.size',
+    'sink.key-type',
+    'batch_max_rows',
+    'sink.batch_size',
   ].map(normalizeLoose),
 );
 


### PR DESCRIPTION
## Summary

PR 6 of the Yak Ops offline connector adaptation plan.

This PR enables **native bounded single-table offline sync** for:

- Doris
- StarRocks
- ClickHouse

The scope is intentionally limited to `GUIDE_SINGLE`. It does not introduce CDC, realtime semantics, multi-table FAN_OUT, or Elasticsearch.

PR #1023~#1027 already established the profile registry, Worker schema discovery, connector adapter boundary, capability-driven editor, and the first JDBC datasource wave. This PR is the first stage that proves those layers can support a datasource whose **management connection and execution connector are different implementations**.

## What changed

### 1. Native execution profiles for new tasks

The default Offline Sync profiles become:

- `DORIS` -> `doris`
- `STARROCKS` -> `starrocks`
- `CLICKHOUSE` -> `clickhouse`

New tasks persist those canonical lowercase connector IDs at creation time.

### 2. Historical tasks are not silently upgraded

Profile selection and compatibility inference are now explicitly separated.

Definitions that predate durable `connectorId` and only contain historical product labels such as `DORIS`, `STARROCKS`, or `CLICKHOUSE` still resolve to the historical JDBC path.

Explicit canonical connector IDs (`doris`, `starrocks`, `clickhouse`) use the new native adapters.

On the frontend the same split exists:

- `connectorIdForNewDataSourceType()` selects the current native profile for new tasks
- `connectorIdForDataSourceType()` remains the legacy compatibility fallback

Selecting or replacing a concrete datasource instance with the same `dbType` also preserves the task's already-persisted connector ID instead of re-deriving it from `dbType`.

### 3. First-class StarRocks and ClickHouse datasources

Add `STARROCKS` and `CLICKHOUSE` to `DataSourceDbType` and datasource management.

Datasource management stays separate from Offline execution:

- StarRocks management uses its MySQL-compatible query port (`9030`) and the existing MySQL JDBC driver
- ClickHouse management uses `jdbc:clickhouse://host:8123/database`
- Offline execution uses Link-Up native `starrocks` / `clickhouse`

ClickHouse datasource runtime dependencies match yak-link-up:

- `com.clickhouse:clickhouse-jdbc:0.3.2-patch11`
- `com.clickhouse:clickhouse-http-client:0.3.2-patch11`

StarRocks optionally accepts custom FE HTTP `nodeUrls`; when omitted, native execution derives the default `host:8030` from the datasource management host.

Doris keeps the existing datasource plugin. Existing datasources without explicit `fenodes` can use the same fallback to `host:8030`; explicit `fenodes` still wins.

### 4. Doris native single-table adapter

`DorisOfflineSyncConnectorAdapter` translates Yak Ops single-table config to the Link-Up native Doris contract.

Source mapping includes:

- `database`
- `table`
- `doris.filter.query`
- `doris.batch.size`
- execution-time `fenodes`, `query-port`, username and password

Sink mapping includes:

- target database/table
- `doris.batch.size`
- `sink.key-type=DUPLICATE|UNIQUE`

Yak Ops `upsert` maps to `UNIQUE`; native overwrite is rejected.

Link-Up Doris Sink auto-creates missing targets internally. To preserve the Yak Ops `autoCreateTable=false` choice, execution validates that the selected target table already exists before Worker submission. When auto-create is enabled, Link-Up's native behavior remains available.

### 5. StarRocks native single-table adapter

`StarRocksOfflineSyncConnectorAdapter` maps:

Source:

- `database`
- `table`
- `scan_filter`
- `scan_batch_rows`
- execution-time `node_urls`, username/password

Sink:

- database/table
- `batch_max_rows`
- append-only write semantics

The current Link-Up StarRocks native Source requires explicit `schema.fields`. Yak Ops derives it automatically at execution time from the selected datasource Catalog rather than making users duplicate table schema in task configuration.

DECIMAL precision/scale is preserved from Catalog metadata. ARRAY/MAP fields are rejected before Worker submission because the current Link-Up StarRocks parser does not support them.

### 6. ClickHouse native single-table adapter

`ClickHouseOfflineSyncConnectorAdapter` maps:

Source:

- `table_path`
- `filter_query`
- `batch_size`

Sink:

- database/table
- `sink.batch_size`
- append-only write semantics

Datasource connection data is translated immediately before execution to native ClickHouse:

- HTTP endpoint `host` as `host:port`
- username/password
- optional `server_time_zone`
- datasource properties -> `clickhouse.config`

This host shape was checked against Link-Up's current `ClickHouseJdbcClient`: it accepts a plain endpoint such as `host:8123`, prepends `http://` when needed, and then builds the ClickHouse JDBC URL internally. Yak Ops therefore does not pass a nested JDBC URL into the native connector.

### 7. Credential boundary remains intact

All three native adapters follow the PR #1025 invariant:

- logical JobSpec build cannot access `DataSourcePO`
- datasource-owned connection fields are removed from task options during build
- credentials and node endpoints are injected only by `resolveForExecution()` immediately before Worker submission

StarRocks schema discovery is also execution-time metadata and does not move datasource credentials into the logical definition.

### 8. Capability-driven UI now reflects native sink semantics

PR #1026 already hides features absent from Worker capabilities. This PR extends product-managed option filtering for native key names so users do not see duplicate low-level fields such as:

- `table`
- `scan_filter`
- `doris.batch.size`
- `sink.key-type`
- `batch_max_rows`
- `sink.batch_size`

True connector-specific advanced options remain available through the dynamic Schema renderer.

The current native sinks do not implement overwrite:

- Doris: Append + capability-driven Upsert
- StarRocks: Append only
- ClickHouse: Append only

The single-table editor and save-time validation now enforce that instead of waiting for Adapter execution to fail. Historical definitions that already contain an unsupported write mode remain visible with a warning instead of being silently rewritten.

### 9. Multi-table is deliberately blocked for this stage

All three adapters fail fast on non-`GUIDE_SINGLE` jobs.

The create drawer also disables `GUIDE_MULTI` whenever either endpoint uses one of these native profiles, preventing creation of a task that this stage intentionally cannot execute.

PR 7 remains responsible for native multi-table / control-plane FAN_OUT strategy.

## Tests

Added / updated regression coverage for:

- `STARROCKS` and `CLICKHOUSE` first-class datasource types
- ServiceLoader discovery and JDBC management plugin contracts
- StarRocks/ClickHouse datasource URL + normalized native metadata
- new-task native profiles vs historical JDBC inference
- native adapters rejecting `GUIDE_MULTI`
- ClickHouse execution-time HTTP translation
- StarRocks Catalog -> `schema.fields` generation
- DECIMAL precision/scale preservation
- product-managed native Schema option filtering
- native overwrite validation

## Compatibility / non-goals

This PR deliberately does **not**:

- migrate existing tasks to native execution automatically
- implement multi-table FAN_OUT or native multi-table orchestration
- expose Custom SQL for native Sources whose runtime capability does not advertise `CUSTOM_SQL`
- add StarRocks/ClickHouse auto-create or upsert semantics
- implement native overwrite
- add CDC or realtime sync semantics
- add Elasticsearch 7/8
- redesign the existing generic multi-table namespace model

## Validation status

- based directly on current `main` after PR #1027 merge (`ed77fb2f90e6f70e3c48e2ba9ad70325610e4164`)
- final branch is ahead by 1 commit and behind by 0
- final head: `6696defbd21729c5b34cee2c0d611d4d74cb5380`
- GitHub CI #227 completed successfully
- frontend `yarn install --frozen-lockfile` completed successfully
- frontend production `yarn build` / `max build` completed successfully
- Java / Maven packaging was **not executed**: the repository workflow again skipped Java setup, private yak-framework checkout/install and `Package Yak Ops` because `YAK_FRAMEWORK_READ_TOKEN` is not configured
- therefore this PR does not claim a Java compile/test pass from CI; the Java regression tests above are committed but were not executed by the current workflow
- Link-Up ClickHouse `host` translation and Yak Ops `DataSourceCatalogReader.listTables/listColumns` call signatures were additionally checked directly against their current source contracts

## Next stage

PR 7 can build on these adapters to introduce an explicit multi-table strategy instead of teaching the editor database-specific behavior: native multi when the complete connector pair supports it, otherwise control-plane FAN_OUT into child single-table jobs.