### PR TITLE
feat(sync): execute multi-table tasks via native or fan-out strategy

### DIFF
--- a/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-offline/src/main/java/io/yak/ops/business/sync/offline/definition/OfflineDefinitionSupport.java
+++ b/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-offline/src/main/java/io/yak/ops/business/sync/offline/definition/OfflineDefinitionSupport.java
@@ -8,29 +8,45 @@ import io.yak.ops.business.sync.offline.config.ConditionalOnOfflineSyncEnabled;
 import io.yak.ops.business.sync.offline.domain.OfflineJobDefinition;
 import io.yak.ops.business.sync.offline.engine.LinkUpJobSpecFactory;
 import io.yak.ops.business.sync.offline.engine.OfflineDefinitionModelAdapter;
+import io.yak.ops.business.sync.offline.engine.plan.OfflineExecutionPlanFactory;
 import io.yak.ops.common.bean.dto.sync.offline.OfflineJobDefinitionDTO;
 import io.yak.ops.common.bean.po.datasource.DataSourcePO;
 import java.nio.charset.StandardCharsets;
 import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
 import java.util.HexFormat;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.stereotype.Component;
 import org.springframework.util.StringUtils;
 
-/** 离线同步任务定义规范化、JobSpec 构建与运行时凭据解析。 */
+/** 离线同步任务定义规范化、执行策略冻结、JobSpec 构建与运行时凭据解析。 */
 @ConditionalOnOfflineSyncEnabled
 @Component
 public class OfflineDefinitionSupport {
 
   private final LinkUpJobSpecFactory jobSpecFactory;
+  private final OfflineExecutionPlanFactory executionPlanFactory;
   private final ObjectMapper objectMapper;
 
+  @Autowired
   public OfflineDefinitionSupport(
       LinkUpJobSpecFactory jobSpecFactory,
+      OfflineExecutionPlanFactory executionPlanFactory,
       @Qualifier("offlineSyncJsonMapper") ObjectMapper objectMapper) {
     this.jobSpecFactory = jobSpecFactory;
+    this.executionPlanFactory = executionPlanFactory;
     this.objectMapper = objectMapper;
+  }
+
+  /** Keeps focused direct construction source-compatible with the pre-PR7 boundary. */
+  public OfflineDefinitionSupport(
+      LinkUpJobSpecFactory jobSpecFactory,
+      ObjectMapper objectMapper) {
+    this(
+        jobSpecFactory,
+        new OfflineExecutionPlanFactory(jobSpecFactory, objectMapper),
+        objectMapper);
   }
 
   public PreparedDefinition prepare(OfflineJobDefinitionDTO dto) {
@@ -40,7 +56,7 @@ public class OfflineDefinitionSupport {
     String mode = mode(basic);
 
     JsonNode buildRequest = OfflineDefinitionModelAdapter.forJobSpec(request, objectMapper);
-    LinkUpJobSpecFactory.BuildResult result = jobSpecFactory.build(buildRequest);
+    OfflineExecutionPlanFactory.BuildResult result = executionPlanFactory.build(buildRequest);
     DataSourcePO source = result.getSourceDataSource();
     DataSourcePO sink = result.getSinkDataSource();
 
@@ -50,14 +66,14 @@ public class OfflineDefinitionSupport {
         trim(text(basic, "jobDesc", null)),
         mode,
         write(request),
-        result.getJobSpecJson(),
+        result.getLogicalSpecJson(),
         id(source),
         id(sink),
         displayType(source, result.getSourceConnectorId()),
         displayType(sink, result.getSinkConnectorId()),
         result.getSourceTable(),
         result.getSinkTable(),
-        digest(result.getJobSpecJson()));
+        digest(result.getLogicalSpecJson()));
   }
 
   public DraftDefinition prepareDraft(OfflineJobDefinitionDTO dto) {

--- a/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-offline/src/main/java/io/yak/ops/business/sync/offline/engine/connector/adapter/JdbcOfflineSyncConnectorAdapter.java
+++ b/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-offline/src/main/java/io/yak/ops/business/sync/offline/engine/connector/adapter/JdbcOfflineSyncConnectorAdapter.java
@@ -59,6 +59,11 @@ public class JdbcOfflineSyncConnectorAdapter implements OfflineSyncConnectorAdap
   }
 
   @Override
+  public boolean supportsNativeMultiTable(String connectorId, Role role) {
+    return true;
+  }
+
+  @Override
   public BuildResult build(BuildContext context) {
     removeDatasourceOwnedOptions(context.options());
     return context.role() == Role.SOURCE ? buildSource(context) : buildSink(context);

--- a/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-offline/src/main/java/io/yak/ops/business/sync/offline/engine/connector/adapter/OfflineSyncConnectorAdapter.java
+++ b/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-offline/src/main/java/io/yak/ops/business/sync/offline/engine/connector/adapter/OfflineSyncConnectorAdapter.java
@@ -19,6 +19,17 @@ public interface OfflineSyncConnectorAdapter {
 
   boolean requiresDataSource(String connectorId, Role role);
 
+  /**
+   * Whether this Yak Ops adapter can translate GUIDE_MULTI directly for the given Link-Up role.
+   *
+   * <p>This is deliberately an adapter capability rather than a dbType switch. The execution plan
+   * may choose NATIVE_MULTI only when the complete source/sink adapter pair returns true; otherwise
+   * the control plane can FAN_OUT the frozen multi-table definition into single-table JobSpecs.</p>
+   */
+  default boolean supportsNativeMultiTable(String connectorId, Role role) {
+    return false;
+  }
+
   BuildResult build(BuildContext context);
 
   void resolveForExecution(ExecutionContext context);

--- a/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-offline/src/main/java/io/yak/ops/business/sync/offline/engine/plan/OfflineExecutionPlan.java
+++ b/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-offline/src/main/java/io/yak/ops/business/sync/offline/engine/plan/OfflineExecutionPlan.java
@@ -1,0 +1,50 @@
+package io.yak.ops.business.sync.offline.engine.plan;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import java.util.List;
+import java.util.Objects;
+import org.springframework.util.StringUtils;
+
+/** Immutable control-plane plan persisted inside the frozen logical execution snapshot. */
+public record OfflineExecutionPlan(
+    OfflineExecutionStrategy strategy,
+    List<Unit> units) {
+
+  public OfflineExecutionPlan {
+    strategy = Objects.requireNonNull(strategy, "strategy");
+    units = List.copyOf(Objects.requireNonNull(units, "units"));
+    if (strategy == OfflineExecutionStrategy.FAN_OUT && units.isEmpty()) {
+      throw new IllegalArgumentException("FAN_OUT execution plan must contain at least one unit");
+    }
+  }
+
+  public boolean isFanOut() {
+    return strategy == OfflineExecutionStrategy.FAN_OUT;
+  }
+
+  public record Unit(
+      String unitKey,
+      String sourceTable,
+      String sinkTable,
+      JsonNode logicalJobSpec) {
+
+    public Unit {
+      if (!StringUtils.hasText(unitKey)) {
+        throw new IllegalArgumentException("fan-out unitKey must not be blank");
+      }
+      if (!StringUtils.hasText(sourceTable)) {
+        throw new IllegalArgumentException("fan-out sourceTable must not be blank");
+      }
+      if (!StringUtils.hasText(sinkTable)) {
+        throw new IllegalArgumentException("fan-out sinkTable must not be blank");
+      }
+      if (logicalJobSpec == null || !logicalJobSpec.isObject()) {
+        throw new IllegalArgumentException("fan-out logicalJobSpec must be a JSON object");
+      }
+      unitKey = unitKey.trim();
+      sourceTable = sourceTable.trim();
+      sinkTable = sinkTable.trim();
+      logicalJobSpec = logicalJobSpec.deepCopy();
+    }
+  }
+}

--- a/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-offline/src/main/java/io/yak/ops/business/sync/offline/engine/plan/OfflineExecutionPlanCodec.java
+++ b/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-offline/src/main/java/io/yak/ops/business/sync/offline/engine/plan/OfflineExecutionPlanCodec.java
@@ -1,0 +1,121 @@
+package io.yak.ops.business.sync.offline.engine.plan;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ArrayNode;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import io.yak.ops.business.sync.offline.config.ConditionalOnOfflineSyncEnabled;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.stereotype.Component;
+import org.springframework.util.StringUtils;
+
+/** Encodes FAN_OUT as a durable control-plane envelope while leaving direct JobSpecs unchanged. */
+@ConditionalOnOfflineSyncEnabled
+@Component
+public class OfflineExecutionPlanCodec {
+
+  static final String API_VERSION = "yak-ops/v1";
+  static final String KIND = "OfflineExecutionPlan";
+
+  private final ObjectMapper objectMapper;
+
+  public OfflineExecutionPlanCodec(
+      @Qualifier("offlineSyncJsonMapper") ObjectMapper objectMapper) {
+    this.objectMapper = objectMapper;
+  }
+
+  public JsonNode encode(OfflineExecutionPlan plan) {
+    if (plan == null || !plan.isFanOut()) {
+      throw new IllegalArgumentException("Only FAN_OUT plans use the Yak Ops execution-plan envelope");
+    }
+
+    ObjectNode root = objectMapper.createObjectNode();
+    root.put("apiVersion", API_VERSION);
+    root.put("kind", KIND);
+    root.put("strategy", plan.strategy().name());
+    ArrayNode units = root.putArray("units");
+    for (OfflineExecutionPlan.Unit unit : plan.units()) {
+      ObjectNode item = units.addObject();
+      item.put("unitKey", unit.unitKey());
+      item.put("sourceTable", unit.sourceTable());
+      item.put("sinkTable", unit.sinkTable());
+      item.set("jobSpec", unit.logicalJobSpec().deepCopy());
+    }
+    return root;
+  }
+
+  public String encodeJson(OfflineExecutionPlan plan) {
+    return write(encode(plan));
+  }
+
+  public Optional<OfflineExecutionPlan> decode(String value) {
+    if (!StringUtils.hasText(value)) {
+      return Optional.empty();
+    }
+    try {
+      return decode(objectMapper.readTree(value));
+    } catch (JsonProcessingException exception) {
+      throw new IllegalStateException("Offline execution snapshot JSON is corrupted", exception);
+    }
+  }
+
+  public Optional<OfflineExecutionPlan> decode(JsonNode root) {
+    if (root == null || !root.isObject() || !KIND.equals(root.path("kind").asText())) {
+      return Optional.empty();
+    }
+    if (!API_VERSION.equals(root.path("apiVersion").asText())) {
+      throw new IllegalStateException(
+          "Unsupported Offline execution plan apiVersion: " + root.path("apiVersion").asText());
+    }
+
+    OfflineExecutionStrategy strategy;
+    try {
+      strategy = OfflineExecutionStrategy.valueOf(root.path("strategy").asText());
+    } catch (IllegalArgumentException exception) {
+      throw new IllegalStateException(
+          "Unsupported Offline execution strategy: " + root.path("strategy").asText(), exception);
+    }
+    if (strategy != OfflineExecutionStrategy.FAN_OUT) {
+      throw new IllegalStateException(
+          "Yak Ops execution-plan envelope currently only persists FAN_OUT strategy");
+    }
+
+    JsonNode encodedUnits = root.path("units");
+    if (!encodedUnits.isArray() || encodedUnits.isEmpty()) {
+      throw new IllegalStateException("FAN_OUT execution plan contains no units");
+    }
+
+    List<OfflineExecutionPlan.Unit> units = new ArrayList<>();
+    for (JsonNode item : encodedUnits) {
+      String unitKey = requiredText(item, "unitKey");
+      String sourceTable = requiredText(item, "sourceTable");
+      String sinkTable = requiredText(item, "sinkTable");
+      JsonNode jobSpec = item.get("jobSpec");
+      if (jobSpec == null || !jobSpec.isObject()) {
+        throw new IllegalStateException("FAN_OUT unit " + unitKey + " is missing jobSpec");
+      }
+      units.add(new OfflineExecutionPlan.Unit(unitKey, sourceTable, sinkTable, jobSpec));
+    }
+    return Optional.of(new OfflineExecutionPlan(strategy, units));
+  }
+
+  private String requiredText(JsonNode node, String field) {
+    String value = node == null ? null : node.path(field).asText(null);
+    if (!StringUtils.hasText(value)) {
+      throw new IllegalStateException("FAN_OUT unit is missing " + field);
+    }
+    return value.trim();
+  }
+
+  private String write(JsonNode value) {
+    try {
+      return objectMapper.writeValueAsString(value);
+    } catch (JsonProcessingException exception) {
+      throw new IllegalStateException("Failed to serialize Offline execution plan", exception);
+    }
+  }
+}

--- a/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-offline/src/main/java/io/yak/ops/business/sync/offline/engine/plan/OfflineExecutionPlanFactory.java
+++ b/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-offline/src/main/java/io/yak/ops/business/sync/offline/engine/plan/OfflineExecutionPlanFactory.java
@@ -1,0 +1,363 @@
+package io.yak.ops.business.sync.offline.engine.plan;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import io.yak.ops.business.sync.offline.config.ConditionalOnOfflineSyncEnabled;
+import io.yak.ops.business.sync.offline.engine.ConnectorIdResolver;
+import io.yak.ops.business.sync.offline.engine.LinkUpJobSpecFactory;
+import io.yak.ops.business.sync.offline.engine.connector.adapter.OfflineSyncConnectorAdapter;
+import io.yak.ops.business.sync.offline.engine.connector.adapter.OfflineSyncConnectorAdapter.Role;
+import io.yak.ops.business.sync.offline.engine.connector.adapter.OfflineSyncConnectorAdapterRegistry;
+import io.yak.ops.common.bean.po.datasource.DataSourcePO;
+import java.util.ArrayList;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Locale;
+import java.util.Set;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.stereotype.Component;
+import org.springframework.util.StringUtils;
+
+/**
+ * Chooses one durable execution shape without teaching the editor database-specific behavior.
+ *
+ * <p>GUIDE_SINGLE remains one Link-Up JobSpec. GUIDE_MULTI remains a native multi-table JobSpec only
+ * when the complete source/sink adapter pair can translate it. Every other explicit multi-table
+ * selection is frozen as FAN_OUT child single-table JobSpecs.</p>
+ */
+@ConditionalOnOfflineSyncEnabled
+@Component
+public class OfflineExecutionPlanFactory {
+
+  private final LinkUpJobSpecFactory jobSpecFactory;
+  private final OfflineSyncConnectorAdapterRegistry adapterRegistry;
+  private final OfflineExecutionPlanCodec planCodec;
+  private final ObjectMapper objectMapper;
+
+  @Autowired
+  public OfflineExecutionPlanFactory(
+      LinkUpJobSpecFactory jobSpecFactory,
+      OfflineSyncConnectorAdapterRegistry adapterRegistry,
+      OfflineExecutionPlanCodec planCodec,
+      @Qualifier("offlineSyncJsonMapper") ObjectMapper objectMapper) {
+    this.jobSpecFactory = jobSpecFactory;
+    this.adapterRegistry = adapterRegistry;
+    this.planCodec = planCodec;
+    this.objectMapper = objectMapper;
+  }
+
+  /** Convenience constructor for focused tests that only need the established JDBC adapter set. */
+  public OfflineExecutionPlanFactory(
+      LinkUpJobSpecFactory jobSpecFactory,
+      ObjectMapper objectMapper) {
+    this(
+        jobSpecFactory,
+        OfflineSyncConnectorAdapterRegistry.standard(objectMapper),
+        new OfflineExecutionPlanCodec(objectMapper),
+        objectMapper);
+  }
+
+  public BuildResult build(JsonNode definition) {
+    requireObject(definition, "任务定义不能为空");
+    String mode = text(definition.path("basic"), "mode", "GUIDE_SINGLE");
+    if (!"GUIDE_SINGLE".equals(mode) && !"GUIDE_MULTI".equals(mode)) {
+      throw new IllegalArgumentException("离线同步仅支持 GUIDE_SINGLE 和 GUIDE_MULTI 模式");
+    }
+
+    if ("GUIDE_SINGLE".equals(mode)) {
+      return direct(jobSpecFactory.build(definition), OfflineExecutionStrategy.SINGLE);
+    }
+
+    String sourceConnectorId = connectorId(definition.path("source"), "jdbc");
+    String sinkConnectorId = connectorId(definition.path("sink"), "jdbc");
+    OfflineSyncConnectorAdapter sourceAdapter =
+        adapterRegistry.resolve(sourceConnectorId, Role.SOURCE);
+    OfflineSyncConnectorAdapter sinkAdapter =
+        adapterRegistry.resolve(sinkConnectorId, Role.SINK);
+
+    boolean nativeMulti =
+        sourceAdapter.supportsNativeMultiTable(sourceConnectorId, Role.SOURCE)
+            && sinkAdapter.supportsNativeMultiTable(sinkConnectorId, Role.SINK);
+    if (nativeMulti) {
+      return direct(jobSpecFactory.build(definition), OfflineExecutionStrategy.NATIVE_MULTI);
+    }
+    return fanOut(definition, sourceConnectorId, sinkConnectorId);
+  }
+
+  private BuildResult fanOut(
+      JsonNode definition,
+      String sourceConnectorId,
+      String sinkConnectorId) {
+    List<String> sourceTables = sourceTables(endpointConfig(definition, "source"));
+    String targetTemplate =
+        requiredText(
+            endpointConfig(definition, "sink"),
+            "targetTableName",
+            "多表 FAN_OUT 缺少目标表命名模板");
+
+    List<OfflineExecutionPlan.Unit> units = new ArrayList<>();
+    List<String> targetTables = new ArrayList<>();
+    LinkUpJobSpecFactory.BuildResult first = null;
+
+    for (int index = 0; index < sourceTables.size(); index++) {
+      String sourceTable = sourceTables.get(index);
+      String sinkTable = renderTargetTable(targetTemplate, sourceTable);
+      JsonNode childDefinition = singleTableDefinition(definition, sourceTable, sinkTable);
+      LinkUpJobSpecFactory.BuildResult child = jobSpecFactory.build(childDefinition);
+
+      if (!sourceConnectorId.equalsIgnoreCase(child.getSourceConnectorId())
+          || !sinkConnectorId.equalsIgnoreCase(child.getSinkConnectorId())) {
+        throw new IllegalStateException("FAN_OUT child connector identity drifted from frozen definition");
+      }
+      if (first == null) {
+        first = child;
+      }
+
+      String unitKey = String.format(Locale.ROOT, "%04d", index + 1);
+      units.add(
+          new OfflineExecutionPlan.Unit(
+              unitKey,
+              sourceTable,
+              sinkTable,
+              child.getJobSpec()));
+      targetTables.add(sinkTable);
+    }
+
+    if (first == null) {
+      throw new IllegalStateException("FAN_OUT execution plan contains no child JobSpec");
+    }
+
+    OfflineExecutionPlan plan =
+        new OfflineExecutionPlan(OfflineExecutionStrategy.FAN_OUT, units);
+    JsonNode encoded = planCodec.encode(plan);
+    return new BuildResult(
+        encoded,
+        planCodec.encodeJson(plan),
+        first.getSourceDataSource(),
+        first.getSinkDataSource(),
+        sourceConnectorId,
+        sinkConnectorId,
+        write(sourceTables),
+        write(targetTables),
+        OfflineExecutionStrategy.FAN_OUT);
+  }
+
+  private BuildResult direct(
+      LinkUpJobSpecFactory.BuildResult result,
+      OfflineExecutionStrategy strategy) {
+    return new BuildResult(
+        result.getJobSpec(),
+        result.getJobSpecJson(),
+        result.getSourceDataSource(),
+        result.getSinkDataSource(),
+        result.getSourceConnectorId(),
+        result.getSinkConnectorId(),
+        result.getSourceTable(),
+        result.getSinkTable(),
+        strategy);
+  }
+
+  private JsonNode singleTableDefinition(
+      JsonNode definition,
+      String sourceTable,
+      String sinkTable) {
+    ObjectNode child = (ObjectNode) definition.deepCopy();
+    child.with("basic").put("mode", "GUIDE_SINGLE");
+
+    ObjectNode sourceConfig = requireObjectNode(
+        child.path("source").path("config"), "来源端 config 不能为空");
+    sourceConfig.put("table", sourceTable);
+    sourceConfig.remove(List.of("tables", "tablePattern"));
+    removeMultiTableOption(sourceConfig);
+
+    ObjectNode sinkConfig = requireObjectNode(
+        child.path("sink").path("config"), "目标端 config 不能为空");
+    sinkConfig.put("targetTableName", sinkTable);
+    removeMultiTableOption(sinkConfig);
+    return child;
+  }
+
+  private void removeMultiTableOption(ObjectNode config) {
+    JsonNode value = config.get("connectorOptions");
+    if (value != null && value.isObject()) {
+      ((ObjectNode) value).remove("table_list");
+    }
+  }
+
+  private List<String> sourceTables(JsonNode config) {
+    LinkedHashSet<String> result = new LinkedHashSet<>();
+    flattenTables(config.path("tables"), null, result);
+    if (result.isEmpty()) {
+      String pattern = text(config, "tablePattern", null);
+      if (StringUtils.hasText(pattern) && !containsWildcard(pattern)) {
+        result.add(pattern.trim());
+      }
+    }
+    if (result.isEmpty()) {
+      throw new IllegalArgumentException(
+          "多表 FAN_OUT 必须冻结至少一张明确的来源表，当前阶段不直接执行通配符表名");
+    }
+    return new ArrayList<>(result);
+  }
+
+  private void flattenTables(JsonNode value, String namespace, Set<String> result) {
+    if (value == null || value.isNull() || value.isMissingNode()) {
+      return;
+    }
+    if (value.isTextual()) {
+      String table = value.asText().trim();
+      if (StringUtils.hasText(table)) {
+        result.add(
+            StringUtils.hasText(namespace) && !table.contains(".")
+                ? namespace + "." + table
+                : table);
+      }
+      return;
+    }
+    if (value.isArray()) {
+      value.forEach(item -> flattenTables(item, namespace, result));
+      return;
+    }
+    if (value.isObject()) {
+      value.fields().forEachRemaining(
+          entry -> flattenTables(entry.getValue(), entry.getKey(), result));
+    }
+  }
+
+  private String renderTargetTable(String template, String sourceTable) {
+    int separator = sourceTable.lastIndexOf('.');
+    String namespace = separator < 0 ? "" : sourceTable.substring(0, separator);
+    String table = separator < 0 ? sourceTable : sourceTable.substring(separator + 1);
+    return template
+        .replace("${schema_name}", namespace)
+        .replace("${table_name}", table);
+  }
+
+  private JsonNode endpointConfig(JsonNode definition, String endpointName) {
+    JsonNode endpoint = definition.get(endpointName);
+    requireObject(endpoint, endpointName + " 配置不能为空");
+    JsonNode config = endpoint.get("config");
+    requireObject(config, endpointName + " config 不能为空");
+    return config;
+  }
+
+  private String connectorId(JsonNode endpoint, String fallback) {
+    JsonNode config = endpoint.path("config");
+    return ConnectorIdResolver.resolve(
+        text(endpoint, "connectorId", text(config, "connectorId", null)),
+        text(endpoint, "connectorType", text(config, "connectorType", null)),
+        text(endpoint, "dbType", text(config, "dbType", null)),
+        fallback);
+  }
+
+  private String requiredText(JsonNode node, String field, String message) {
+    String value = text(node, field, null);
+    if (!StringUtils.hasText(value)) {
+      throw new IllegalArgumentException(message);
+    }
+    return value.trim();
+  }
+
+  private String text(JsonNode node, String field, String fallback) {
+    JsonNode value = node == null ? null : node.get(field);
+    if (value == null || value.isNull() || !value.isValueNode()) {
+      return fallback;
+    }
+    return value.asText(fallback);
+  }
+
+  private boolean containsWildcard(String value) {
+    return value.contains("*") || value.contains("?") || value.contains("[");
+  }
+
+  private void requireObject(JsonNode node, String message) {
+    if (node == null || !node.isObject()) {
+      throw new IllegalArgumentException(message);
+    }
+  }
+
+  private ObjectNode requireObjectNode(JsonNode node, String message) {
+    requireObject(node, message);
+    return (ObjectNode) node;
+  }
+
+  private String write(Object value) {
+    try {
+      return objectMapper.writeValueAsString(value);
+    } catch (JsonProcessingException exception) {
+      throw new IllegalStateException("序列化多表信息失败", exception);
+    }
+  }
+
+  public static final class BuildResult {
+    private final JsonNode logicalSpec;
+    private final String logicalSpecJson;
+    private final DataSourcePO sourceDataSource;
+    private final DataSourcePO sinkDataSource;
+    private final String sourceConnectorId;
+    private final String sinkConnectorId;
+    private final String sourceTable;
+    private final String sinkTable;
+    private final OfflineExecutionStrategy strategy;
+
+    BuildResult(
+        JsonNode logicalSpec,
+        String logicalSpecJson,
+        DataSourcePO sourceDataSource,
+        DataSourcePO sinkDataSource,
+        String sourceConnectorId,
+        String sinkConnectorId,
+        String sourceTable,
+        String sinkTable,
+        OfflineExecutionStrategy strategy) {
+      this.logicalSpec = logicalSpec;
+      this.logicalSpecJson = logicalSpecJson;
+      this.sourceDataSource = sourceDataSource;
+      this.sinkDataSource = sinkDataSource;
+      this.sourceConnectorId = sourceConnectorId;
+      this.sinkConnectorId = sinkConnectorId;
+      this.sourceTable = sourceTable;
+      this.sinkTable = sinkTable;
+      this.strategy = strategy;
+    }
+
+    public JsonNode getLogicalSpec() {
+      return logicalSpec;
+    }
+
+    public String getLogicalSpecJson() {
+      return logicalSpecJson;
+    }
+
+    public DataSourcePO getSourceDataSource() {
+      return sourceDataSource;
+    }
+
+    public DataSourcePO getSinkDataSource() {
+      return sinkDataSource;
+    }
+
+    public String getSourceConnectorId() {
+      return sourceConnectorId;
+    }
+
+    public String getSinkConnectorId() {
+      return sinkConnectorId;
+    }
+
+    public String getSourceTable() {
+      return sourceTable;
+    }
+
+    public String getSinkTable() {
+      return sinkTable;
+    }
+
+    public OfflineExecutionStrategy getStrategy() {
+      return strategy;
+    }
+  }
+}

--- a/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-offline/src/main/java/io/yak/ops/business/sync/offline/engine/plan/OfflineExecutionStrategy.java
+++ b/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-offline/src/main/java/io/yak/ops/business/sync/offline/engine/plan/OfflineExecutionStrategy.java
@@ -1,0 +1,8 @@
+package io.yak.ops.business.sync.offline.engine.plan;
+
+/** Control-plane execution shape for one frozen Offline Sync definition. */
+public enum OfflineExecutionStrategy {
+  SINGLE,
+  NATIVE_MULTI,
+  FAN_OUT
+}

--- a/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-offline/src/main/java/io/yak/ops/business/sync/offline/execution/OfflineExecutionCoordinator.java
+++ b/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-offline/src/main/java/io/yak/ops/business/sync/offline/execution/OfflineExecutionCoordinator.java
@@ -11,6 +11,7 @@ import io.yak.ops.business.sync.offline.definition.OfflineJobDefinitionService;
 import io.yak.ops.business.sync.offline.domain.OfflineExecutionStatus;
 import io.yak.ops.business.sync.offline.domain.OfflineJobExecution;
 import io.yak.ops.business.sync.offline.domain.core.BatchExecution;
+import io.yak.ops.business.sync.offline.domain.core.BatchScope;
 import io.yak.ops.business.sync.offline.domain.core.BatchStatus;
 import io.yak.ops.business.sync.offline.domain.core.BatchTriggerToken;
 import io.yak.ops.business.sync.offline.engine.LinkUpClient;
@@ -18,16 +19,20 @@ import io.yak.ops.business.sync.offline.engine.LinkUpClient.LinkUpJobResponse;
 import io.yak.ops.business.sync.offline.engine.LinkUpClient.LinkUpNodeResponse;
 import io.yak.ops.business.sync.offline.engine.LinkUpClient.LinkUpRequestException;
 import io.yak.ops.business.sync.offline.engine.LinkUpClient.LinkUpTransportException;
+import io.yak.ops.business.sync.offline.engine.plan.OfflineExecutionPlan;
+import io.yak.ops.business.sync.offline.engine.plan.OfflineExecutionPlanCodec;
 import io.yak.ops.business.sync.offline.execution.adapter.OfflineBatchScopeExecutionAdapter;
 import io.yak.ops.business.sync.offline.repository.OfflineBatchExecutionRepository;
 import io.yak.ops.business.sync.offline.repository.OfflineJobExecutionRepository;
 import java.util.Objects;
+import java.util.Optional;
 import java.util.function.Supplier;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.stereotype.Component;
 import org.springframework.util.StringUtils;
 
-/** Coordinates claim -> frozen scope -> Link-Up submit -> Attempt state application. */
+/** Coordinates claim -> frozen scope/plan -> Link-Up submit -> Attempt state application. */
 @ConditionalOnOfflineSyncEnabled
 @Component
 public class OfflineExecutionCoordinator {
@@ -41,8 +46,11 @@ public class OfflineExecutionCoordinator {
   private final OfflineExecutionStateManager stateManager;
   private final OfflineAuditBridge auditBridge;
   private final LinkUpClient linkUpClient;
+  private final OfflineExecutionPlanCodec executionPlanCodec;
+  private final OfflineFanOutExecutionCoordinator fanOutCoordinator;
   private final ObjectMapper objectMapper;
 
+  @Autowired
   public OfflineExecutionCoordinator(
       OfflineJobDefinitionService definitionService,
       OfflineExecutionClaimManager claimManager,
@@ -53,6 +61,8 @@ public class OfflineExecutionCoordinator {
       OfflineExecutionStateManager stateManager,
       OfflineAuditBridge auditBridge,
       LinkUpClient linkUpClient,
+      OfflineExecutionPlanCodec executionPlanCodec,
+      OfflineFanOutExecutionCoordinator fanOutCoordinator,
       @Qualifier("offlineSyncJsonMapper") ObjectMapper objectMapper) {
     this.definitionService = definitionService;
     this.claimManager = claimManager;
@@ -63,7 +73,42 @@ public class OfflineExecutionCoordinator {
     this.stateManager = stateManager;
     this.auditBridge = auditBridge;
     this.linkUpClient = linkUpClient;
+    this.executionPlanCodec = executionPlanCodec;
+    this.fanOutCoordinator = fanOutCoordinator;
     this.objectMapper = objectMapper;
+  }
+
+  /** Keeps the pre-PR7 focused-test constructor source-compatible. */
+  public OfflineExecutionCoordinator(
+      OfflineJobDefinitionService definitionService,
+      OfflineExecutionClaimManager claimManager,
+      OfflineJobExecutionRepository executionRepository,
+      OfflineBatchExecutionRepository batchRepository,
+      OfflineBatchRuntime batchRuntime,
+      OfflineBatchScopeExecutionAdapter scopeExecutionAdapter,
+      OfflineExecutionStateManager stateManager,
+      OfflineAuditBridge auditBridge,
+      LinkUpClient linkUpClient,
+      ObjectMapper objectMapper) {
+    this(
+        definitionService,
+        claimManager,
+        executionRepository,
+        batchRepository,
+        batchRuntime,
+        scopeExecutionAdapter,
+        stateManager,
+        auditBridge,
+        linkUpClient,
+        new OfflineExecutionPlanCodec(objectMapper),
+        new OfflineFanOutExecutionCoordinator(
+            batchRepository,
+            definitionService,
+            stateManager,
+            linkUpClient,
+            new OfflineExecutionPlanCodec(objectMapper),
+            objectMapper),
+        objectMapper);
   }
 
   public OfflineJobExecution execute(
@@ -118,6 +163,10 @@ public class OfflineExecutionCoordinator {
     if (previous == null || previous.getId() == null) {
       throw new IllegalArgumentException("重试来源实例不能为空");
     }
+    if (fanOutCoordinator.isFanOut(previous)) {
+      throw new IllegalStateException(
+          "FAN_OUT 暂不支持整组 Retry；部分表可能已经远端提交成功，请重新执行任务或后续按失败表重试");
+    }
     return submitClaimIfNeeded(claimManager.claimRetry(previous.getId()));
   }
 
@@ -145,7 +194,9 @@ public class OfflineExecutionCoordinator {
         audit,
         () -> {
           stateManager.markCancellationRequested(execution);
-          if (StringUtils.hasText(execution.getEngineJobId())) {
+          if (fanOutCoordinator.isFanOut(execution)) {
+            fanOutCoordinator.cancel(execution);
+          } else if (StringUtils.hasText(execution.getEngineJobId())) {
             stateManager.applySnapshot(
                 execution,
                 linkUpClient.cancel(execution.getEngineJobId()),
@@ -154,6 +205,16 @@ public class OfflineExecutionCoordinator {
           auditBridge.observeState(execution);
           return execution;
         });
+  }
+
+  public boolean reconcileFanOutIfNeeded(OfflineJobExecution execution) {
+    if (!fanOutCoordinator.isFanOut(execution)) {
+      return false;
+    }
+    AuditOperationHandle audit = auditBridge.ensureOperation(execution);
+    callInAuditContext(audit, () -> fanOutCoordinator.reconcile(execution));
+    auditBridge.observeState(execution);
+    return true;
   }
 
   public void applySnapshot(
@@ -189,6 +250,18 @@ public class OfflineExecutionCoordinator {
 
   private OfflineJobExecution submitClaim(OfflineExecutionClaim claim) {
     OfflineJobExecution execution = claim.getExecution();
+    Optional<OfflineExecutionPlan> plan = executionPlanCodec.decode(claim.getLogicalJobSpecJson());
+    if (plan.isPresent() && plan.get().isFanOut()) {
+      requireFullSelection(execution);
+      stateManager.recordCreated(execution);
+      AuditOperationHandle audit = auditBridge.ensureOperation(execution);
+      OfflineJobExecution result =
+          callInAuditContext(audit, () -> fanOutCoordinator.submit(execution, plan.get()));
+      auditBridge.submitted(execution);
+      auditBridge.observeState(execution);
+      return result;
+    }
+
     String executionJobSpec = resolveScopedExecutionJobSpec(claim);
     stateManager.recordCreated(execution);
     AuditOperationHandle audit = auditBridge.ensureOperation(execution);
@@ -254,6 +327,22 @@ public class OfflineExecutionCoordinator {
               batch.batchScope());
     }
     return definitionService.resolveExecutionJobSpec(logicalJobSpec);
+  }
+
+  private void requireFullSelection(OfflineJobExecution execution) {
+    Long batchId = execution.getBatchId();
+    if (batchId == null || batchId <= 0L) {
+      throw new IllegalStateException("FAN_OUT 执行必须绑定 BatchExecution");
+    }
+    BatchExecution batch =
+        batchRepository
+            .findById(batchId)
+            .orElseThrow(
+                () -> new IllegalStateException("Attempt 绑定的 BatchExecution 不存在：" + batchId));
+    if (!(batch.batchScope() instanceof BatchScope.FullSelection)) {
+      throw new IllegalStateException(
+          "FAN_OUT 当前仅支持 FullSelection；DataWindow / Partition / Cursor scoped Batch 仍保持单表边界");
+    }
   }
 
   private void ensureLatestAttemptForCancel(OfflineJobExecution execution) {

--- a/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-offline/src/main/java/io/yak/ops/business/sync/offline/execution/OfflineFanOutExecutionCoordinator.java
+++ b/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-offline/src/main/java/io/yak/ops/business/sync/offline/execution/OfflineFanOutExecutionCoordinator.java
@@ -1,0 +1,432 @@
+package io.yak.ops.business.sync.offline.execution;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import io.yak.ops.business.sync.offline.config.ConditionalOnOfflineSyncEnabled;
+import io.yak.ops.business.sync.offline.definition.OfflineJobDefinitionService;
+import io.yak.ops.business.sync.offline.domain.OfflineExecutionStatus;
+import io.yak.ops.business.sync.offline.domain.OfflineJobExecution;
+import io.yak.ops.business.sync.offline.domain.core.BatchExecution;
+import io.yak.ops.business.sync.offline.engine.LinkUpClient;
+import io.yak.ops.business.sync.offline.engine.LinkUpClient.LinkUpJobResponse;
+import io.yak.ops.business.sync.offline.engine.LinkUpClient.LinkUpNodeResponse;
+import io.yak.ops.business.sync.offline.engine.LinkUpClient.LinkUpRequestException;
+import io.yak.ops.business.sync.offline.engine.LinkUpClient.LinkUpTransportException;
+import io.yak.ops.business.sync.offline.engine.plan.OfflineExecutionPlan;
+import io.yak.ops.business.sync.offline.engine.plan.OfflineExecutionPlanCodec;
+import io.yak.ops.business.sync.offline.repository.OfflineBatchExecutionRepository;
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Optional;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.stereotype.Component;
+import org.springframework.util.StringUtils;
+
+/** Executes one logical FAN_OUT Attempt as deterministic child single-table Link-Up jobs. */
+@ConditionalOnOfflineSyncEnabled
+@Component
+public class OfflineFanOutExecutionCoordinator {
+
+  private static final String FAN_OUT = "FAN_OUT";
+
+  private final OfflineBatchExecutionRepository batchRepository;
+  private final OfflineJobDefinitionService definitionService;
+  private final OfflineExecutionStateManager stateManager;
+  private final LinkUpClient linkUpClient;
+  private final OfflineExecutionPlanCodec planCodec;
+  private final ObjectMapper objectMapper;
+  private final OfflineFanOutSnapshotAggregator snapshotAggregator;
+
+  public OfflineFanOutExecutionCoordinator(
+      OfflineBatchExecutionRepository batchRepository,
+      OfflineJobDefinitionService definitionService,
+      OfflineExecutionStateManager stateManager,
+      LinkUpClient linkUpClient,
+      OfflineExecutionPlanCodec planCodec,
+      @Qualifier("offlineSyncJsonMapper") ObjectMapper objectMapper) {
+    this.batchRepository = batchRepository;
+    this.definitionService = definitionService;
+    this.stateManager = stateManager;
+    this.linkUpClient = linkUpClient;
+    this.planCodec = planCodec;
+    this.objectMapper = objectMapper;
+    this.snapshotAggregator = new OfflineFanOutSnapshotAggregator(objectMapper);
+  }
+
+  public boolean isFanOut(OfflineJobExecution execution) {
+    return frozenPlan(execution).map(OfflineExecutionPlan::isFanOut).orElse(false);
+  }
+
+  public OfflineJobExecution submit(
+      OfflineJobExecution execution,
+      OfflineExecutionPlan plan) {
+    requireFanOut(plan);
+
+    List<PreparedUnit> prepared;
+    try {
+      // Resolve every child first so schema/target validation cannot create a half-submitted plan.
+      prepared = prepare(plan);
+    } catch (RuntimeException exception) {
+      stateManager.markFailed(execution, safeMessage(exception), false);
+      throw exception;
+    }
+
+    try {
+      LinkUpNodeResponse node = linkUpClient.node();
+      stateManager.bindWorker(execution, node == null ? null : node.getInstanceId());
+      stateManager.markSubmitting(execution);
+    } catch (RuntimeException exception) {
+      stateManager.markFailed(execution, safeMessage(exception), false);
+      throw exception;
+    }
+
+    List<OfflineFanOutUnitState> states = initialStates(execution, plan);
+    // Persist the full child manifest before the first mutating request. From this point onward a
+    // persisted CREATED child truly means that no dispatch intent has been recorded for that unit.
+    applyAggregate(execution, states, "FAN_OUT_PLAN_READY");
+    for (PreparedUnit unit : prepared) {
+      OfflineFanOutUnitState state = requireState(states, unit.unit().unitKey());
+      if (!OfflineExecutionStatus.isCreated(state.status())) {
+        continue;
+      }
+      markDispatching(execution, states, state);
+      submitUnit(execution, unit, state);
+      applyAggregate(execution, states, "FAN_OUT_UNIT_SUBMITTED");
+    }
+    applyAggregate(execution, states, "FAN_OUT_SUBMITTED");
+    return execution;
+  }
+
+  /**
+   * Reconciles every active child. A CREATED child proven absent may be resumed from the frozen
+   * plan. Any child whose previous submission may have reached the Worker is never blindly replayed.
+   */
+  public OfflineJobExecution reconcile(OfflineJobExecution execution) {
+    OfflineExecutionPlan plan = requireFrozenPlan(execution);
+    List<OfflineFanOutUnitState> states = currentStates(execution, plan);
+    Map<String, PreparedUnit> prepared = new LinkedHashMap<>();
+    boolean cancellationRequested = Boolean.TRUE.equals(execution.getCancellationRequested());
+
+    for (OfflineExecutionPlan.Unit unit : plan.units()) {
+      OfflineFanOutUnitState state = requireState(states, unit.unitKey());
+      if (!OfflineExecutionStatus.isActive(state.status())) {
+        continue;
+      }
+
+      // A persisted cancellation intent must never create a new remote write. CREATED is safe to
+      // cancel locally because FAN_OUT records SUBMITTED before every mutating child request.
+      if (cancellationRequested && OfflineExecutionStatus.isCreated(state.status())) {
+        state.apply(state.localResponse(OfflineExecutionStatus.CANCELED, null, null));
+        continue;
+      }
+
+      LinkUpJobResponse response;
+      try {
+        response = queryUnit(state);
+      } catch (LinkUpRequestException exception) {
+        if (exception.getStatusCode() == 404) {
+          state.apply(
+              state.localResponse(
+                  OfflineExecutionStatus.UNKNOWN,
+                  "FAN_OUT_CHILD_NOT_FOUND",
+                  "已提交的 FAN_OUT 子任务暂时无法通过 externalExecutionId 确认"));
+          continue;
+        }
+        throw exception;
+      }
+
+      if (response == null) {
+        if (cancellationRequested) {
+          state.apply(state.localResponse(OfflineExecutionStatus.CANCELED, null, null));
+          continue;
+        }
+        PreparedUnit child =
+            prepared.computeIfAbsent(unit.unitKey(), ignored -> prepare(unit));
+        markDispatching(execution, states, state);
+        submitUnit(execution, child, state);
+      } else {
+        state.apply(normalizeResponse(state, response));
+      }
+
+      if (cancellationRequested
+          && OfflineExecutionStatus.isConfirmedActive(state.status())
+          && StringUtils.hasText(state.engineJobId())) {
+        state.apply(normalizeResponse(state, linkUpClient.cancel(state.engineJobId())));
+      }
+    }
+
+    applyAggregate(execution, states, "FAN_OUT_RECONCILED");
+    return execution;
+  }
+
+  public OfflineJobExecution cancel(OfflineJobExecution execution) {
+    OfflineExecutionPlan plan = requireFrozenPlan(execution);
+    List<OfflineFanOutUnitState> states = currentStates(execution, plan);
+
+    for (OfflineFanOutUnitState state : states) {
+      if (!OfflineExecutionStatus.isActive(state.status())) {
+        continue;
+      }
+
+      if (OfflineExecutionStatus.isCreated(state.status())) {
+        state.apply(state.localResponse(OfflineExecutionStatus.CANCELED, null, null));
+        continue;
+      }
+
+      String jobId = state.engineJobId();
+      if (!StringUtils.hasText(jobId)) {
+        try {
+          LinkUpJobResponse found =
+              linkUpClient.findByExternalExecutionId(state.externalExecutionId());
+          state.apply(normalizeResponse(state, found));
+          jobId = state.engineJobId();
+        } catch (LinkUpRequestException exception) {
+          if (exception.getStatusCode() == 404) {
+            // Non-CREATED means a mutating request may already have reached Link-Up. Preserve that
+            // uncertainty instead of manufacturing a successful cancellation locally.
+            state.apply(
+                state.localResponse(
+                    OfflineExecutionStatus.UNKNOWN,
+                    "FAN_OUT_CANCEL_UNCONFIRMED",
+                    "FAN_OUT 子任务提交状态不确定，取消结果无法确认"));
+            continue;
+          }
+          throw exception;
+        }
+      }
+
+      if (StringUtils.hasText(jobId)
+          && OfflineExecutionStatus.isConfirmedActive(state.status())) {
+        state.apply(normalizeResponse(state, linkUpClient.cancel(jobId)));
+      }
+    }
+
+    applyAggregate(execution, states, "FAN_OUT_CANCELED");
+    return execution;
+  }
+
+  private void markDispatching(
+      OfflineJobExecution execution,
+      List<OfflineFanOutUnitState> states,
+      OfflineFanOutUnitState state) {
+    // This write-ahead state is the crash-safety boundary. Once SUBMITTED is durable, recovery and
+    // cancellation must reconcile by externalExecutionId instead of assuming the child is unsent.
+    state.apply(state.localResponse(OfflineExecutionStatus.SUBMITTED, null, null));
+    applyAggregate(execution, states, "FAN_OUT_UNIT_DISPATCHING");
+  }
+
+  private void submitUnit(
+      OfflineJobExecution execution,
+      PreparedUnit unit,
+      OfflineFanOutUnitState state) {
+    try {
+      LinkUpJobResponse response =
+          linkUpClient.submit(
+              state.externalExecutionId(),
+              state.idempotencyKey(),
+              execution.getDefinitionVersion() == null ? 1 : execution.getDefinitionVersion(),
+              unit.executionJobSpec());
+      state.apply(normalizeResponse(state, response));
+    } catch (LinkUpRequestException exception) {
+      state.apply(
+          state.localResponse(
+              OfflineExecutionStatus.FAILED,
+              exception.getCode(),
+              safeMessage(exception)));
+    } catch (LinkUpTransportException exception) {
+      state.apply(
+          state.localResponse(
+              exception.isUncertain()
+                  ? OfflineExecutionStatus.UNKNOWN
+                  : OfflineExecutionStatus.FAILED,
+              exception.isUncertain()
+                  ? "FAN_OUT_SUBMIT_UNCERTAIN"
+                  : "FAN_OUT_TRANSPORT_FAILED",
+              safeMessage(exception)));
+    } catch (RuntimeException exception) {
+      state.apply(
+          state.localResponse(
+              OfflineExecutionStatus.FAILED,
+              "FAN_OUT_SUBMIT_FAILED",
+              safeMessage(exception)));
+    }
+  }
+
+  /** Returns null only when a CREATED child is proven absent and may be submitted safely. */
+  private LinkUpJobResponse queryUnit(OfflineFanOutUnitState state) {
+    if (StringUtils.hasText(state.engineJobId())) {
+      return linkUpClient.getJob(state.engineJobId());
+    }
+
+    try {
+      return linkUpClient.findByExternalExecutionId(state.externalExecutionId());
+    } catch (LinkUpRequestException exception) {
+      if (exception.getStatusCode() == 404
+          && OfflineExecutionStatus.isCreated(state.status())) {
+        return null;
+      }
+      throw exception;
+    }
+  }
+
+  private List<PreparedUnit> prepare(OfflineExecutionPlan plan) {
+    List<PreparedUnit> prepared = new ArrayList<>();
+    for (OfflineExecutionPlan.Unit unit : plan.units()) {
+      prepared.add(prepare(unit));
+    }
+    return prepared;
+  }
+
+  private PreparedUnit prepare(OfflineExecutionPlan.Unit unit) {
+    String resolved = definitionService.resolveExecutionJobSpec(write(unit.logicalJobSpec()));
+    return new PreparedUnit(unit, parseObject(resolved));
+  }
+
+  private List<OfflineFanOutUnitState> initialStates(
+      OfflineJobExecution execution,
+      OfflineExecutionPlan plan) {
+    List<OfflineFanOutUnitState> states = new ArrayList<>();
+    for (OfflineExecutionPlan.Unit unit : plan.units()) {
+      states.add(OfflineFanOutUnitState.initial(execution, unit, objectMapper));
+    }
+    return states;
+  }
+
+  private List<OfflineFanOutUnitState> currentStates(
+      OfflineJobExecution execution,
+      OfflineExecutionPlan plan) {
+    JsonNode root = read(execution.getEngineSnapshotJson());
+    JsonNode transitions = root == null ? null : root.path("transitions");
+    JsonNode encoded = transitions == null ? null : transitions.path("units");
+    if (transitions == null
+        || !FAN_OUT.equals(transitions.path("strategy").asText())
+        || encoded == null
+        || !encoded.isArray()) {
+      return initialStates(execution, plan);
+    }
+
+    Map<String, OfflineFanOutUnitState> persisted = new LinkedHashMap<>();
+    for (JsonNode item : encoded) {
+      OfflineFanOutUnitState state = OfflineFanOutUnitState.fromJson(item, objectMapper);
+      persisted.put(state.unitKey(), state);
+    }
+
+    List<OfflineFanOutUnitState> states = new ArrayList<>();
+    for (OfflineExecutionPlan.Unit unit : plan.units()) {
+      OfflineFanOutUnitState state = persisted.get(unit.unitKey());
+      if (state == null) {
+        state = OfflineFanOutUnitState.initial(execution, unit, objectMapper);
+      }
+      if (!unit.sourceTable().equals(state.sourceTable())
+          || !unit.sinkTable().equals(state.sinkTable())) {
+        throw new IllegalStateException("FAN_OUT persisted unit no longer matches frozen plan");
+      }
+      states.add(state);
+    }
+    return states;
+  }
+
+  private void applyAggregate(
+      OfflineJobExecution execution,
+      List<OfflineFanOutUnitState> states,
+      String eventType) {
+    stateManager.applySnapshot(execution, snapshotAggregator.aggregate(execution, states), eventType);
+  }
+
+  private LinkUpJobResponse normalizeResponse(
+      OfflineFanOutUnitState state,
+      LinkUpJobResponse response) {
+    LinkUpJobResponse value = response == null ? new LinkUpJobResponse() : response;
+    if (!StringUtils.hasText(value.getExternalExecutionId())) {
+      value.setExternalExecutionId(state.externalExecutionId());
+    }
+    if (!StringUtils.hasText(value.getIdempotencyKey())) {
+      value.setIdempotencyKey(state.idempotencyKey());
+    }
+    if (!StringUtils.hasText(value.getStatus())) {
+      value.setStatus(state.status());
+    }
+    return value;
+  }
+
+  private Optional<OfflineExecutionPlan> frozenPlan(OfflineJobExecution execution) {
+    if (execution == null || execution.getBatchId() == null || execution.getBatchId() <= 0L) {
+      return Optional.empty();
+    }
+    BatchExecution batch = batchRepository.findById(execution.getBatchId()).orElse(null);
+    if (batch == null || !Objects.equals(batch.taskId(), execution.getJobDefinitionId())) {
+      return Optional.empty();
+    }
+    return planCodec.decode(batch.snapshot().logicalJobSpec());
+  }
+
+  private OfflineExecutionPlan requireFrozenPlan(OfflineJobExecution execution) {
+    OfflineExecutionPlan plan =
+        frozenPlan(execution)
+            .orElseThrow(
+                () -> new IllegalStateException("当前 Attempt 不包含 FAN_OUT 冻结执行计划"));
+    requireFanOut(plan);
+    return plan;
+  }
+
+  private void requireFanOut(OfflineExecutionPlan plan) {
+    if (plan == null || !plan.isFanOut()) {
+      throw new IllegalArgumentException("OfflineFanOutExecutionCoordinator 仅接受 FAN_OUT 计划");
+    }
+  }
+
+  private OfflineFanOutUnitState requireState(
+      List<OfflineFanOutUnitState> states,
+      String unitKey) {
+    return states.stream()
+        .filter(state -> state.unitKey().equals(unitKey))
+        .findFirst()
+        .orElseThrow(() -> new IllegalStateException("FAN_OUT unit state missing: " + unitKey));
+  }
+
+  private JsonNode read(String value) {
+    if (!StringUtils.hasText(value)) {
+      return null;
+    }
+    try {
+      return objectMapper.readTree(value);
+    } catch (JsonProcessingException exception) {
+      throw new IllegalStateException("FAN_OUT execution snapshot JSON is corrupted", exception);
+    }
+  }
+
+  private ObjectNode parseObject(String value) {
+    try {
+      JsonNode node = objectMapper.readTree(value);
+      if (node == null || !node.isObject()) {
+        throw new IllegalStateException("FAN_OUT child execution JobSpec must be a JSON object");
+      }
+      return (ObjectNode) node;
+    } catch (JsonProcessingException exception) {
+      throw new IllegalStateException("FAN_OUT child execution JobSpec JSON is corrupted", exception);
+    }
+  }
+
+  private String write(JsonNode value) {
+    try {
+      return objectMapper.writeValueAsString(value);
+    } catch (JsonProcessingException exception) {
+      throw new IllegalStateException("Failed to serialize FAN_OUT child JobSpec", exception);
+    }
+  }
+
+  private String safeMessage(RuntimeException exception) {
+    return exception.getMessage() == null || exception.getMessage().isBlank()
+        ? exception.getClass().getSimpleName()
+        : exception.getMessage();
+  }
+
+  private record PreparedUnit(
+      OfflineExecutionPlan.Unit unit,
+      ObjectNode executionJobSpec) {}
+}

--- a/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-offline/src/main/java/io/yak/ops/business/sync/offline/execution/OfflineFanOutSnapshotAggregator.java
+++ b/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-offline/src/main/java/io/yak/ops/business/sync/offline/execution/OfflineFanOutSnapshotAggregator.java
@@ -1,0 +1,211 @@
+package io.yak.ops.business.sync.offline.execution;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ArrayNode;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import io.yak.ops.business.sync.offline.domain.OfflineExecutionStatus;
+import io.yak.ops.business.sync.offline.domain.OfflineJobExecution;
+import io.yak.ops.business.sync.offline.engine.LinkUpClient.LinkUpJobResponse;
+import java.util.List;
+import org.springframework.util.StringUtils;
+
+/** Builds the one logical parent snapshot exposed by a FAN_OUT Attempt. */
+final class OfflineFanOutSnapshotAggregator {
+
+  private static final String FAN_OUT = "FAN_OUT";
+  private static final String FAN_OUT_RETRY_UNSUPPORTED = "FAN_OUT_RETRY_UNSUPPORTED";
+
+  private final ObjectMapper objectMapper;
+
+  OfflineFanOutSnapshotAggregator(ObjectMapper objectMapper) {
+    this.objectMapper = objectMapper;
+  }
+
+  LinkUpJobResponse aggregate(
+      OfflineJobExecution execution,
+      List<OfflineFanOutUnitState> states) {
+    LinkUpJobResponse response = new LinkUpJobResponse();
+    response.setExternalExecutionId(execution.getExternalExecutionId());
+    response.setIdempotencyKey(execution.getIdempotencyKey());
+    response.setDefinitionVersion(execution.getDefinitionVersion());
+    response.setWorkerInstanceId(firstWorker(states, execution.getWorkerInstanceId()));
+    response.setStatus(aggregateStatus(states).name());
+    response.setStateVersion(value(execution.getStateVersion(), 0L) + 1L);
+    response.setCancellationRequested(Boolean.TRUE.equals(execution.getCancellationRequested()));
+    response.setStartTimeMillis(minPositive(states, "startTimeMillis"));
+    response.setEndTimeMillis(maxPositive(states, "endTimeMillis"));
+    Long start = response.getStartTimeMillis();
+    Long end = response.getEndTimeMillis();
+    response.setDurationMillis(
+        start != null && end != null && end >= start
+            ? end - start
+            : maxPositive(states, "durationMillis"));
+    response.setMetrics(aggregateMetrics(states));
+    response.setCommitSummary(aggregateCommitSummary(states));
+    response.setPipelines(aggregatePipelines(states));
+    response.setTransitions(unitManifest(states));
+
+    long failed =
+        states.stream()
+            .filter(
+                state ->
+                    OfflineExecutionStatus.parse(state.status())
+                        == OfflineExecutionStatus.FAILED)
+            .count();
+    long unknown =
+        states.stream()
+            .filter(
+                state ->
+                    OfflineExecutionStatus.parse(state.status())
+                        == OfflineExecutionStatus.UNKNOWN)
+            .count();
+    if (failed > 0L) {
+      response.setErrorCode(FAN_OUT_RETRY_UNSUPPORTED);
+      response.setErrorMessage(
+          "FAN_OUT 有 " + failed + " 个子任务失败；已成功写入的表不会被自动整组重放");
+    } else if (unknown > 0L) {
+      response.setErrorCode("FAN_OUT_UNIT_UNKNOWN");
+      response.setErrorMessage("FAN_OUT 有 " + unknown + " 个子任务的远端提交状态暂时无法确认");
+    }
+    return response;
+  }
+
+  private OfflineExecutionStatus aggregateStatus(List<OfflineFanOutUnitState> states) {
+    List<OfflineExecutionStatus> statuses =
+        states.stream()
+            .map(OfflineFanOutUnitState::status)
+            .map(OfflineExecutionStatus::parse)
+            .toList();
+
+    if (statuses.contains(OfflineExecutionStatus.UNKNOWN)) {
+      return OfflineExecutionStatus.UNKNOWN;
+    }
+    if (statuses.contains(OfflineExecutionStatus.RUNNING)) {
+      return OfflineExecutionStatus.RUNNING;
+    }
+    if (statuses.contains(OfflineExecutionStatus.QUEUED)) {
+      return OfflineExecutionStatus.QUEUED;
+    }
+    if (statuses.contains(OfflineExecutionStatus.SUBMITTED)
+        || statuses.contains(OfflineExecutionStatus.CREATED)) {
+      return OfflineExecutionStatus.SUBMITTED;
+    }
+    if (statuses.contains(OfflineExecutionStatus.FAILED)) {
+      return OfflineExecutionStatus.FAILED;
+    }
+    if (statuses.contains(OfflineExecutionStatus.CANCELED)) {
+      return OfflineExecutionStatus.CANCELED;
+    }
+    return OfflineExecutionStatus.SUCCEEDED;
+  }
+
+  private ObjectNode aggregateMetrics(List<OfflineFanOutUnitState> states) {
+    ObjectNode metrics = objectMapper.createObjectNode();
+    sum(metrics, states, "sourceRecordCount");
+    sum(metrics, states, "sinkAttemptedRecordCount");
+    sum(metrics, states, "sinkSuccessRecordCount");
+    sum(metrics, states, "sourceReadBytes");
+    sum(metrics, states, "sinkWrittenBytes");
+    sum(metrics, states, "failedRecordCount");
+    sum(metrics, states, "skippedRecordCount");
+    sum(metrics, states, "databaseCommitMillis");
+    sum(metrics, states, "sqlExecutionMillis");
+    sumDecimal(metrics, states, "sourceAverageQps");
+    sumDecimal(metrics, states, "sinkAverageQps");
+    return metrics;
+  }
+
+  private ObjectNode aggregateCommitSummary(List<OfflineFanOutUnitState> states) {
+    ObjectNode commit = objectMapper.createObjectNode();
+    long total = 0L;
+    for (OfflineFanOutUnitState state : states) {
+      total +=
+          state
+              .response()
+              .path("commitSummary")
+              .path("successfullyCommittedRecordCount")
+              .asLong(0L);
+    }
+    commit.put("successfullyCommittedRecordCount", total);
+    return commit;
+  }
+
+  private ArrayNode aggregatePipelines(List<OfflineFanOutUnitState> states) {
+    ArrayNode result = objectMapper.createArrayNode();
+    for (OfflineFanOutUnitState state : states) {
+      JsonNode pipelines = state.response().path("pipelines");
+      if (pipelines.isArray()) {
+        pipelines.forEach(item -> result.add(item.deepCopy()));
+      }
+    }
+    return result;
+  }
+
+  private ObjectNode unitManifest(List<OfflineFanOutUnitState> states) {
+    ObjectNode transitions = objectMapper.createObjectNode();
+    transitions.put("strategy", FAN_OUT);
+    ArrayNode units = transitions.putArray("units");
+    states.forEach(state -> units.add(state.toJson()));
+    return transitions;
+  }
+
+  private void sum(
+      ObjectNode metrics,
+      List<OfflineFanOutUnitState> states,
+      String field) {
+    long total = 0L;
+    for (OfflineFanOutUnitState state : states) {
+      total += state.response().path("metrics").path(field).asLong(0L);
+    }
+    metrics.put(field, total);
+  }
+
+  private void sumDecimal(
+      ObjectNode metrics,
+      List<OfflineFanOutUnitState> states,
+      String field) {
+    double total = 0D;
+    for (OfflineFanOutUnitState state : states) {
+      total += state.response().path("metrics").path(field).asDouble(0D);
+    }
+    metrics.put(field, total);
+  }
+
+  private Long minPositive(List<OfflineFanOutUnitState> states, String field) {
+    Long result = null;
+    for (OfflineFanOutUnitState state : states) {
+      long current = state.response().path(field).asLong(0L);
+      if (current > 0L && (result == null || current < result)) {
+        result = current;
+      }
+    }
+    return result;
+  }
+
+  private Long maxPositive(List<OfflineFanOutUnitState> states, String field) {
+    Long result = null;
+    for (OfflineFanOutUnitState state : states) {
+      long current = state.response().path(field).asLong(0L);
+      if (current > 0L && (result == null || current > result)) {
+        result = current;
+      }
+    }
+    return result;
+  }
+
+  private String firstWorker(
+      List<OfflineFanOutUnitState> states,
+      String fallback) {
+    for (OfflineFanOutUnitState state : states) {
+      if (StringUtils.hasText(state.workerInstanceId())) {
+        return state.workerInstanceId();
+      }
+    }
+    return fallback;
+  }
+
+  private long value(Long value, long fallback) {
+    return value == null ? fallback : value;
+  }
+}

--- a/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-offline/src/main/java/io/yak/ops/business/sync/offline/execution/OfflineFanOutUnitState.java
+++ b/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-offline/src/main/java/io/yak/ops/business/sync/offline/execution/OfflineFanOutUnitState.java
@@ -1,0 +1,178 @@
+package io.yak.ops.business.sync.offline.execution;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import io.yak.ops.business.sync.offline.domain.OfflineExecutionStatus;
+import io.yak.ops.business.sync.offline.domain.OfflineJobExecution;
+import io.yak.ops.business.sync.offline.engine.LinkUpClient.LinkUpJobResponse;
+import io.yak.ops.business.sync.offline.engine.plan.OfflineExecutionPlan;
+import org.springframework.util.StringUtils;
+
+/** Persisted state of one physical Link-Up child inside a logical FAN_OUT Attempt. */
+final class OfflineFanOutUnitState {
+
+  private final String unitKey;
+  private final String sourceTable;
+  private final String sinkTable;
+  private final String externalExecutionId;
+  private final String idempotencyKey;
+  private final ObjectMapper objectMapper;
+  private JsonNode response;
+
+  private OfflineFanOutUnitState(
+      String unitKey,
+      String sourceTable,
+      String sinkTable,
+      String externalExecutionId,
+      String idempotencyKey,
+      JsonNode response,
+      ObjectMapper objectMapper) {
+    this.unitKey = unitKey;
+    this.sourceTable = sourceTable;
+    this.sinkTable = sinkTable;
+    this.externalExecutionId = externalExecutionId;
+    this.idempotencyKey = idempotencyKey;
+    this.response = response;
+    this.objectMapper = objectMapper;
+  }
+
+  static OfflineFanOutUnitState initial(
+      OfflineJobExecution execution,
+      OfflineExecutionPlan.Unit unit,
+      ObjectMapper objectMapper) {
+    String external = execution.getExternalExecutionId() + "-f" + unit.unitKey();
+    String idempotency = execution.getIdempotencyKey() + ":fanout:" + unit.unitKey();
+    ObjectNode response = objectMapper.createObjectNode();
+    response.put("externalExecutionId", external);
+    response.put("idempotencyKey", idempotency);
+    response.put("status", OfflineExecutionStatus.CREATED.name());
+    response.put("stateVersion", 0L);
+    response.set("metrics", objectMapper.createObjectNode());
+    response.set("commitSummary", objectMapper.createObjectNode());
+    response.set("pipelines", objectMapper.createArrayNode());
+    return new OfflineFanOutUnitState(
+        unit.unitKey(),
+        unit.sourceTable(),
+        unit.sinkTable(),
+        external,
+        idempotency,
+        response,
+        objectMapper);
+  }
+
+  static OfflineFanOutUnitState fromJson(JsonNode item, ObjectMapper objectMapper) {
+    String unitKey = requireText(item, "unitKey");
+    String sourceTable = requireText(item, "sourceTable");
+    String sinkTable = requireText(item, "sinkTable");
+    String external = requireText(item, "externalExecutionId");
+    String idempotency = requireText(item, "idempotencyKey");
+    JsonNode response = item.path("response");
+    if (!response.isObject()) {
+      ObjectNode fallback = objectMapper.createObjectNode();
+      fallback.put("externalExecutionId", external);
+      fallback.put("idempotencyKey", idempotency);
+      fallback.put("status", OfflineExecutionStatus.CREATED.name());
+      fallback.put("stateVersion", 0L);
+      fallback.set("metrics", objectMapper.createObjectNode());
+      fallback.set("commitSummary", objectMapper.createObjectNode());
+      fallback.set("pipelines", objectMapper.createArrayNode());
+      response = fallback;
+    } else {
+      response = response.deepCopy();
+    }
+    return new OfflineFanOutUnitState(
+        unitKey,
+        sourceTable,
+        sinkTable,
+        external,
+        idempotency,
+        response,
+        objectMapper);
+  }
+
+  ObjectNode toJson() {
+    ObjectNode item = objectMapper.createObjectNode();
+    item.put("unitKey", unitKey);
+    item.put("sourceTable", sourceTable);
+    item.put("sinkTable", sinkTable);
+    item.put("externalExecutionId", externalExecutionId);
+    item.put("idempotencyKey", idempotencyKey);
+    item.set("response", response.deepCopy());
+    return item;
+  }
+
+  void apply(LinkUpJobResponse value) {
+    if (value != null) {
+      response = objectMapper.valueToTree(value);
+    }
+  }
+
+  LinkUpJobResponse localResponse(
+      OfflineExecutionStatus status,
+      String errorCode,
+      String errorMessage) {
+    LinkUpJobResponse value = new LinkUpJobResponse();
+    value.setExternalExecutionId(externalExecutionId);
+    value.setIdempotencyKey(idempotencyKey);
+    value.setJobId(engineJobId());
+    value.setWorkerInstanceId(workerInstanceId());
+    value.setStatus(status.name());
+    value.setStateVersion(stateVersion() + 1L);
+    value.setCancellationRequested(status == OfflineExecutionStatus.CANCELED);
+    value.setErrorCode(errorCode);
+    value.setErrorMessage(errorMessage);
+    value.setMetrics(objectMapper.createObjectNode());
+    value.setCommitSummary(objectMapper.createObjectNode());
+    value.setPipelines(objectMapper.createArrayNode());
+    return value;
+  }
+
+  String unitKey() {
+    return unitKey;
+  }
+
+  String sourceTable() {
+    return sourceTable;
+  }
+
+  String sinkTable() {
+    return sinkTable;
+  }
+
+  String externalExecutionId() {
+    return externalExecutionId;
+  }
+
+  String idempotencyKey() {
+    return idempotencyKey;
+  }
+
+  JsonNode response() {
+    return response;
+  }
+
+  String engineJobId() {
+    return response.path("jobId").asText(null);
+  }
+
+  String workerInstanceId() {
+    return response.path("workerInstanceId").asText(null);
+  }
+
+  String status() {
+    return response.path("status").asText(OfflineExecutionStatus.CREATED.name());
+  }
+
+  long stateVersion() {
+    return response.path("stateVersion").asLong(0L);
+  }
+
+  private static String requireText(JsonNode node, String field) {
+    String value = node == null ? null : node.path(field).asText(null);
+    if (!StringUtils.hasText(value)) {
+      throw new IllegalStateException("FAN_OUT persisted unit is missing " + field);
+    }
+    return value.trim();
+  }
+}

--- a/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-offline/src/main/java/io/yak/ops/business/sync/offline/execution/OfflineJobExecutionService.java
+++ b/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-offline/src/main/java/io/yak/ops/business/sync/offline/execution/OfflineJobExecutionService.java
@@ -169,6 +169,11 @@ public class OfflineJobExecutionService implements OfflineScheduleExecutionGatew
     return executionLogQuery.logs(executionQuery.require(id), cursor, limit);
   }
 
+  /** Reconciler lets the execution layer own FAN_OUT child discovery/aggregation. */
+  public boolean reconcileFanOutIfNeeded(OfflineJobExecution execution) {
+    return coordinator.reconcileFanOutIfNeeded(execution);
+  }
+
   /** Reconciler enters state application through the stable facade. */
   public void applySnapshot(OfflineJobExecution execution, LinkUpJobResponse response, String type) {
     coordinator.applySnapshot(execution, response, type);

--- a/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-offline/src/main/java/io/yak/ops/business/sync/offline/execution/adapter/OfflineBatchScopeExecutionAdapter.java
+++ b/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-offline/src/main/java/io/yak/ops/business/sync/offline/execution/adapter/OfflineBatchScopeExecutionAdapter.java
@@ -45,6 +45,10 @@ public class OfflineBatchScopeExecutionAdapter implements OfflineExecutionScopeV
     }
 
     ObjectNode root = parseObject(logicalJobSpecJson);
+    if ("OfflineExecutionPlan".equals(root.path("kind").asText())) {
+      throw new IllegalStateException(
+          "FAN_OUT 当前仅支持 FULL_SELECTION BatchScope；DataWindow / Partition / Cursor 不会跨表猜测路由");
+    }
     ObjectNode options = requireScopedSourceOptions(root);
     String predicate = predicate(taskId, options, scope);
     mergeWhereCondition(options, predicate);
@@ -110,10 +114,11 @@ public class OfflineBatchScopeExecutionAdapter implements OfflineExecutionScopeV
               options,
               "partition_column",
               "PartitionScope 需要 source.options.partition_column"));
-      String values = partitions.partitions().stream()
-          .map(this::literal)
-          .reduce((left, right) -> left + ", " + right)
-          .orElseThrow();
+      String values =
+          partitions.partitions().stream()
+              .map(this::literal)
+              .reduce((left, right) -> left + ", " + right)
+              .orElseThrow();
       return column + " IN (" + values + ")";
     }
 

--- a/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-offline/src/main/java/io/yak/ops/business/sync/offline/execution/query/OfflineExecutionQuery.java
+++ b/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-offline/src/main/java/io/yak/ops/business/sync/offline/execution/query/OfflineExecutionQuery.java
@@ -94,16 +94,24 @@ public class OfflineExecutionQuery {
 
   public JsonNode tableMetrics(Long id) {
     OfflineJobExecution execution = require(id);
+    JsonNode snapshot = readEngineSnapshot(execution);
+    JsonNode snapshotPipelines = snapshotPipelines(snapshot);
+
     if (!OfflineExecutionStatus.isActive(execution.getStatus())) {
-      JsonNode snapshotPipelines = snapshotPipelines(execution);
       if (snapshotPipelines.isArray() && !snapshotPipelines.isEmpty()) {
         return OfflinePipelineMetricsMapper.flatten(objectMapper, snapshotPipelines);
       }
     }
 
+    // FAN_OUT has no single parent Link-Up jobId. Its control-plane aggregate snapshot is the live
+    // table-metrics read model and is refreshed by each child submit/reconcile transition.
     if (!StringUtils.hasText(execution.getEngineJobId())) {
+      if (isFanOutSnapshot(snapshot)) {
+        return OfflinePipelineMetricsMapper.flatten(objectMapper, snapshotPipelines);
+      }
       throw new IllegalStateException("当前执行实例尚未获得 Link-Up jobId");
     }
+
     return OfflinePipelineMetricsMapper.flatten(
         objectMapper, linkUpClient.pipelines(execution.getEngineJobId()));
   }
@@ -168,8 +176,12 @@ public class OfflineExecutionQuery {
     }
   }
 
-  private JsonNode snapshotPipelines(OfflineJobExecution execution) {
-    JsonNode snapshot = readEngineSnapshot(execution);
+  private boolean isFanOutSnapshot(JsonNode snapshot) {
+    return snapshot != null
+        && "FAN_OUT".equals(snapshot.path("transitions").path("strategy").asText());
+  }
+
+  private JsonNode snapshotPipelines(JsonNode snapshot) {
     if (snapshot == null) {
       return objectMapper.createArrayNode();
     }

--- a/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-offline/src/main/java/io/yak/ops/business/sync/offline/reconcile/OfflineExecutionReconciler.java
+++ b/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-offline/src/main/java/io/yak/ops/business/sync/offline/reconcile/OfflineExecutionReconciler.java
@@ -96,6 +96,10 @@ public class OfflineExecutionReconciler {
         return;
       }
 
+      if (executionService.reconcileFanOutIfNeeded(execution)) {
+        return;
+      }
+
       LinkUpJobResponse response = queryExecution(execution);
       executionService.applySnapshot(execution, response, "RECONCILED");
       reconcileCancellation(execution, response);

--- a/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-offline/src/test/java/io/yak/ops/business/sync/offline/architecture/OfflineFanOutArchitectureTest.java
+++ b/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-offline/src/test/java/io/yak/ops/business/sync/offline/architecture/OfflineFanOutArchitectureTest.java
@@ -1,0 +1,58 @@
+package io.yak.ops.business.sync.offline.architecture;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.yak.ops.business.sync.offline.execution.OfflineFanOutExecutionCoordinator;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.stream.Stream;
+import org.junit.jupiter.api.Test;
+import org.springframework.stereotype.Component;
+import org.springframework.stereotype.Service;
+
+class OfflineFanOutArchitectureTest {
+
+  @Test
+  void fanOutCoordinatorRemainsAnInternalComponent() {
+    assertThat(OfflineFanOutExecutionCoordinator.class.getAnnotation(Component.class)).isNotNull();
+    assertThat(OfflineFanOutExecutionCoordinator.class.getAnnotation(Service.class)).isNull();
+  }
+
+  @Test
+  void nonExecutionProductionCodeDoesNotImportFanOutCoordinator() throws IOException {
+    Path root = productionRoot();
+    try (Stream<Path> paths = Files.walk(root)) {
+      for (Path file : paths.filter(path -> path.toString().endsWith(".java")).toList()) {
+        String relative = root.relativize(file).toString().replace('\\', '/');
+        if (relative.startsWith("execution/")) {
+          continue;
+        }
+        assertThat(Files.readString(file))
+            .as("%s must enter FAN_OUT through OfflineJobExecutionService", relative)
+            .doesNotContain(
+                "import io.yak.ops.business.sync.offline.execution.OfflineFanOutExecutionCoordinator");
+      }
+    }
+  }
+
+  private Path productionRoot() {
+    Path moduleRoot = Path.of("src/main/java/io/yak/ops/business/sync/offline");
+    if (Files.isDirectory(moduleRoot)) {
+      return moduleRoot;
+    }
+    return Path.of(
+        "yak-ops-business",
+        "yak-ops-business-sync",
+        "yak-ops-business-sync-offline",
+        "src",
+        "main",
+        "java",
+        "io",
+        "yak",
+        "ops",
+        "business",
+        "sync",
+        "offline");
+  }
+}

--- a/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-offline/src/test/java/io/yak/ops/business/sync/offline/engine/plan/OfflineExecutionPlanFactoryTest.java
+++ b/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-offline/src/test/java/io/yak/ops/business/sync/offline/engine/plan/OfflineExecutionPlanFactoryTest.java
@@ -1,0 +1,180 @@
+package io.yak.ops.business.sync.offline.engine.plan;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import io.yak.ops.business.datasource.dao.DataSourceDao;
+import io.yak.ops.business.sync.offline.engine.LinkUpJobSpecFactory;
+import io.yak.ops.business.sync.offline.engine.OfflineDefinitionModelAdapter;
+import io.yak.ops.business.sync.offline.engine.connector.adapter.JdbcOfflineSyncConnectorAdapter;
+import io.yak.ops.business.sync.offline.engine.connector.adapter.OfflineSyncConnectorAdapter;
+import io.yak.ops.business.sync.offline.engine.connector.adapter.OfflineSyncConnectorAdapterRegistry;
+import io.yak.ops.common.bean.po.datasource.DataSourcePO;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+
+class OfflineExecutionPlanFactoryTest {
+
+  private final ObjectMapper mapper = new ObjectMapper();
+
+  @Test
+  void keepsJdbcMultiTableAsOneNativeMultiJobSpec() throws Exception {
+    DataSourceDao dao = mock(DataSourceDao.class);
+    when(dao.selectById(1L)).thenReturn(dataSource(1L, "source"));
+    when(dao.selectById(2L)).thenReturn(dataSource(2L, "sink"));
+
+    OfflineSyncConnectorAdapterRegistry registry =
+        new OfflineSyncConnectorAdapterRegistry(
+            List.of(new JdbcOfflineSyncConnectorAdapter(mapper)));
+    LinkUpJobSpecFactory jobSpecFactory = new LinkUpJobSpecFactory(dao, mapper, registry);
+    OfflineExecutionPlanFactory factory =
+        new OfflineExecutionPlanFactory(
+            jobSpecFactory,
+            registry,
+            new OfflineExecutionPlanCodec(mapper),
+            mapper);
+
+    JsonNode definition =
+        OfflineDefinitionModelAdapter.forJobSpec(
+            publicMultiDefinition("jdbc", "jdbc", true), mapper);
+    OfflineExecutionPlanFactory.BuildResult result = factory.build(definition);
+
+    assertThat(result.getStrategy()).isEqualTo(OfflineExecutionStrategy.NATIVE_MULTI);
+    assertThat(result.getLogicalSpec().path("kind").asText()).isEqualTo("BatchSyncJob");
+    assertThat(
+            result
+                .getLogicalSpec()
+                .path("source")
+                .path("options")
+                .path("table_list")
+                .size())
+        .isEqualTo(2);
+  }
+
+  @Test
+  void freezesFanOutWhenCompleteAdapterPairCannotTranslateNativeMulti() throws Exception {
+    OfflineSyncConnectorAdapter adapter = new SingleOnlySyntheticAdapter();
+    OfflineSyncConnectorAdapterRegistry registry =
+        new OfflineSyncConnectorAdapterRegistry(List.of(adapter));
+    DataSourceDao dao = mock(DataSourceDao.class);
+    LinkUpJobSpecFactory jobSpecFactory = new LinkUpJobSpecFactory(dao, mapper, registry);
+    OfflineExecutionPlanCodec codec = new OfflineExecutionPlanCodec(mapper);
+    OfflineExecutionPlanFactory factory =
+        new OfflineExecutionPlanFactory(jobSpecFactory, registry, codec, mapper);
+
+    JsonNode definition =
+        OfflineDefinitionModelAdapter.forJobSpec(
+            publicMultiDefinition("synthetic", "synthetic", false), mapper);
+    OfflineExecutionPlanFactory.BuildResult result = factory.build(definition);
+    OfflineExecutionPlan plan = codec.decode(result.getLogicalSpecJson()).orElseThrow();
+
+    assertThat(result.getStrategy()).isEqualTo(OfflineExecutionStrategy.FAN_OUT);
+    assertThat(plan.units()).hasSize(2);
+    assertThat(plan.units().get(0).sourceTable()).isEqualTo("business.orders");
+    assertThat(plan.units().get(0).sinkTable()).isEqualTo("ods.orders");
+    assertThat(
+            plan.units()
+                .get(0)
+                .logicalJobSpec()
+                .path("source")
+                .path("options")
+                .path("table_path")
+                .asText())
+        .isEqualTo("business.orders");
+    assertThat(
+            plan.units()
+                .get(1)
+                .logicalJobSpec()
+                .path("sink")
+                .path("options")
+                .path("table_path")
+                .asText())
+        .isEqualTo("ods.order_item");
+  }
+
+  private JsonNode publicMultiDefinition(
+      String sourceConnector, String sinkConnector, boolean withDatasourceIds) throws Exception {
+    String ids =
+        withDatasourceIds
+            ? "\"dataSourceId\":\"1\""
+            : "\"dataSourceId\":\"\"";
+    String sinkIds =
+        withDatasourceIds
+            ? "\"dataSourceId\":\"2\""
+            : "\"dataSourceId\":\"\"";
+    return mapper.readTree(
+        """
+        {
+          "basic": {"jobName":"multi","mode":"GUIDE_MULTI"},
+          "source": {
+            "connectorId":"%s",
+            "dbType":"MYSQL",
+            %s,
+            "database":"business",
+            "tables":["orders","order_item"],
+            "tablePattern":"",
+            "options":{}
+          },
+          "sink": {
+            "connectorId":"%s",
+            "dbType":"MYSQL",
+            %s,
+            "database":"ods",
+            "tableNamingRule":"SAME_NAME",
+            "tablePrefix":"",
+            "tableSuffix":"",
+            "autoCreateTable":false,
+            "writeMode":"APPEND",
+            "options":{}
+          },
+          "channel":{"parallelism":2}
+        }
+        """
+            .formatted(sourceConnector, ids, sinkConnector, sinkIds));
+  }
+
+  private DataSourcePO dataSource(Long id, String name) {
+    DataSourcePO value = new DataSourcePO();
+    value.setId(id);
+    value.setName(name);
+    value.setJdbcUrl("jdbc:mysql://127.0.0.1:3306/demo");
+    value.setConnectionParams(
+        "{\"driver\":\"com.mysql.cj.jdbc.Driver\",\"username\":\"root\",\"password\":\"secret\"}");
+    return value;
+  }
+
+  private static final class SingleOnlySyntheticAdapter implements OfflineSyncConnectorAdapter {
+
+    @Override
+    public boolean supports(String connectorId, Role role) {
+      return "synthetic".equalsIgnoreCase(connectorId);
+    }
+
+    @Override
+    public boolean requiresDataSource(String connectorId, Role role) {
+      return false;
+    }
+
+    @Override
+    public BuildResult build(BuildContext context) {
+      ObjectNode options = context.options();
+      if (context.role() == Role.SOURCE) {
+        String table = context.config().path("table").asText();
+        options.put("table_path", table);
+        return new BuildResult(options, table, List.of(table));
+      }
+      String table = context.config().path("targetTableName").asText();
+      options.put("table_path", table);
+      return new BuildResult(options, table, List.of());
+    }
+
+    @Override
+    public void resolveForExecution(ExecutionContext context) {
+      // No datasource-owned execution fields for the synthetic adapter.
+    }
+  }
+}

--- a/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-offline/src/test/java/io/yak/ops/business/sync/offline/execution/OfflineFanOutExecutionCoordinatorTest.java
+++ b/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-offline/src/test/java/io/yak/ops/business/sync/offline/execution/OfflineFanOutExecutionCoordinatorTest.java
@@ -1,0 +1,279 @@
+package io.yak.ops.business.sync.offline.execution;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.inOrder;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.yak.ops.business.sync.offline.definition.OfflineJobDefinitionService;
+import io.yak.ops.business.sync.offline.domain.OfflineExecutionStatus;
+import io.yak.ops.business.sync.offline.domain.OfflineJobExecution;
+import io.yak.ops.business.sync.offline.domain.core.BatchExecution;
+import io.yak.ops.business.sync.offline.domain.core.BatchKey;
+import io.yak.ops.business.sync.offline.domain.core.BatchScope;
+import io.yak.ops.business.sync.offline.domain.core.BatchStatus;
+import io.yak.ops.business.sync.offline.domain.core.BatchTrigger;
+import io.yak.ops.business.sync.offline.domain.core.ExecutionSnapshot;
+import io.yak.ops.business.sync.offline.domain.core.RetryPolicySnapshot;
+import io.yak.ops.business.sync.offline.engine.LinkUpClient;
+import io.yak.ops.business.sync.offline.engine.LinkUpClient.LinkUpJobResponse;
+import io.yak.ops.business.sync.offline.engine.LinkUpClient.LinkUpNodeResponse;
+import io.yak.ops.business.sync.offline.engine.LinkUpClient.LinkUpRequestException;
+import io.yak.ops.business.sync.offline.engine.plan.OfflineExecutionPlan;
+import io.yak.ops.business.sync.offline.engine.plan.OfflineExecutionPlanCodec;
+import io.yak.ops.business.sync.offline.engine.plan.OfflineExecutionStrategy;
+import io.yak.ops.business.sync.offline.repository.OfflineBatchExecutionRepository;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InOrder;
+
+class OfflineFanOutExecutionCoordinatorTest {
+
+  private final ObjectMapper mapper = new ObjectMapper();
+  private final OfflineBatchExecutionRepository batchRepository =
+      mock(OfflineBatchExecutionRepository.class);
+  private final OfflineJobDefinitionService definitionService =
+      mock(OfflineJobDefinitionService.class);
+  private final OfflineExecutionStateManager stateManager =
+      mock(OfflineExecutionStateManager.class);
+  private final LinkUpClient linkUpClient = mock(LinkUpClient.class);
+  private final OfflineExecutionPlanCodec codec = new OfflineExecutionPlanCodec(mapper);
+
+  private OfflineFanOutExecutionCoordinator coordinator;
+
+  @BeforeEach
+  void setUp() {
+    coordinator =
+        new OfflineFanOutExecutionCoordinator(
+            batchRepository,
+            definitionService,
+            stateManager,
+            linkUpClient,
+            codec,
+            mapper);
+    when(definitionService.resolveExecutionJobSpec(anyString()))
+        .thenAnswer(invocation -> invocation.getArgument(0));
+  }
+
+  @Test
+  void submitsEveryUnitAndAggregatesPartialFailureWithoutParentRetry() throws Exception {
+    OfflineExecutionPlan plan = plan();
+    OfflineJobExecution execution = execution();
+    LinkUpNodeResponse node = new LinkUpNodeResponse();
+    node.setInstanceId("worker-1");
+    when(linkUpClient.node()).thenReturn(node);
+    when(linkUpClient.submit(
+            eq("yak-offline-test-f0001"),
+            eq("idem:fanout:0001"),
+            eq(1),
+            any(JsonNode.class)))
+        .thenReturn(response("job-1", "SUCCEEDED", 10L));
+    when(linkUpClient.submit(
+            eq("yak-offline-test-f0002"),
+            eq("idem:fanout:0002"),
+            eq(1),
+            any(JsonNode.class)))
+        .thenReturn(response("job-2", "FAILED", 0L));
+
+    coordinator.submit(execution, plan);
+
+    ArgumentCaptor<LinkUpJobResponse> snapshots =
+        ArgumentCaptor.forClass(LinkUpJobResponse.class);
+    verify(stateManager, org.mockito.Mockito.atLeastOnce())
+        .applySnapshot(eq(execution), snapshots.capture(), anyString());
+    LinkUpJobResponse aggregate =
+        snapshots.getAllValues().get(snapshots.getAllValues().size() - 1);
+
+    assertThat(aggregate.getStatus()).isEqualTo("FAILED");
+    assertThat(aggregate.getErrorCode()).isEqualTo("FAN_OUT_RETRY_UNSUPPORTED");
+    assertThat(aggregate.getTransitions().path("strategy").asText()).isEqualTo("FAN_OUT");
+    assertThat(aggregate.getTransitions().path("units").size()).isEqualTo(2);
+    assertThat(
+            aggregate
+                .getCommitSummary()
+                .path("successfullyCommittedRecordCount")
+                .asLong())
+        .isEqualTo(10L);
+  }
+
+  @Test
+  void persistsDispatchIntentBeforeFirstRemoteMutation() throws Exception {
+    OfflineExecutionPlan plan = plan();
+    OfflineJobExecution execution = execution();
+    LinkUpNodeResponse node = new LinkUpNodeResponse();
+    node.setInstanceId("worker-1");
+    when(linkUpClient.node()).thenReturn(node);
+    when(linkUpClient.submit(anyString(), anyString(), eq(1), any(JsonNode.class)))
+        .thenReturn(response("job", "SUCCEEDED", 1L));
+
+    coordinator.submit(execution, plan);
+
+    InOrder order = inOrder(stateManager, linkUpClient);
+    order.verify(stateManager)
+        .applySnapshot(
+            eq(execution),
+            any(LinkUpJobResponse.class),
+            eq("FAN_OUT_PLAN_READY"));
+    order.verify(stateManager)
+        .applySnapshot(
+            eq(execution),
+            any(LinkUpJobResponse.class),
+            eq("FAN_OUT_UNIT_DISPATCHING"));
+    order.verify(linkUpClient)
+        .submit(
+            eq("yak-offline-test-f0001"),
+            eq("idem:fanout:0001"),
+            eq(1),
+            any(JsonNode.class));
+  }
+
+  @Test
+  void reconcileFindsDispatchingChildAndOnlyResumesProvenUnsentUnit() throws Exception {
+    OfflineExecutionPlan plan = plan();
+    OfflineJobExecution execution = execution();
+    execution.setEngineSnapshotJson(snapshotWithFirstDispatching(execution, plan));
+    when(batchRepository.findById(77L)).thenReturn(Optional.of(batch(plan)));
+    when(linkUpClient.findByExternalExecutionId("yak-offline-test-f0001"))
+        .thenReturn(response("job-1", "SUCCEEDED", 10L));
+    when(linkUpClient.findByExternalExecutionId("yak-offline-test-f0002"))
+        .thenThrow(new LinkUpRequestException(404, "NOT_FOUND", "missing"));
+    when(linkUpClient.submit(
+            eq("yak-offline-test-f0002"),
+            eq("idem:fanout:0002"),
+            eq(1),
+            any(JsonNode.class)))
+        .thenReturn(response("job-2", "SUCCEEDED", 20L));
+
+    coordinator.reconcile(execution);
+
+    verify(linkUpClient, never())
+        .submit(
+            eq("yak-offline-test-f0001"),
+            eq("idem:fanout:0001"),
+            eq(1),
+            any(JsonNode.class));
+    verify(linkUpClient)
+        .submit(
+            eq("yak-offline-test-f0002"),
+            eq("idem:fanout:0002"),
+            eq(1),
+            any(JsonNode.class));
+
+    ArgumentCaptor<LinkUpJobResponse> snapshots =
+        ArgumentCaptor.forClass(LinkUpJobResponse.class);
+    verify(stateManager)
+        .applySnapshot(eq(execution), snapshots.capture(), eq("FAN_OUT_RECONCILED"));
+    assertThat(snapshots.getValue().getStatus()).isEqualTo("SUCCEEDED");
+    assertThat(
+            snapshots
+                .getValue()
+                .getCommitSummary()
+                .path("successfullyCommittedRecordCount")
+                .asLong())
+        .isEqualTo(30L);
+  }
+
+  @Test
+  void reconcileNeverSubmitsCreatedChildrenAfterCancellationIntent() throws Exception {
+    OfflineExecutionPlan plan = plan();
+    OfflineJobExecution execution = execution();
+    execution.setCancellationRequested(true);
+    when(batchRepository.findById(77L)).thenReturn(Optional.of(batch(plan)));
+
+    coordinator.reconcile(execution);
+
+    verify(linkUpClient, never())
+        .submit(anyString(), anyString(), eq(1), any(JsonNode.class));
+    verify(linkUpClient, never()).findByExternalExecutionId(anyString());
+
+    ArgumentCaptor<LinkUpJobResponse> snapshots =
+        ArgumentCaptor.forClass(LinkUpJobResponse.class);
+    verify(stateManager)
+        .applySnapshot(eq(execution), snapshots.capture(), eq("FAN_OUT_RECONCILED"));
+    assertThat(snapshots.getValue().getStatus()).isEqualTo("CANCELED");
+    assertThat(snapshots.getValue().getTransitions().path("units").size()).isEqualTo(2);
+  }
+
+  private String snapshotWithFirstDispatching(
+      OfflineJobExecution execution,
+      OfflineExecutionPlan plan) throws Exception {
+    List<OfflineFanOutUnitState> states = new ArrayList<>();
+    for (OfflineExecutionPlan.Unit unit : plan.units()) {
+      states.add(OfflineFanOutUnitState.initial(execution, unit, mapper));
+    }
+    OfflineFanOutUnitState first = states.get(0);
+    first.apply(first.localResponse(OfflineExecutionStatus.SUBMITTED, null, null));
+    return mapper.writeValueAsString(
+        new OfflineFanOutSnapshotAggregator(mapper).aggregate(execution, states));
+  }
+
+  private OfflineExecutionPlan plan() throws Exception {
+    JsonNode first =
+        mapper.readTree(
+            """
+            {"apiVersion":"link-up/v1","kind":"BatchSyncJob","source":{"options":{}},"sink":{"options":{}}}
+            """);
+    JsonNode second = first.deepCopy();
+    return new OfflineExecutionPlan(
+        OfflineExecutionStrategy.FAN_OUT,
+        List.of(
+            new OfflineExecutionPlan.Unit("0001", "business.orders", "ods.orders", first),
+            new OfflineExecutionPlan.Unit(
+                "0002", "business.order_item", "ods.order_item", second)));
+  }
+
+  private OfflineJobExecution execution() {
+    OfflineJobExecution execution = new OfflineJobExecution();
+    execution.setId(99L);
+    execution.setBatchId(77L);
+    execution.setJobDefinitionId(10L);
+    execution.setDefinitionVersion(1);
+    execution.setExternalExecutionId("yak-offline-test");
+    execution.setIdempotencyKey("idem");
+    execution.setStatus("CREATED");
+    execution.setStateVersion(1L);
+    execution.setCancellationRequested(false);
+    return execution;
+  }
+
+  private BatchExecution batch(OfflineExecutionPlan plan) {
+    return new BatchExecution(
+        77L,
+        10L,
+        BatchKey.manual("fanout-test"),
+        BatchTrigger.MANUAL,
+        BatchScope.fullSelection(),
+        new ExecutionSnapshot(
+            "{}",
+            1,
+            new RetryPolicySnapshot(3, 1),
+            "digest",
+            codec.encodeJson(plan)),
+        BatchStatus.RUNNING,
+        List.of());
+  }
+
+  private LinkUpJobResponse response(String jobId, String status, long committed) {
+    LinkUpJobResponse response = new LinkUpJobResponse();
+    response.setJobId(jobId);
+    response.setWorkerInstanceId("worker-1");
+    response.setStatus(status);
+    response.setStateVersion(2L);
+    response.setMetrics(mapper.createObjectNode());
+    response.setPipelines(mapper.createArrayNode());
+    response.setCommitSummary(
+        mapper.createObjectNode().put("successfullyCommittedRecordCount", committed));
+    return response;
+  }
+}

--- a/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-offline/src/test/java/io/yak/ops/business/sync/offline/execution/adapter/OfflineBatchScopeExecutionAdapterTest.java
+++ b/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-offline/src/test/java/io/yak/ops/business/sync/offline/execution/adapter/OfflineBatchScopeExecutionAdapterTest.java
@@ -19,11 +19,13 @@ class OfflineBatchScopeExecutionAdapterTest {
 
   @Test
   void dataWindowProjectsToWhereConditionWithoutChangingDomainScope() {
-    String scoped = adapter.apply(
-        10L,
-        logicalJobSpec("tenant_id = 7"),
-        BatchScope.dataWindow(
-            LocalDateTime.of(2026, 8, 1, 0, 0), LocalDateTime.of(2026, 8, 2, 0, 0)));
+    String scoped =
+        adapter.apply(
+            10L,
+            logicalJobSpec("tenant_id = 7"),
+            BatchScope.dataWindow(
+                LocalDateTime.of(2026, 8, 1, 0, 0),
+                LocalDateTime.of(2026, 8, 2, 0, 0)));
     assertThat(scoped).contains("tenant_id = 7");
     assertThat(scoped).contains("updated_at >= '2026-08-01 00:00'");
     assertThat(scoped).contains("updated_at < '2026-08-02 00:00'");
@@ -32,10 +34,11 @@ class OfflineBatchScopeExecutionAdapterTest {
   @Test
   void cursorRangeUsesCursorRouteInsteadOfTreatingCursorIdAsColumn() {
     when(cursorGateway.requireSourceColumn(10L, "orders-watermark")).thenReturn("updated_at");
-    String scoped = adapter.apply(
-        10L,
-        logicalJobSpec(null),
-        BatchScope.cursorRange("orders-watermark", "100", "200"));
+    String scoped =
+        adapter.apply(
+            10L,
+            logicalJobSpec(null),
+            BatchScope.cursorRange("orders-watermark", "100", "200"));
     assertThat(scoped).contains("updated_at > '100'");
     assertThat(scoped).contains("updated_at <= '200'");
   }
@@ -50,8 +53,29 @@ class OfflineBatchScopeExecutionAdapterTest {
         .hasMessageContaining("单表");
   }
 
+  @Test
+  void scopedBatchRejectsFanOutEnvelopeBeforeTryingToInterpretOneChildRoute() {
+    String logical =
+        "{\"apiVersion\":\"yak-ops/v1\",\"kind\":\"OfflineExecutionPlan\",\"strategy\":\"FAN_OUT\",\"units\":[]}";
+
+    assertThatThrownBy(
+            () ->
+                adapter.validate(
+                    10L,
+                    logical,
+                    BatchScope.dataWindow(
+                        LocalDateTime.of(2026, 8, 1, 0, 0),
+                        LocalDateTime.of(2026, 8, 2, 0, 0))))
+        .isInstanceOf(IllegalStateException.class)
+        .hasMessageContaining("FAN_OUT")
+        .hasMessageContaining("FULL_SELECTION");
+  }
+
   private String logicalJobSpec(String whereCondition) {
-    String where = whereCondition == null ? "" : ",\"where_condition\":\"" + whereCondition + "\"";
+    String where =
+        whereCondition == null
+            ? ""
+            : ",\"where_condition\":\"" + whereCondition + "\"";
     return "{\"kind\":\"BatchSyncJob\",\"source\":{\"connectorId\":\"jdbc\",\"options\":{\"table_path\":\"orders\",\"partition_column\":\"updated_at\""
         + where
         + "}},\"sink\":{}}";

--- a/yak-ops-ui/src/pages/integration/batch-link-up/components/CreateSyncTaskDrawer.tsx
+++ b/yak-ops-ui/src/pages/integration/batch-link-up/components/CreateSyncTaskDrawer.tsx
@@ -69,7 +69,6 @@ interface ConnectorOption {
 }
 
 const DEFAULT_DB_TYPE = 'MYSQL';
-const NATIVE_SINGLE_ONLY_CONNECTORS = new Set(['doris', 'starrocks', 'clickhouse']);
 
 const brandCssVariables = {
   '--yak-brand-color': BRAND_COLOR,
@@ -113,11 +112,6 @@ export default function CreateSyncTaskDrawer({
 
   const sourceDbType = Form.useWatch('sourceDbType', form);
   const targetDbType = Form.useWatch('targetDbType', form);
-  const sourceConnectorId = connectorIdForNewDataSourceType(sourceDbType, 'SOURCE');
-  const targetConnectorId = connectorIdForNewDataSourceType(targetDbType, 'SINK');
-  const nativeSingleOnly =
-    NATIVE_SINGLE_ONLY_CONNECTORS.has(sourceConnectorId) ||
-    NATIVE_SINGLE_ONLY_CONNECTORS.has(targetConnectorId);
 
   const modeOptions: Array<{
     value: SyncMode;
@@ -137,13 +131,10 @@ export default function CreateSyncTaskDrawer({
     {
       value: 'GUIDE_MULTI',
       title: intl.formatMessage({ id: 'pages.batchLinkUp.create.mode.multi' }),
-      description: nativeSingleOnly
-        ? '当前选择的 Native Connector 本阶段仅开放单表离线同步'
-        : intl.formatMessage({
-            id: 'pages.batchLinkUp.create.mode.multiDescription',
-          }),
+      description: intl.formatMessage({
+        id: 'pages.batchLinkUp.create.mode.multiDescription',
+      }),
       icon: <DatabaseOutlined />,
-      disabled: nativeSingleOnly,
     },
   ];
 
@@ -180,12 +171,6 @@ export default function CreateSyncTaskDrawer({
     });
   }, [connectorOptions, form, open]);
 
-  useEffect(() => {
-    if (nativeSingleOnly && form.getFieldValue('mode') === 'GUIDE_MULTI') {
-      form.setFieldValue('mode', 'GUIDE_SINGLE');
-    }
-  }, [form, nativeSingleOnly]);
-
   const updateAutoJobName = (side: 'source' | 'target', value: string) => {
     const nextSourceDbType =
       side === 'source' ? value : form.getFieldValue('sourceDbType') || '';
@@ -220,13 +205,6 @@ export default function CreateSyncTaskDrawer({
       const values = await form.validateFields();
       const source = resolveEndpoint(values.sourceDbType, connectorOptions, 'SOURCE');
       const sink = resolveEndpoint(values.targetDbType, connectorOptions, 'SINK');
-      if (
-        values.mode === 'GUIDE_MULTI' &&
-        (NATIVE_SINGLE_ONLY_CONNECTORS.has(source.connectorId) ||
-          NATIVE_SINGLE_ONLY_CONNECTORS.has(sink.connectorId))
-      ) {
-        throw new Error('当前选择的 Native Connector 本阶段仅支持单表离线同步');
-      }
 
       const normalizedValues: CreateSyncTaskValues = {
         jobName: values.jobName.trim(),


### PR DESCRIPTION
## Summary

PR 7 of the Yak Ops offline connector adaptation plan.

PR #1028 enabled bounded native single-table execution for Doris, StarRocks and ClickHouse while deliberately blocking `GUIDE_MULTI`. This PR removes that database-specific creation block and introduces an explicit control-plane multi-table execution strategy:

```text
GUIDE_SINGLE
  -> SINGLE

GUIDE_MULTI
  + complete source/sink adapter pair can translate multi-table directly
  -> NATIVE_MULTI

GUIDE_MULTI
  + otherwise
  -> FAN_OUT into frozen child single-table JobSpecs
```

The scope stays offline/bounded. It does not add CDC, realtime semantics, a new connector, or database-specific multi-table orchestration.

## What changed

### 1. Explicit execution-plan boundary

Add `OfflineExecutionStrategy`, `OfflineExecutionPlan`, `OfflineExecutionPlanCodec` and `OfflineExecutionPlanFactory` under the engine boundary.

The planner owns execution shape; `LinkUpJobSpecFactory` continues to own exactly one Link-Up JobSpec construction and does not regain orchestration logic.

`GUIDE_SINGLE` and direct multi-table JobSpecs keep the existing Link-Up JobSpec persistence format. `FAN_OUT` uses a small Yak Ops execution-plan envelope containing frozen child logical JobSpecs.

This means an already-published task does not get re-planned from future connector behavior at execution time.

### 2. Adapter capability instead of dbType branching

`OfflineSyncConnectorAdapter` gains `supportsNativeMultiTable(connectorId, role)` with a conservative default of `false`.

`JdbcOfflineSyncConnectorAdapter` declares the established JDBC multi-table translation for both SOURCE and SINK.

The planner chooses direct multi only when the complete source/sink adapter pair opts in. Doris / StarRocks / ClickHouse keep their PR #1028 single-table adapter boundary and therefore naturally use FAN_OUT without any `if (DORIS)` / `if (STARROCKS)` / `if (CLICKHOUSE)` branches.

Future connectors can opt into native multi without changing the planner or editor.

### 3. FAN_OUT freezes child single-table JobSpecs

For an explicit multi-table selection the planner expands the target naming template once and freezes one credential-free logical child JobSpec per table:

```text
one Yak Ops logical execution
  -> table A -> target A
  -> table B -> target B
  -> table C -> target C
```

Each child is still built through the existing `LinkUpJobSpecFactory`, so connector adapters remain the only connector-option translation boundary.

Unresolved wildcard-only selections are deliberately rejected. A FAN_OUT plan must contain concrete table identities so recovery never expands to a different table set later.

### 4. Credentials remain execution-time only

The frozen FAN_OUT envelope persists logical child JobSpecs only.

Before any child is submitted, all child JobSpecs are resolved through the existing execution-time adapter path. DataSource credentials/endpoints therefore remain outside the persisted task definition and frozen Batch snapshot.

All children are pre-resolved before the first remote submit so a local schema/target validation failure cannot create a half-submitted plan.

### 5. Deterministic child identity + write-ahead dispatch evidence

A parent Attempt remains the product-visible logical execution. Physical Link-Up children use deterministic identities derived from the parent Attempt and frozen unit key:

```text
externalExecutionId: <parent>-f0001
idempotencyKey:      <parent-key>:fanout:0001
```

Child state is persisted inside the parent's engine snapshot `transitions.units` rather than introducing another execution table.

Before the first mutating child request, the complete child manifest is persisted. Immediately before each `submit`, that child is persisted as `SUBMITTED` (`FAN_OUT_UNIT_DISPATCHING`). This creates a write-ahead crash boundary:

- durable `CREATED` means no dispatch intent was recorded for that child
- durable `SUBMITTED` / `UNKNOWN` means the mutating request may have reached Link-Up and must be reconciled by external id rather than replayed blindly

Reconciliation behavior is conservative:

- known `jobId` -> query that child directly
- no `jobId` -> find by deterministic `externalExecutionId`
- `CREATED` + confirmed 404 -> safe to submit the frozen child
- a child whose mutating submit may already have reached Link-Up is never blindly replayed
- uncertain children remain `UNKNOWN` until their remote state can be confirmed

This covers both crash windows: before remote submit and after remote acceptance but before the next local response snapshot.

### 6. Parent state / metrics aggregation

`OfflineFanOutSnapshotAggregator` produces one logical parent snapshot from all children.

It aggregates:

- terminal/active status
- source/sink record counts
- read/write bytes
- failed/skipped records
- average source/sink QPS
- database/SQL timing
- committed record count
- child pipelines
- durable child identity/state evidence under `transitions.units`

Active FAN_OUT table metrics read from this aggregate snapshot because there is intentionally no fake parent Link-Up `jobId`. Normal single-job pre-submit behavior remains unchanged.

### 7. Cancellation stays conservative

Parent cancellation is propagated to known active children.

A durable `CREATED` child can be canceled locally without remote submission because dispatch intent is written before every mutating request. Reconciliation also checks persisted cancellation intent before safe-resume submission, so restart recovery does not create a new child write after cancellation.

If a previously dispatching/submitted/uncertain child cannot be found while canceling, the control plane keeps it `UNKNOWN` instead of manufacturing a successful cancellation.

### 8. Whole-plan automatic retry is intentionally disabled

A FAN_OUT failure uses the non-retryable code `FAN_OUT_RETRY_UNSUPPORTED`.

This is deliberate: another child may already have committed rows remotely. Automatically replaying the complete logical task would manufacture duplicate-write risk for append-style sinks such as StarRocks / ClickHouse.

The current stage supports reconciliation and cancellation, but not automatic failed-table-only retry. That can be designed later against persisted child evidence.

### 9. Scoped Batch boundary stays explicit

FAN_OUT currently accepts only `FullSelection` Batch scope.

`DataWindow`, `PartitionScope` and `CursorRange` are rejected before materialization/execution instead of applying one range blindly to heterogeneous child tables. Existing scoped Batch V1 remains single-table/JDBC-bound.

### 10. UI no longer hard-codes native single-table connector names

The create drawer no longer disables `GUIDE_MULTI` for Doris / StarRocks / ClickHouse and no longer contains a native-single-only connector list.

The editor selects the product mode; the backend execution planner owns whether that mode becomes direct multi or FAN_OUT.

## Tests

Added focused coverage for:

- JDBC GUIDE_MULTI remains one direct `NATIVE_MULTI` JobSpec
- a connector pair without native multi support freezes a FAN_OUT plan
- source/target table expansion produces independent child single-table JobSpecs
- partial FAN_OUT failure aggregates to parent failure and uses the non-retryable boundary
- complete child manifest + per-child dispatch intent are persisted before remote mutation
- crash recovery finds a dispatching/already-submitted child by deterministic external id
- only a durable `CREATED` child proven absent is safely resumed
- persisted cancellation intent never submits a previously unsubmitted child
- non-FullSelection BatchScope rejects the FAN_OUT envelope explicitly
- FAN_OUT execution stays an internal Component and background entrypoints continue through the stable execution facade

Existing single-table behavior remains on the original execution path.

## Compatibility / non-goals

This PR deliberately does **not**:

- add a new datasource or connector
- change Doris / StarRocks / ClickHouse single-table adapter semantics
- add database-specific multi-table branches
- move FAN_OUT orchestration into `LinkUpJobSpecFactory`
- add a new child-execution persistence table
- auto-retry a partially committed FAN_OUT plan
- implement failed-table-only retry yet
- aggregate physical child Link-Up remote log streams into one synthetic remote log
- enable wildcard expansion at execution time
- apply DataWindow / Partition / Cursor scopes across FAN_OUT children
- add Elasticsearch
- add CDC / realtime / RowKind semantics

## Validation status

- based directly on current `main` after PR #1028 merge (`265bfa6e1e9796bf3b3617e406a763e1e9a120c0`)
- branch is ahead by 1 focused commit and behind by 0
- final head: `c27bbc844703be65128a20b2a9ad9eefde3cfa68`
- focused unit/architecture tests are committed for planning, write-ahead dispatch evidence, aggregation, crash recovery, cancellation and scoped-Batch boundaries
- GitHub Actions CI #236 completed successfully
- frontend `yarn install --frozen-lockfile` completed successfully
- frontend production `yarn build` / `max build` completed successfully
- Java / Maven packaging was **not executed**: the workflow detected that Yak Framework access was unavailable and skipped Java 21 setup, private yak-framework checkout/install and `Package Yak Ops`
- therefore this PR does not claim a Java compile/test pass from CI; the Java regression tests above are committed but were not executed by the current workflow
- a local Maven run is also not claimed because this execution environment cannot clone/download the repository dependencies required for the private framework build

## Next stage

PR 8 can add Elasticsearch 7 / 8 control-plane support once the Link-Up runtime packaging/isolation boundary allows the two versioned Elasticsearch connectors to be loaded safely.