### PR TITLE
feat(sync): enable Elasticsearch 7 and 8 single-index connectors

### DIFF
--- a/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-offline/src/main/java/io/yak/ops/business/sync/offline/engine/OfflineDefinitionModelAdapter.java
+++ b/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-offline/src/main/java/io/yak/ops/business/sync/offline/engine/OfflineDefinitionModelAdapter.java
@@ -44,6 +44,23 @@ public final class OfflineDefinitionModelAdapter {
       "connection_check_timeout_sec",
       "connect_timeout_ms",
       "socket_timeout_ms");
+  private static final Set<String> ELASTICSEARCH_DATASOURCE_OWNED_FIELDS = Set.of(
+      "url",
+      "endpoint",
+      "hosts",
+      "host",
+      "hostname",
+      "scheme",
+      "protocol",
+      "port",
+      "username",
+      "user",
+      "password",
+      "passwd",
+      "connectionParams",
+      "connection_params",
+      "connect_timeout_ms",
+      "socket_timeout_ms");
 
   private static final List<String> SOURCE_FIELDS = List.of(
       "database",
@@ -88,8 +105,8 @@ public final class OfflineDefinitionModelAdapter {
   }
 
   /**
-   * 清理 JDBC 数据源负责维护的连接字段，防止凭据进入 definition_json。
-   * 非 JDBC Connector 的 options 不做处理。
+   * 清理由数据源负责维护的连接字段，防止凭据进入 definition_json。
+   * 非数据源拥有的 Task Connector options 保持原样。
    */
   public static void sanitizeForPersistence(ObjectNode definition) {
     if (definition == null) {
@@ -115,28 +132,40 @@ public final class OfflineDefinitionModelAdapter {
     } catch (IllegalArgumentException ignored) {
       return;
     }
-    if (!ConnectorIdResolver.isJdbc(connectorId)) {
+    Set<String> datasourceOwnedFields = datasourceOwnedFields(connectorId);
+    if (datasourceOwnedFields.isEmpty()) {
       return;
     }
 
-    removeDatasourceOwnedFields(endpoint);
+    removeDatasourceOwnedFields(endpoint, datasourceOwnedFields);
     JsonNode options = endpoint.get("options");
     if (options != null && options.isObject()) {
-      removeDatasourceOwnedFields((ObjectNode) options);
+      removeDatasourceOwnedFields((ObjectNode) options, datasourceOwnedFields);
     }
     JsonNode config = endpoint.get("config");
     if (config != null && config.isObject()) {
       ObjectNode configObject = (ObjectNode) config;
-      removeDatasourceOwnedFields(configObject);
+      removeDatasourceOwnedFields(configObject, datasourceOwnedFields);
       JsonNode connectorOptions = configObject.get("connectorOptions");
       if (connectorOptions != null && connectorOptions.isObject()) {
-        removeDatasourceOwnedFields((ObjectNode) connectorOptions);
+        removeDatasourceOwnedFields((ObjectNode) connectorOptions, datasourceOwnedFields);
       }
     }
   }
 
-  private static void removeDatasourceOwnedFields(ObjectNode node) {
-    JDBC_DATASOURCE_OWNED_FIELDS.forEach(node::remove);
+  private static Set<String> datasourceOwnedFields(String connectorId) {
+    if (ConnectorIdResolver.isJdbc(connectorId)) {
+      return JDBC_DATASOURCE_OWNED_FIELDS;
+    }
+    if ("elasticsearch7".equalsIgnoreCase(connectorId)
+        || "elasticsearch8".equalsIgnoreCase(connectorId)) {
+      return ELASTICSEARCH_DATASOURCE_OWNED_FIELDS;
+    }
+    return Set.of();
+  }
+
+  private static void removeDatasourceOwnedFields(ObjectNode node, Set<String> fields) {
+    fields.forEach(node::remove);
   }
 
   private static void adaptEndpoint(

--- a/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-offline/src/main/java/io/yak/ops/business/sync/offline/engine/connector/OfflineSyncConnectorRegistry.java
+++ b/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-offline/src/main/java/io/yak/ops/business/sync/offline/engine/connector/OfflineSyncConnectorRegistry.java
@@ -31,6 +31,16 @@ public final class OfflineSyncConnectorRegistry {
       nativeProfile("doris-native", DataSourceDbType.DORIS, "doris", "DORIS"),
       nativeProfile("starrocks-native", DataSourceDbType.STARROCKS, "starrocks", "STARROCKS"),
       nativeProfile("clickhouse-native", DataSourceDbType.CLICKHOUSE, "clickhouse", "CLICKHOUSE"),
+      nativeProfile(
+          "elasticsearch7-native",
+          DataSourceDbType.ELASTICSEARCH7,
+          "elasticsearch7",
+          "ELASTICSEARCH7"),
+      nativeProfile(
+          "elasticsearch8-native",
+          DataSourceDbType.ELASTICSEARCH8,
+          "elasticsearch8",
+          "ELASTICSEARCH8"),
       jdbcProfile("kingbase-jdbc", DataSourceDbType.KINGBASE, "JDBC-KINGBASE"),
       jdbcProfile("dameng-jdbc", DataSourceDbType.DAMENG, "JDBC-DAMENG"));
 
@@ -52,7 +62,11 @@ public final class OfflineSyncConnectorRegistry {
       "POSTGRES", DataSourceDbType.POSTGRE_SQL,
       "OPENGAUSS", DataSourceDbType.OPEN_GAUSS,
       "SQLSERVER", DataSourceDbType.SQL_SERVER,
-      "MSSQL", DataSourceDbType.SQL_SERVER);
+      "MSSQL", DataSourceDbType.SQL_SERVER,
+      "ELASTICSEARCH_7", DataSourceDbType.ELASTICSEARCH7,
+      "ES7", DataSourceDbType.ELASTICSEARCH7,
+      "ELASTICSEARCH_8", DataSourceDbType.ELASTICSEARCH8,
+      "ES8", DataSourceDbType.ELASTICSEARCH8);
 
   private static final Map<DataSourceDbType, OfflineSyncConnectorProfile> DEFAULTS =
       buildDefaults();

--- a/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-offline/src/main/java/io/yak/ops/business/sync/offline/engine/connector/adapter/ElasticsearchOfflineSyncConnectorAdapter.java
+++ b/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-offline/src/main/java/io/yak/ops/business/sync/offline/engine/connector/adapter/ElasticsearchOfflineSyncConnectorAdapter.java
@@ -1,0 +1,244 @@
+package io.yak.ops.business.sync.offline.engine.connector.adapter;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ArrayNode;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import io.yak.ops.business.sync.offline.config.ConditionalOnOfflineSyncEnabled;
+import java.util.List;
+import java.util.Locale;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.stereotype.Component;
+import org.springframework.util.StringUtils;
+
+/**
+ * Translates Yak Ops GUIDE_SINGLE tasks to the bounded Elasticsearch 7 / 8 Link-Up connectors.
+ * Vendor SDKs stay inside Link-Up runtime plugin islands; this adapter only owns option semantics.
+ */
+@ConditionalOnOfflineSyncEnabled
+@Component
+public class ElasticsearchOfflineSyncConnectorAdapter implements OfflineSyncConnectorAdapter {
+
+  private static final List<String> DATASOURCE_OWNED_OPTIONS =
+      List.of(
+          "hosts",
+          "host",
+          "scheme",
+          "port",
+          "username",
+          "user",
+          "password",
+          "passwd",
+          "connect_timeout_ms",
+          "socket_timeout_ms");
+
+  private final ObjectMapper objectMapper;
+
+  public ElasticsearchOfflineSyncConnectorAdapter(
+      @Qualifier("offlineSyncJsonMapper") ObjectMapper objectMapper) {
+    this.objectMapper = objectMapper;
+  }
+
+  @Override
+  public boolean supports(String connectorId, Role role) {
+    return "elasticsearch7".equalsIgnoreCase(connectorId)
+        || "elasticsearch8".equalsIgnoreCase(connectorId);
+  }
+
+  @Override
+  public boolean requiresDataSource(String connectorId, Role role) {
+    return true;
+  }
+
+  @Override
+  public BuildResult build(BuildContext context) {
+    requireSingle(context);
+    ObjectNode options = context.options();
+    removeDatasourceOwned(options);
+
+    if (context.role() == Role.SOURCE) {
+      String index = sourceIndex(context.config());
+      options.put("index", index);
+      normalizeQueryDsl(options);
+      if (!options.hasNonNull("scroll_size")) {
+        options.put("scroll_size", context.fetchSize());
+      }
+      return new BuildResult(options, index, List.of(index));
+    }
+
+    String index = sinkIndex(context.config());
+    if (context.config().path("autoCreateTable").asBoolean(false)) {
+      throw new IllegalArgumentException(
+          "Elasticsearch Sink 当前不支持自动创建 index，请先创建目标 index 和 mapping");
+    }
+    String writeMode = text(context.config(), "writeMode", "append").toLowerCase(Locale.ROOT);
+    if (!"append".equals(writeMode)) {
+      throw new IllegalArgumentException(
+          "Elasticsearch Sink 当前仅开放 Append 产品语义；稳定 _id 不等同于 UPSERT capability");
+    }
+    options.put("index", index);
+    if (!options.hasNonNull("batch_size")) {
+      options.put("batch_size", context.batchSize());
+    }
+    return new BuildResult(options, index, List.of());
+  }
+
+  @Override
+  public void resolveForExecution(ExecutionContext context) {
+    if (context.dataSource() == null) {
+      throw new IllegalArgumentException("Elasticsearch Connector 必须选择数据源");
+    }
+    ObjectNode options = context.options();
+    removeDatasourceOwned(options);
+
+    JsonNode connection = readConnection(context.dataSource().getConnectionParams());
+    ArrayNode hosts = hosts(connection);
+    if (hosts.isEmpty()) {
+      throw new IllegalArgumentException("Elasticsearch 数据源缺少 hosts/host 连接地址");
+    }
+    options.set("hosts", hosts);
+
+    String username = firstText(connection, "username", "user");
+    String password = firstTextAllowEmpty(connection, "password", "passwd");
+    if (username != null) options.put("username", username);
+    if (password != null) options.put("password", password);
+    copyPositiveInt(connection, options, "connect_timeout_ms");
+    copyPositiveInt(connection, options, "socket_timeout_ms");
+  }
+
+  private void normalizeQueryDsl(ObjectNode options) {
+    JsonNode query = options.get("query");
+    if (query == null || query.isNull()) return;
+    if (query.isTextual()) {
+      String value = query.asText();
+      if (!StringUtils.hasText(value)) options.remove("query");
+      else options.put("query", value.trim());
+      return;
+    }
+    if (!query.isObject()) {
+      throw new IllegalArgumentException("Elasticsearch query 必须是 Query DSL JSON 对象或 JSON 字符串");
+    }
+    try {
+      options.put("query", objectMapper.writeValueAsString(query));
+    } catch (JsonProcessingException exception) {
+      throw new IllegalArgumentException("序列化 Elasticsearch Query DSL 失败", exception);
+    }
+  }
+
+  private void requireSingle(BuildContext context) {
+    if (!"GUIDE_SINGLE".equals(context.mode())) {
+      throw new IllegalArgumentException(
+          context.connectorId()
+              + " 当前阶段仅支持单 index GUIDE_SINGLE；multi-index/FAN_OUT 不在 PR 8 范围内");
+    }
+  }
+
+  private String sourceIndex(JsonNode config) {
+    String readMode = text(config, "readMode", "table");
+    if ("sql".equalsIgnoreCase(readMode)) {
+      throw new IllegalArgumentException("Elasticsearch Source 不支持 SQL 读取，请使用 index + Query DSL");
+    }
+    return requireIndex(text(config, "table", text(config, "index", null)), "请选择来源 index");
+  }
+
+  private String sinkIndex(JsonNode config) {
+    return requireIndex(
+        text(config, "targetTableName", text(config, "table", text(config, "index", null))),
+        "请选择或填写目标 index");
+  }
+
+  private String requireIndex(String value, String message) {
+    if (!StringUtils.hasText(value)) throw new IllegalArgumentException(message);
+    String index = value.trim();
+    if (index.contains("*") || index.contains(",")) {
+      throw new IllegalArgumentException(
+          "当前阶段仅支持一个明确的 Elasticsearch index/alias，不支持 wildcard 或多 index");
+    }
+    return index;
+  }
+
+  private JsonNode readConnection(String json) {
+    if (!StringUtils.hasText(json)) return objectMapper.createObjectNode();
+    try {
+      JsonNode value = objectMapper.readTree(json);
+      return value != null && value.isObject() ? value : objectMapper.createObjectNode();
+    } catch (JsonProcessingException exception) {
+      throw new IllegalArgumentException("Elasticsearch 数据源连接参数不是有效 JSON", exception);
+    }
+  }
+
+  private ArrayNode hosts(JsonNode connection) {
+    ArrayNode result = objectMapper.createArrayNode();
+    JsonNode configured = connection.get("hosts");
+    if (configured != null && configured.isArray()) {
+      for (JsonNode item : configured) {
+        addHost(result, item.asText(null));
+      }
+    } else if (configured != null && configured.isValueNode()) {
+      for (String part : configured.asText("").split(",")) addHost(result, part);
+    }
+    if (!result.isEmpty()) return result;
+
+    String host = firstText(connection, "host", "hostname");
+    if (!StringUtils.hasText(host)) return result;
+    String scheme = firstText(connection, "scheme", "protocol");
+    if (!StringUtils.hasText(scheme)) scheme = "http";
+    int port = intValue(connection, "port", "https".equalsIgnoreCase(scheme) ? 443 : 9200);
+    addHost(result, scheme + "://" + host + ":" + port);
+    return result;
+  }
+
+  private void addHost(ArrayNode target, String value) {
+    if (!StringUtils.hasText(value)) return;
+    String normalized = value.trim();
+    while (normalized.endsWith("/")) normalized = normalized.substring(0, normalized.length() - 1);
+    if (!normalized.startsWith("http://") && !normalized.startsWith("https://")) {
+      normalized = "http://" + normalized;
+    }
+    target.add(normalized);
+  }
+
+  private void copyPositiveInt(JsonNode source, ObjectNode target, String field) {
+    JsonNode value = source.get(field);
+    if (value == null || value.isNull()) return;
+    int parsed = value.isNumber() ? value.asInt() : intValue(source, field, -1);
+    if (parsed > 0) target.put(field, parsed);
+  }
+
+  private int intValue(JsonNode node, String field, int fallback) {
+    JsonNode value = node.get(field);
+    if (value == null || value.isNull()) return fallback;
+    if (value.isNumber()) return value.asInt(fallback);
+    try {
+      return Integer.parseInt(value.asText().trim());
+    } catch (RuntimeException ignored) {
+      return fallback;
+    }
+  }
+
+  private String firstText(JsonNode node, String... fields) {
+    String value = firstTextAllowEmpty(node, fields);
+    return StringUtils.hasText(value) ? value.trim() : null;
+  }
+
+  private String firstTextAllowEmpty(JsonNode node, String... fields) {
+    if (node == null || !node.isObject()) return null;
+    for (String field : fields) {
+      JsonNode value = node.get(field);
+      if (value != null && value.isValueNode() && !value.isNull()) return value.asText();
+    }
+    return null;
+  }
+
+  private String text(JsonNode node, String field, String fallback) {
+    JsonNode value = node == null ? null : node.get(field);
+    return value == null || value.isNull() || !value.isValueNode()
+        ? fallback
+        : value.asText(fallback);
+  }
+
+  private void removeDatasourceOwned(ObjectNode options) {
+    options.remove(DATASOURCE_OWNED_OPTIONS);
+  }
+}

--- a/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-offline/src/test/java/io/yak/ops/business/sync/offline/engine/OfflineDefinitionModelAdapterTest.java
+++ b/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-offline/src/test/java/io/yak/ops/business/sync/offline/engine/OfflineDefinitionModelAdapterTest.java
@@ -169,6 +169,70 @@ class OfflineDefinitionModelAdapterTest {
   }
 
   @Test
+  void shouldStripElasticsearchDatasourceFieldsFromEveryPersistedShape() throws Exception {
+    ObjectNode definition = (ObjectNode) mapper.readTree("""
+        {
+          "source": {
+            "connectorId": "elasticsearch7",
+            "dbType": "ELASTICSEARCH7",
+            "host": "es-a",
+            "username": "elastic",
+            "password": "top-secret",
+            "options": {
+              "hosts": ["http://es-a:9200"],
+              "password": "option-secret",
+              "query": "{\"match_all\":{}}",
+              "scroll_size": 500
+            },
+            "config": {
+              "password": "config-secret",
+              "connectorOptions": {
+                "username": "bad-user",
+                "password": "nested-secret",
+                "document_id_field": "id",
+                "max_retries": 3
+              }
+            }
+          },
+          "sink": {
+            "dbType": "ELASTICSEARCH8",
+            "endpoint": "https://es-b:9200",
+            "connectionParams": "secret-json",
+            "options": {
+              "socket_timeout_ms": 999,
+              "batch_size": 200
+            }
+          }
+        }
+        """);
+
+    OfflineDefinitionModelAdapter.sanitizeForPersistence(definition);
+
+    JsonNode source = definition.path("source");
+    assertThat(source.has("host")).isFalse();
+    assertThat(source.has("username")).isFalse();
+    assertThat(source.has("password")).isFalse();
+    assertThat(source.path("options").has("hosts")).isFalse();
+    assertThat(source.path("options").has("password")).isFalse();
+    assertThat(source.path("options").path("query").asText())
+        .isEqualTo("{\"match_all\":{}}");
+    assertThat(source.path("options").path("scroll_size").asInt()).isEqualTo(500);
+    assertThat(source.path("config").has("password")).isFalse();
+    assertThat(source.path("config").path("connectorOptions").has("username")).isFalse();
+    assertThat(source.path("config").path("connectorOptions").has("password")).isFalse();
+    assertThat(source.path("config").path("connectorOptions").path("document_id_field").asText())
+        .isEqualTo("id");
+    assertThat(source.path("config").path("connectorOptions").path("max_retries").asInt())
+        .isEqualTo(3);
+
+    JsonNode sink = definition.path("sink");
+    assertThat(sink.has("endpoint")).isFalse();
+    assertThat(sink.has("connectionParams")).isFalse();
+    assertThat(sink.path("options").has("socket_timeout_ms")).isFalse();
+    assertThat(sink.path("options").path("batch_size").asInt()).isEqualTo(200);
+  }
+
+  @Test
   void shouldKeepLegacyWorkflowDefinitionUntouched() throws Exception {
     JsonNode definition = mapper.readTree("""
         {

--- a/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-offline/src/test/java/io/yak/ops/business/sync/offline/engine/connector/OfflineSyncConnectorRegistryTest.java
+++ b/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-offline/src/test/java/io/yak/ops/business/sync/offline/engine/connector/OfflineSyncConnectorRegistryTest.java
@@ -20,6 +20,14 @@ class OfflineSyncConnectorRegistryTest {
     assertThat(profiles.get(DataSourceDbType.DORIS).sourceConnectorId()).isEqualTo("doris");
     assertThat(profiles.get(DataSourceDbType.STARROCKS).sourceConnectorId()).isEqualTo("starrocks");
     assertThat(profiles.get(DataSourceDbType.CLICKHOUSE).sourceConnectorId()).isEqualTo("clickhouse");
+    assertThat(profiles.get(DataSourceDbType.ELASTICSEARCH7).sourceConnectorId())
+        .isEqualTo("elasticsearch7");
+    assertThat(profiles.get(DataSourceDbType.ELASTICSEARCH7).sinkConnectorId())
+        .isEqualTo("elasticsearch7");
+    assertThat(profiles.get(DataSourceDbType.ELASTICSEARCH8).sourceConnectorId())
+        .isEqualTo("elasticsearch8");
+    assertThat(profiles.get(DataSourceDbType.ELASTICSEARCH8).sinkConnectorId())
+        .isEqualTo("elasticsearch8");
     assertThat(profiles.get(DataSourceDbType.DB2).sourceConnectorId()).isEqualTo("jdbc");
     assertThat(profiles.get(DataSourceDbType.OPEN_GAUSS).sourceConnectorId()).isEqualTo("jdbc");
     assertThat(profiles.get(DataSourceDbType.SQL_SERVER).sourceConnectorId()).isEqualTo("jdbc");
@@ -33,5 +41,17 @@ class OfflineSyncConnectorRegistryTest {
     assertThat(OfflineSyncConnectorRegistry.defaultConnectorId("CLICKHOUSE")).contains("jdbc");
     assertThat(OfflineSyncConnectorRegistry.defaultConnectorId("POSTGRESQL")).contains("jdbc");
     assertThat(OfflineSyncConnectorRegistry.defaultConnectorId("HTTP")).isEmpty();
+  }
+
+  @Test
+  void shouldResolveVersionedElasticsearchAliasesWithoutCollapsingThem() {
+    assertThat(OfflineSyncConnectorRegistry.defaultProfile("ES7"))
+        .get()
+        .extracting(OfflineSyncConnectorProfile::sourceConnectorId)
+        .isEqualTo("elasticsearch7");
+    assertThat(OfflineSyncConnectorRegistry.defaultProfile("ELASTICSEARCH_8"))
+        .get()
+        .extracting(OfflineSyncConnectorProfile::sourceConnectorId)
+        .isEqualTo("elasticsearch8");
   }
 }

--- a/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-offline/src/test/java/io/yak/ops/business/sync/offline/engine/connector/adapter/ElasticsearchOfflineSyncConnectorAdapterTest.java
+++ b/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-offline/src/test/java/io/yak/ops/business/sync/offline/engine/connector/adapter/ElasticsearchOfflineSyncConnectorAdapterTest.java
@@ -1,0 +1,176 @@
+package io.yak.ops.business.sync.offline.engine.connector.adapter;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import io.yak.ops.business.sync.offline.engine.connector.adapter.OfflineSyncConnectorAdapter.BuildContext;
+import io.yak.ops.business.sync.offline.engine.connector.adapter.OfflineSyncConnectorAdapter.ExecutionContext;
+import io.yak.ops.business.sync.offline.engine.connector.adapter.OfflineSyncConnectorAdapter.Role;
+import io.yak.ops.common.bean.po.datasource.DataSourcePO;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+
+class ElasticsearchOfflineSyncConnectorAdapterTest {
+
+  private final ObjectMapper mapper = new ObjectMapper();
+  private final ElasticsearchOfflineSyncConnectorAdapter adapter =
+      new ElasticsearchOfflineSyncConnectorAdapter(mapper);
+
+  @Test
+  void buildsCredentialFreeSingleIndexSourceAndInjectsConnectionOnlyAtExecution() throws Exception {
+    ObjectNode config =
+        (ObjectNode)
+            mapper.readTree(
+                """
+                {
+                  "table":"orders-v1",
+                  "connectorOptions":{
+                    "scroll_size":321,
+                    "query":{"term":{"tenant_id":7}},
+                    "password":"must-not-persist",
+                    "connect_timeout_ms":999
+                  }
+                }
+                """);
+    ObjectNode options = (ObjectNode) config.path("connectorOptions").deepCopy();
+
+    var result =
+        adapter.build(
+            context("elasticsearch7", Role.SOURCE, "GUIDE_SINGLE", config, options));
+
+    assertThat(result.options().path("index").asText()).isEqualTo("orders-v1");
+    assertThat(result.options().path("scroll_size").asInt()).isEqualTo(321);
+    JsonNode query = mapper.readTree(result.options().path("query").asText());
+    assertThat(query.path("term").path("tenant_id").asInt()).isEqualTo(7);
+    assertThat(result.options().has("password")).isFalse();
+    assertThat(result.options().has("connect_timeout_ms")).isFalse();
+
+    DataSourcePO dataSource = new DataSourcePO();
+    dataSource.setConnectionParams(
+        "{\"hosts\":[\"http://es-a:9200\",\"http://es-b:9200\"],"
+            + "\"username\":\"elastic\",\"password\":\"secret\","
+            + "\"connect_timeout_ms\":12000}");
+    adapter.resolveForExecution(
+        new ExecutionContext(
+            "elasticsearch7", Role.SOURCE, "source", dataSource, result.options()));
+
+    assertThat(result.options().path("hosts")).hasSize(2);
+    assertThat(result.options().path("username").asText()).isEqualTo("elastic");
+    assertThat(result.options().path("password").asText()).isEqualTo("secret");
+    assertThat(result.options().path("connect_timeout_ms").asInt()).isEqualTo(12000);
+  }
+
+  @Test
+  void keepsDocumentIdAsAdvancedSinkOptionWithoutExposingUpsert() throws Exception {
+    ObjectNode config =
+        (ObjectNode)
+            mapper.readTree(
+                """
+                {
+                  "targetTableName":"orders-v2",
+                  "autoCreateTable":false,
+                  "writeMode":"append",
+                  "connectorOptions":{
+                    "document_id_field":"id",
+                    "max_retries":3,
+                    "batch_size":200
+                  }
+                }
+                """);
+    ObjectNode options = (ObjectNode) config.path("connectorOptions").deepCopy();
+
+    var result =
+        adapter.build(
+            context("elasticsearch8", Role.SINK, "GUIDE_SINGLE", config, options));
+
+    assertThat(result.options().path("index").asText()).isEqualTo("orders-v2");
+    assertThat(result.options().path("document_id_field").asText()).isEqualTo("id");
+    assertThat(result.options().path("max_retries").asInt()).isEqualTo(3);
+    assertThat(result.options().path("batch_size").asInt()).isEqualTo(200);
+    assertThat(result.options().has("write_mode")).isFalse();
+  }
+
+  @Test
+  void rejectsMultiIndexAndUnsupportedSinkSemantics() throws Exception {
+    ObjectNode source =
+        (ObjectNode) mapper.readTree("{\"table\":\"orders-*\"}");
+    assertThatThrownBy(
+            () ->
+                adapter.build(
+                    context(
+                        "elasticsearch7",
+                        Role.SOURCE,
+                        "GUIDE_SINGLE",
+                        source,
+                        mapper.createObjectNode())))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining("一个明确");
+
+    ObjectNode sink =
+        (ObjectNode)
+            mapper.readTree(
+                "{\"targetTableName\":\"orders\",\"autoCreateTable\":true,\"writeMode\":\"append\"}");
+    assertThatThrownBy(
+            () ->
+                adapter.build(
+                    context(
+                        "elasticsearch8",
+                        Role.SINK,
+                        "GUIDE_SINGLE",
+                        sink,
+                        mapper.createObjectNode())))
+        .hasMessageContaining("不支持自动创建");
+
+    sink.put("autoCreateTable", false);
+    sink.put("writeMode", "upsert");
+    assertThatThrownBy(
+            () ->
+                adapter.build(
+                    context(
+                        "elasticsearch8",
+                        Role.SINK,
+                        "GUIDE_SINGLE",
+                        sink,
+                        mapper.createObjectNode())))
+        .hasMessageContaining("Append");
+  }
+
+  @Test
+  void rejectsGuideMultiEvenThoughPr7SupportsFanOutForOtherConnectors() throws Exception {
+    ObjectNode config = (ObjectNode) mapper.readTree("{\"table\":\"orders\"}");
+
+    assertThatThrownBy(
+            () ->
+                adapter.build(
+                    context(
+                        "elasticsearch7",
+                        Role.SOURCE,
+                        "GUIDE_MULTI",
+                        config,
+                        mapper.createObjectNode())))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining("GUIDE_SINGLE");
+  }
+
+  private BuildContext context(
+      String connectorId,
+      Role role,
+      String mode,
+      ObjectNode config,
+      ObjectNode options) {
+    return new BuildContext(
+        connectorId,
+        role,
+        mode,
+        "es-test",
+        config,
+        mapper.createObjectNode(),
+        options,
+        1000,
+        500,
+        role == Role.SINK ? List.of("orders") : List.of());
+  }
+}

--- a/yak-ops-common/src/main/java/io/yak/ops/common/enums/datasource/DataSourceDbType.java
+++ b/yak-ops-common/src/main/java/io/yak/ops/common/enums/datasource/DataSourceDbType.java
@@ -19,6 +19,8 @@ public enum DataSourceDbType {
   DORIS("Doris"),
   STARROCKS("StarRocks"),
   CLICKHOUSE("ClickHouse"),
+  ELASTICSEARCH7("Elasticsearch 7"),
+  ELASTICSEARCH8("Elasticsearch 8"),
   KINGBASE("KingbaseES"),
   DAMENG("达梦");
 
@@ -36,6 +38,10 @@ public enum DataSourceDbType {
       normalized = "OPEN_GAUSS";
     } else if ("SQLSERVER".equals(normalized) || "MSSQL".equals(normalized)) {
       normalized = "SQL_SERVER";
+    } else if ("ELASTICSEARCH_7".equals(normalized) || "ES7".equals(normalized)) {
+      normalized = "ELASTICSEARCH7";
+    } else if ("ELASTICSEARCH_8".equals(normalized) || "ES8".equals(normalized)) {
+      normalized = "ELASTICSEARCH8";
     }
 
     try {

--- a/yak-ops-common/src/test/java/io/yak/ops/common/enums/datasource/DataSourceDbTypeTest.java
+++ b/yak-ops-common/src/test/java/io/yak/ops/common/enums/datasource/DataSourceDbTypeTest.java
@@ -19,10 +19,14 @@ class DataSourceDbTypeTest {
         .isEqualTo(DataSourceDbType.SQL_SERVER);
     assertThat(DataSourceDbType.parse("mssql"))
         .isEqualTo(DataSourceDbType.SQL_SERVER);
+    assertThat(DataSourceDbType.parse("es7"))
+        .isEqualTo(DataSourceDbType.ELASTICSEARCH7);
+    assertThat(DataSourceDbType.parse("elasticsearch-8"))
+        .isEqualTo(DataSourceDbType.ELASTICSEARCH8);
   }
 
   @Test
-  void shouldExposeJdbcAndNativeOlapTypesAsFirstClassTypes() {
+  void shouldExposeJdbcNativeOlapAndVersionedSearchTypesAsFirstClassTypes() {
     assertThat(DataSourceDbType.values())
         .contains(
             DataSourceDbType.DB2,
@@ -31,9 +35,13 @@ class DataSourceDbTypeTest {
             DataSourceDbType.OCEANBASE,
             DataSourceDbType.DORIS,
             DataSourceDbType.STARROCKS,
-            DataSourceDbType.CLICKHOUSE);
+            DataSourceDbType.CLICKHOUSE,
+            DataSourceDbType.ELASTICSEARCH7,
+            DataSourceDbType.ELASTICSEARCH8);
     assertThat(DataSourceDbType.STARROCKS.getDisplayName()).isEqualTo("StarRocks");
     assertThat(DataSourceDbType.CLICKHOUSE.getDisplayName()).isEqualTo("ClickHouse");
+    assertThat(DataSourceDbType.ELASTICSEARCH7.getDisplayName()).isEqualTo("Elasticsearch 7");
+    assertThat(DataSourceDbType.ELASTICSEARCH8.getDisplayName()).isEqualTo("Elasticsearch 8");
   }
 
   @Test

--- a/yak-ops-plugins/yak-ops-plugin-datasource/pom.xml
+++ b/yak-ops-plugins/yak-ops-plugin-datasource/pom.xml
@@ -21,6 +21,7 @@
         <module>yak-ops-plugin-datasource-api</module>
         <module>yak-ops-plugin-datasource-jdbc</module>
         <module>yak-ops-plugin-datasource-doris</module>
+        <module>yak-ops-plugin-datasource-elasticsearch</module>
         <module>yak-ops-plugin-datasource-all</module>
     </modules>
 </project>

--- a/yak-ops-plugins/yak-ops-plugin-datasource/yak-ops-plugin-datasource-all/src/test/java/io/yak/ops/plugin/datasource/AllDataSourcePluginsTest.java
+++ b/yak-ops-plugins/yak-ops-plugin-datasource/yak-ops-plugin-datasource-all/src/test/java/io/yak/ops/plugin/datasource/AllDataSourcePluginsTest.java
@@ -31,6 +31,8 @@ class AllDataSourcePluginsTest {
             DataSourceDbType.OCEANBASE,
             DataSourceDbType.DORIS,
             DataSourceDbType.STARROCKS,
-            DataSourceDbType.CLICKHOUSE);
+            DataSourceDbType.CLICKHOUSE,
+            DataSourceDbType.ELASTICSEARCH7,
+            DataSourceDbType.ELASTICSEARCH8);
   }
 }

--- a/yak-ops-plugins/yak-ops-plugin-datasource/yak-ops-plugin-datasource-elasticsearch/pom.xml
+++ b/yak-ops-plugins/yak-ops-plugin-datasource/yak-ops-plugin-datasource-elasticsearch/pom.xml
@@ -11,24 +11,19 @@
         <relativePath>../pom.xml</relativePath>
     </parent>
 
-    <artifactId>yak-ops-plugin-datasource-all</artifactId>
+    <artifactId>yak-ops-plugin-datasource-elasticsearch</artifactId>
 
-    <name>Yak Ops All Datasource Plugins</name>
-    <description>Runtime aggregation of all built-in Yak Ops datasource plugins</description>
+    <name>Yak Ops Elasticsearch Datasource Plugin</name>
+    <description>SDK-free Elasticsearch 7/8 control-plane datasource integration over HTTP</description>
 
     <dependencies>
         <dependency>
             <groupId>io.yak.ops</groupId>
-            <artifactId>yak-ops-plugin-datasource-jdbc</artifactId>
+            <artifactId>yak-ops-plugin-datasource-api</artifactId>
         </dependency>
         <dependency>
-            <groupId>io.yak.ops</groupId>
-            <artifactId>yak-ops-plugin-datasource-doris</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>io.yak.ops</groupId>
-            <artifactId>yak-ops-plugin-datasource-elasticsearch</artifactId>
-            <version>${project.version}</version>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-databind</artifactId>
         </dependency>
         <dependency>
             <groupId>org.springframework.boot</groupId>

--- a/yak-ops-plugins/yak-ops-plugin-datasource/yak-ops-plugin-datasource-elasticsearch/src/main/java/io/yak/ops/plugin/database/elasticsearch/AbstractElasticsearchDataSourcePlugin.java
+++ b/yak-ops-plugins/yak-ops-plugin-datasource/yak-ops-plugin-datasource-elasticsearch/src/main/java/io/yak/ops/plugin/database/elasticsearch/AbstractElasticsearchDataSourcePlugin.java
@@ -1,0 +1,352 @@
+package io.yak.ops.plugin.database.elasticsearch;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ArrayNode;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import io.yak.ops.common.enums.datasource.DataSourceDbType;
+import io.yak.ops.spi.datasource.DataSourceCapability;
+import io.yak.ops.spi.datasource.DataSourceCatalog;
+import io.yak.ops.spi.datasource.DataSourceConnection;
+import io.yak.ops.spi.datasource.DataSourcePlugin;
+import io.yak.ops.spi.datasource.DataSourcePluginDescriptor;
+import io.yak.ops.spi.datasource.DataSourcePluginDescriptor.ConnectionForm;
+import io.yak.ops.spi.datasource.DataSourcePluginDescriptor.FieldType;
+import io.yak.ops.spi.datasource.DataSourcePluginDescriptor.FormField;
+import io.yak.ops.spi.datasource.DataSourcePluginDescriptor.FormOption;
+import io.yak.ops.spi.datasource.DataSourcePluginDescriptor.FormRule;
+import io.yak.ops.spi.datasource.DataSourcePluginDescriptor.FormSection;
+import io.yak.ops.spi.datasource.DataSourcePluginException;
+import io.yak.ops.spi.datasource.DataSourcePluginException.Operation;
+import java.net.URI;
+import java.util.ArrayList;
+import java.util.EnumSet;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Locale;
+import java.util.Set;
+
+/** Shared SDK-free control-plane implementation for Elasticsearch 7 and Elasticsearch 8. */
+abstract class AbstractElasticsearchDataSourcePlugin implements DataSourcePlugin {
+
+  private static final ObjectMapper MAPPER = new ObjectMapper();
+  private static final int DEFAULT_PORT = 9200;
+
+  protected abstract int expectedMajorVersion();
+
+  @Override
+  public DataSourcePluginDescriptor descriptor() {
+    List<FormField> connection =
+        List.of(
+            field(
+                "scheme",
+                "协议",
+                FieldType.SELECT,
+                null,
+                "http",
+                List.of(new FormOption("HTTP", "http"), new FormOption("HTTPS", "https")),
+                required("请选择连接协议")),
+            field(
+                "host",
+                "主机地址",
+                FieldType.INPUT,
+                "例如 127.0.0.1",
+                "127.0.0.1",
+                List.of(),
+                required("请输入 Elasticsearch 主机地址")),
+            field(
+                "port",
+                "端口",
+                FieldType.NUMBER,
+                "默认 9200",
+                DEFAULT_PORT,
+                List.of(),
+                List.of(new FormRule(true, null, 1, 65535, "端口必须在 1 到 65535 之间"))),
+            field(
+                "username",
+                "用户名",
+                FieldType.INPUT,
+                "可选；启用 Basic Auth 时填写",
+                null,
+                List.of(),
+                List.of()),
+            field(
+                "password",
+                "密码",
+                FieldType.PASSWORD,
+                "可选；启用 Basic Auth 时填写",
+                null,
+                List.of(),
+                List.of()));
+
+    FormField hosts =
+        field(
+            "hosts",
+            "节点地址",
+            FieldType.TEXTAREA,
+            "可选；多个地址用逗号分隔，例如 http://es-1:9200,http://es-2:9200",
+            null,
+            List.of(),
+            List.of());
+
+    return new DataSourcePluginDescriptor(
+        dbType(),
+        dbType().getDisplayName(),
+        DataSourcePluginDescriptor.CURRENT_API_VERSION,
+        EnumSet.of(DataSourceCapability.CONNECTION_TEST, DataSourceCapability.CATALOG_METADATA),
+        new ConnectionForm(
+            List.of(
+                new FormSection("connection", "连接参数", "", false, true, connection),
+                new FormSection(
+                    "advanced",
+                    "高级配置",
+                    "节点列表仅用于连接容错；Yak Ops Catalog 使用首个可配置节点，实际离线执行由 Link-Up Connector 管理。",
+                    true,
+                    false,
+                    List.of(hosts))),
+            concat(connection, hosts)),
+        false,
+        null);
+  }
+
+  @Override
+  public DataSourceConnection parseConnection(String connectionJson) {
+    ObjectNode source = parseObject(connectionJson);
+    String scheme = text(source, "scheme", "http").toLowerCase(Locale.ROOT);
+    if (!"http".equals(scheme) && !"https".equals(scheme)) {
+      throw parameter("Elasticsearch scheme 仅支持 http 或 https");
+    }
+
+    LinkedHashSet<String> endpoints = new LinkedHashSet<>();
+    appendHosts(endpoints, source.get("hosts"), scheme);
+    appendTextHosts(endpoints, text(source, "url", null), scheme);
+    appendTextHosts(endpoints, text(source, "endpoint", null), scheme);
+
+    String host = text(source, "host", null);
+    int port = intValue(source, "port", DEFAULT_PORT);
+    if (port < 1 || port > 65535) {
+      throw parameter("Elasticsearch 端口必须在 1 到 65535 之间");
+    }
+    if (endpoints.isEmpty()) {
+      if (host == null || host.isBlank()) {
+        throw parameter("请输入 Elasticsearch 主机地址或 hosts 节点列表");
+      }
+      endpoints.add(normalizeEndpoint(scheme + "://" + host.trim() + ":" + port, scheme));
+    }
+
+    List<String> hosts = List.copyOf(endpoints);
+    URI primary = URI.create(hosts.get(0));
+    ObjectNode normalized = MAPPER.createObjectNode();
+    normalized.put("dbType", dbType().name());
+    normalized.put("scheme", primary.getScheme());
+    normalized.put("host", primary.getHost());
+    normalized.put("port", primary.getPort() > 0 ? primary.getPort() : defaultPort(primary.getScheme()));
+    ArrayNode hostArray = normalized.putArray("hosts");
+    hosts.forEach(hostArray::add);
+
+    String username = trimToNull(text(source, "username", text(source, "user", null)));
+    String password = textAllowEmpty(source, "password", textAllowEmpty(source, "passwd", null));
+    if (username != null) normalized.put("username", username);
+    if (password != null) normalized.put("password", password);
+
+    return new ElasticsearchConnection(
+        dbType(), hosts, username, password, write(normalized));
+  }
+
+  @Override
+  public void testConnection(DataSourceConnection connection, int timeoutSeconds) {
+    ElasticsearchConnection elasticsearch = requireConnection(connection);
+    JsonNode root =
+        new ElasticsearchHttpClient(elasticsearch, timeoutSeconds)
+            .get("/", Operation.CONNECTIVITY);
+    String version = root.path("version").path("number").asText(null);
+    if (version == null || version.isBlank()) {
+      throw new DataSourcePluginException(
+          Operation.CONNECTIVITY, "Elasticsearch 未返回 version.number");
+    }
+    int actual = major(version);
+    if (actual != expectedMajorVersion()) {
+      throw new DataSourcePluginException(
+          Operation.CONNECTIVITY,
+          "数据源类型为 "
+              + dbType().getDisplayName()
+              + "，但服务端版本为 "
+              + version
+              + "（major="
+              + actual
+              + "）");
+    }
+  }
+
+  @Override
+  public DataSourceCatalog createCatalog(DataSourceConnection connection, int timeoutSeconds) {
+    return new ElasticsearchHttpCatalog(
+        requireConnection(connection), Math.max(1, timeoutSeconds), expectedMajorVersion());
+  }
+
+  @Override
+  public DataSourceCatalog createCatalog(
+      DataSourceConnection connection,
+      int connectionTimeoutSeconds,
+      int queryTimeoutSeconds) {
+    return new ElasticsearchHttpCatalog(
+        requireConnection(connection),
+        Math.max(1, Math.max(connectionTimeoutSeconds, queryTimeoutSeconds)),
+        expectedMajorVersion());
+  }
+
+  @Override
+  public boolean acceptsUrl(String jdbcUrl) {
+    // A plain HTTP URL cannot distinguish ES7 from ES8. Versioned plugins require explicit dbType.
+    return false;
+  }
+
+  private ElasticsearchConnection requireConnection(DataSourceConnection connection) {
+    if (!(connection instanceof ElasticsearchConnection elasticsearch)
+        || elasticsearch.dbType() != dbType()) {
+      throw parameter("Elasticsearch 连接类型不匹配：" + dbType());
+    }
+    return elasticsearch;
+  }
+
+  private ObjectNode parseObject(String json) {
+    if (json == null || json.isBlank()) throw parameter("Elasticsearch 连接参数不能为空");
+    try {
+      JsonNode value = MAPPER.readTree(json);
+      if (value == null || !value.isObject()) {
+        throw parameter("Elasticsearch 连接参数必须是 JSON 对象");
+      }
+      return (ObjectNode) value;
+    } catch (JsonProcessingException exception) {
+      throw new DataSourcePluginException(Operation.PARAMETER, "Elasticsearch 连接参数不是有效 JSON", exception);
+    }
+  }
+
+  private void appendHosts(Set<String> result, JsonNode value, String scheme) {
+    if (value == null || value.isNull()) return;
+    if (value.isArray()) {
+      for (JsonNode item : value) {
+        if (item != null && item.isValueNode()) {
+          appendTextHosts(result, item.asText(), scheme);
+        }
+      }
+      return;
+    }
+    if (value.isValueNode()) appendTextHosts(result, value.asText(), scheme);
+  }
+
+  private void appendTextHosts(Set<String> result, String value, String scheme) {
+    if (value == null || value.isBlank()) return;
+    for (String part : value.split(",")) {
+      if (!part.isBlank()) result.add(normalizeEndpoint(part, scheme));
+    }
+  }
+
+  private String normalizeEndpoint(String value, String defaultScheme) {
+    String endpoint = value.trim();
+    if (!endpoint.contains("://")) endpoint = defaultScheme + "://" + endpoint;
+    while (endpoint.endsWith("/")) endpoint = endpoint.substring(0, endpoint.length() - 1);
+    URI uri;
+    try {
+      uri = URI.create(endpoint);
+    } catch (IllegalArgumentException exception) {
+      throw new DataSourcePluginException(Operation.PARAMETER, "Elasticsearch 节点地址不合法：" + value, exception);
+    }
+    if ((!("http".equalsIgnoreCase(uri.getScheme()) || "https".equalsIgnoreCase(uri.getScheme())))
+        || uri.getHost() == null
+        || (uri.getPath() != null && !uri.getPath().isEmpty())
+        || uri.getQuery() != null
+        || uri.getFragment() != null
+        || uri.getUserInfo() != null) {
+      throw parameter("Elasticsearch 节点必须是 http(s)://host[:port]：" + value);
+    }
+    int port = uri.getPort() > 0 ? uri.getPort() : defaultPort(uri.getScheme());
+    return uri.getScheme().toLowerCase(Locale.ROOT) + "://" + uri.getHost() + ":" + port;
+  }
+
+  private int defaultPort(String scheme) {
+    return "https".equalsIgnoreCase(scheme) ? 443 : DEFAULT_PORT;
+  }
+
+  private int major(String version) {
+    int separator = version.indexOf('.');
+    String value = separator < 0 ? version : version.substring(0, separator);
+    try {
+      return Integer.parseInt(value);
+    } catch (NumberFormatException exception) {
+      throw new DataSourcePluginException(
+          Operation.CONNECTIVITY, "无法识别 Elasticsearch 版本：" + version, exception);
+    }
+  }
+
+  private int intValue(JsonNode node, String field, int fallback) {
+    JsonNode value = node.get(field);
+    if (value == null || value.isNull()) return fallback;
+    if (value.isIntegralNumber()) return value.asInt();
+    try {
+      return Integer.parseInt(value.asText().trim());
+    } catch (RuntimeException exception) {
+      throw parameter(field + " 必须是整数");
+    }
+  }
+
+  private String text(JsonNode node, String field, String fallback) {
+    JsonNode value = node == null ? null : node.get(field);
+    if (value == null || value.isNull() || !value.isValueNode()) return fallback;
+    String result = value.asText();
+    return result == null || result.isBlank() ? fallback : result.trim();
+  }
+
+  private String textAllowEmpty(JsonNode node, String field, String fallback) {
+    JsonNode value = node == null ? null : node.get(field);
+    return value == null || value.isNull() || !value.isValueNode() ? fallback : value.asText();
+  }
+
+  private String trimToNull(String value) {
+    return value == null || value.trim().isEmpty() ? null : value.trim();
+  }
+
+  private String write(JsonNode value) {
+    try {
+      return MAPPER.writeValueAsString(value);
+    } catch (JsonProcessingException exception) {
+      throw new DataSourcePluginException(Operation.PARAMETER, "序列化 Elasticsearch 连接参数失败", exception);
+    }
+  }
+
+  private DataSourcePluginException parameter(String message) {
+    return new DataSourcePluginException(Operation.PARAMETER, message);
+  }
+
+  private List<FormField> concat(List<FormField> fields, FormField extra) {
+    List<FormField> result = new ArrayList<>(fields);
+    result.add(extra);
+    return List.copyOf(result);
+  }
+
+  private FormRule required(String message) {
+    return new FormRule(true, null, null, null, message);
+  }
+
+  private FormField field(
+      String key,
+      String label,
+      FieldType type,
+      String placeholder,
+      Object defaultValue,
+      List<FormOption> options,
+      List<FormRule> rules) {
+    return new FormField(
+        key,
+        label,
+        type,
+        placeholder,
+        defaultValue,
+        options,
+        rules,
+        List.of(),
+        List.of(),
+        null);
+  }
+}

--- a/yak-ops-plugins/yak-ops-plugin-datasource/yak-ops-plugin-datasource-elasticsearch/src/main/java/io/yak/ops/plugin/database/elasticsearch/Elasticsearch7DataSourcePlugin.java
+++ b/yak-ops-plugins/yak-ops-plugin-datasource/yak-ops-plugin-datasource-elasticsearch/src/main/java/io/yak/ops/plugin/database/elasticsearch/Elasticsearch7DataSourcePlugin.java
@@ -1,0 +1,17 @@
+package io.yak.ops.plugin.database.elasticsearch;
+
+import io.yak.ops.common.enums.datasource.DataSourceDbType;
+
+/** Elasticsearch 7 control-plane datasource profile. */
+public final class Elasticsearch7DataSourcePlugin extends AbstractElasticsearchDataSourcePlugin {
+
+  @Override
+  public DataSourceDbType dbType() {
+    return DataSourceDbType.ELASTICSEARCH7;
+  }
+
+  @Override
+  protected int expectedMajorVersion() {
+    return 7;
+  }
+}

--- a/yak-ops-plugins/yak-ops-plugin-datasource/yak-ops-plugin-datasource-elasticsearch/src/main/java/io/yak/ops/plugin/database/elasticsearch/Elasticsearch8DataSourcePlugin.java
+++ b/yak-ops-plugins/yak-ops-plugin-datasource/yak-ops-plugin-datasource-elasticsearch/src/main/java/io/yak/ops/plugin/database/elasticsearch/Elasticsearch8DataSourcePlugin.java
@@ -1,0 +1,17 @@
+package io.yak.ops.plugin.database.elasticsearch;
+
+import io.yak.ops.common.enums.datasource.DataSourceDbType;
+
+/** Elasticsearch 8 control-plane datasource profile. */
+public final class Elasticsearch8DataSourcePlugin extends AbstractElasticsearchDataSourcePlugin {
+
+  @Override
+  public DataSourceDbType dbType() {
+    return DataSourceDbType.ELASTICSEARCH8;
+  }
+
+  @Override
+  protected int expectedMajorVersion() {
+    return 8;
+  }
+}

--- a/yak-ops-plugins/yak-ops-plugin-datasource/yak-ops-plugin-datasource-elasticsearch/src/main/java/io/yak/ops/plugin/database/elasticsearch/ElasticsearchConnection.java
+++ b/yak-ops-plugins/yak-ops-plugin-datasource/yak-ops-plugin-datasource-elasticsearch/src/main/java/io/yak/ops/plugin/database/elasticsearch/ElasticsearchConnection.java
@@ -1,0 +1,85 @@
+package io.yak.ops.plugin.database.elasticsearch;
+
+import io.yak.ops.common.enums.datasource.DataSourceDbType;
+import io.yak.ops.spi.datasource.DataSourceConnection;
+import java.util.List;
+import java.util.Map;
+
+/** SDK-free Elasticsearch connection model owned by the Yak Ops control-plane plugin. */
+final class ElasticsearchConnection implements DataSourceConnection {
+
+  static final String VIRTUAL_DATABASE = "elasticsearch";
+
+  private final DataSourceDbType dbType;
+  private final List<String> hosts;
+  private final String username;
+  private final String password;
+  private final String normalizedJson;
+
+  ElasticsearchConnection(
+      DataSourceDbType dbType,
+      List<String> hosts,
+      String username,
+      String password,
+      String normalizedJson) {
+    this.dbType = dbType;
+    this.hosts = List.copyOf(hosts);
+    this.username = username;
+    this.password = password;
+    this.normalizedJson = normalizedJson;
+  }
+
+  List<String> hosts() {
+    return hosts;
+  }
+
+  String primaryHost() {
+    return hosts.get(0);
+  }
+
+  @Override
+  public DataSourceDbType dbType() {
+    return dbType;
+  }
+
+  /** Historical SPI field; for HTTP-native sources it carries the primary endpoint. */
+  @Override
+  public String jdbcUrl() {
+    return primaryHost();
+  }
+
+  @Override
+  public String driverClassName() {
+    return null;
+  }
+
+  @Override
+  public String username() {
+    return username;
+  }
+
+  @Override
+  public String password() {
+    return password;
+  }
+
+  @Override
+  public String database() {
+    return VIRTUAL_DATABASE;
+  }
+
+  @Override
+  public String schema() {
+    return null;
+  }
+
+  @Override
+  public Map<String, String> properties() {
+    return Map.of("hosts", String.join(",", hosts));
+  }
+
+  @Override
+  public String normalizedJson() {
+    return normalizedJson;
+  }
+}

--- a/yak-ops-plugins/yak-ops-plugin-datasource/yak-ops-plugin-datasource-elasticsearch/src/main/java/io/yak/ops/plugin/database/elasticsearch/ElasticsearchHttpCatalog.java
+++ b/yak-ops-plugins/yak-ops-plugin-datasource/yak-ops-plugin-datasource-elasticsearch/src/main/java/io/yak/ops/plugin/database/elasticsearch/ElasticsearchHttpCatalog.java
@@ -1,0 +1,271 @@
+package io.yak.ops.plugin.database.elasticsearch;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import io.yak.ops.spi.datasource.DataSourceCatalog;
+import io.yak.ops.spi.datasource.DataSourcePluginException;
+import io.yak.ops.spi.datasource.DataSourcePluginException.Operation;
+import io.yak.ops.spi.datasource.catalog.DataSourceCatalogQuery;
+import io.yak.ops.spi.datasource.catalog.DataSourceCatalogReadRequest;
+import io.yak.ops.spi.datasource.catalog.DataSourceTablePath;
+import io.yak.ops.spi.datasource.metadata.DataSourceColumn;
+import io.yak.ops.spi.datasource.metadata.DataSourceTable;
+import io.yak.ops.spi.datasource.query.DataSourceQueryResult;
+import java.sql.Types;
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.Iterator;
+import java.util.LinkedHashMap;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+import java.util.Set;
+
+/** Maps Elasticsearch index/alias/mapping metadata onto the stable datasource Catalog contract. */
+final class ElasticsearchHttpCatalog implements DataSourceCatalog {
+
+  private final ElasticsearchHttpClient client;
+  private final int expectedMajor;
+  private volatile boolean versionChecked;
+
+  ElasticsearchHttpCatalog(
+      ElasticsearchConnection connection, int timeoutSeconds, int expectedMajor) {
+    this(new ElasticsearchHttpClient(connection, timeoutSeconds), expectedMajor);
+  }
+
+  ElasticsearchHttpCatalog(ElasticsearchHttpClient client, int expectedMajor) {
+    this.client = client;
+    this.expectedMajor = expectedMajor;
+  }
+
+  @Override
+  public List<String> listDatabases() {
+    ensureVersion();
+    return List.of(ElasticsearchConnection.VIRTUAL_DATABASE);
+  }
+
+  @Override
+  public List<String> listSchemas(String database) {
+    requireVirtualDatabase(database);
+    ensureVersion();
+    return List.of();
+  }
+
+  @Override
+  public List<DataSourceTable> listTables(DataSourceCatalogQuery query) {
+    requireVirtualDatabase(query == null ? null : query.getDatabase());
+    ensureVersion();
+    JsonNode aliases = client.get("/_aliases", Operation.CATALOG);
+
+    Map<String, Set<String>> aliasTargets = new LinkedHashMap<>();
+    List<DataSourceTable> result = new ArrayList<>();
+    Iterator<Map.Entry<String, JsonNode>> indices = aliases.fields();
+    while (indices.hasNext()) {
+      Map.Entry<String, JsonNode> entry = indices.next();
+      String index = entry.getKey();
+      if (matches(query, index)) {
+        result.add(table(index, "INDEX", null));
+      }
+      JsonNode aliasNode = entry.getValue().path("aliases");
+      if (aliasNode.isObject()) {
+        aliasNode.fieldNames()
+            .forEachRemaining(
+                alias -> aliasTargets.computeIfAbsent(alias, ignored -> new LinkedHashSet<>()).add(index));
+      }
+    }
+
+    for (Map.Entry<String, Set<String>> entry : aliasTargets.entrySet()) {
+      if (entry.getValue().size() == 1 && matches(query, entry.getKey())) {
+        result.add(
+            table(
+                entry.getKey(),
+                "ALIAS",
+                "alias -> " + entry.getValue().iterator().next()));
+      }
+    }
+
+    result.sort(Comparator.comparing(DataSourceTable::getName, String.CASE_INSENSITIVE_ORDER));
+    Integer limit = query == null ? null : query.getLimit();
+    return limit == null || result.size() <= limit
+        ? List.copyOf(result)
+        : List.copyOf(result.subList(0, limit));
+  }
+
+  @Override
+  public List<DataSourceColumn> listColumns(DataSourceTablePath tablePath) {
+    if (tablePath == null) throw catalog("Elasticsearch tablePath 不能为空");
+    requireVirtualDatabase(tablePath.getDatabase());
+    return mappingColumns(tablePath.getTable());
+  }
+
+  @Override
+  public List<DataSourceColumn> describe(DataSourceCatalogReadRequest request) {
+    if (request == null || request.sqlMode()) {
+      throw unsupportedRead("Elasticsearch Catalog 不支持 SQL describe");
+    }
+    return mappingColumns(indexFromPath(request.tablePath()));
+  }
+
+  @Override
+  public DataSourceQueryResult preview(DataSourceCatalogReadRequest request, int limit) {
+    throw unsupportedRead("Elasticsearch 预览由 Link-Up bounded Source 执行，本地 Catalog 不直接读取文档");
+  }
+
+  @Override
+  public long count(DataSourceCatalogReadRequest request) {
+    throw unsupportedRead("Elasticsearch count 不属于当前 control-plane Catalog 能力");
+  }
+
+  @Override
+  public String buildSqlTemplate(String tablePath) {
+    throw unsupportedRead("Elasticsearch 不提供 SQL 模板能力");
+  }
+
+  @Override
+  public String resolveSql(String sql, DataSourceCatalogReadRequest request) {
+    throw unsupportedRead("Elasticsearch 不提供 SQL 变量解析能力");
+  }
+
+  private List<DataSourceColumn> mappingColumns(String indexOrAlias) {
+    ensureVersion();
+    String index = requireIndex(indexOrAlias);
+    JsonNode mapping =
+        client.get("/" + client.encodePathSegment(index) + "/_mapping", Operation.CATALOG);
+    if (!mapping.isObject() || mapping.size() != 1) {
+      throw catalog(
+          "Elasticsearch index/alias 必须解析到一个 concrete index：" + index);
+    }
+
+    JsonNode concrete = mapping.elements().next();
+    JsonNode properties = concrete.path("mappings").path("properties");
+    if (!properties.isObject()) return List.of();
+
+    List<DataSourceColumn> columns = new ArrayList<>();
+    int[] ordinal = new int[] {1};
+    flattenProperties(properties, "", columns, ordinal);
+    return List.copyOf(columns);
+  }
+
+  private void flattenProperties(
+      JsonNode properties,
+      String prefix,
+      List<DataSourceColumn> columns,
+      int[] ordinal) {
+    Iterator<Map.Entry<String, JsonNode>> fields = properties.fields();
+    while (fields.hasNext()) {
+      Map.Entry<String, JsonNode> entry = fields.next();
+      String name = prefix.isEmpty() ? entry.getKey() : prefix + "." + entry.getKey();
+      JsonNode mapping = entry.getValue();
+      String type = mapping.path("type").asText(null);
+      JsonNode nested = mapping.path("properties");
+      if (type == null || type.isBlank()) type = nested.isObject() ? "object" : "unknown";
+
+      columns.add(
+          new DataSourceColumn(
+              name,
+              type,
+              jdbcType(type),
+              null,
+              null,
+              true,
+              ordinal[0]++,
+              false,
+              null));
+
+      if (nested.isObject()) {
+        flattenProperties(nested, name, columns, ordinal);
+      }
+    }
+  }
+
+  private int jdbcType(String type) {
+    String normalized = type == null ? "" : type.toLowerCase(Locale.ROOT);
+    return switch (normalized) {
+      case "boolean" -> Types.BOOLEAN;
+      case "byte" -> Types.TINYINT;
+      case "short" -> Types.SMALLINT;
+      case "integer" -> Types.INTEGER;
+      case "long", "unsigned_long" -> Types.BIGINT;
+      case "half_float", "float" -> Types.FLOAT;
+      case "double" -> Types.DOUBLE;
+      case "scaled_float" -> Types.DECIMAL;
+      case "date", "date_nanos" -> Types.TIMESTAMP;
+      case "binary" -> Types.VARBINARY;
+      default -> Types.VARCHAR;
+    };
+  }
+
+  private void ensureVersion() {
+    if (versionChecked) return;
+    synchronized (this) {
+      if (versionChecked) return;
+      JsonNode root = client.get("/", Operation.CATALOG);
+      String version = root.path("version").path("number").asText(null);
+      if (version == null || version.isBlank()) {
+        throw catalog("Elasticsearch 未返回 version.number");
+      }
+      int separator = version.indexOf('.');
+      String majorText = separator < 0 ? version : version.substring(0, separator);
+      int actual;
+      try {
+        actual = Integer.parseInt(majorText);
+      } catch (NumberFormatException exception) {
+        throw new DataSourcePluginException(
+            Operation.CATALOG, "无法识别 Elasticsearch 版本：" + version, exception);
+      }
+      if (actual != expectedMajor) {
+        throw catalog(
+            "Elasticsearch Catalog 版本不匹配：期望 major="
+                + expectedMajor
+                + "，实际="
+                + version);
+      }
+      versionChecked = true;
+    }
+  }
+
+  private boolean matches(DataSourceCatalogQuery query, String value) {
+    if (query == null || query.getKeyword() == null || query.getKeyword().isBlank()) return true;
+    return value.toLowerCase(Locale.ROOT)
+        .contains(query.getKeyword().trim().toLowerCase(Locale.ROOT));
+  }
+
+  private DataSourceTable table(String name, String type, String remarks) {
+    return new DataSourceTable(
+        ElasticsearchConnection.VIRTUAL_DATABASE, null, name, type, remarks);
+  }
+
+  private void requireVirtualDatabase(String database) {
+    if (database == null || database.isBlank()) return;
+    if (!ElasticsearchConnection.VIRTUAL_DATABASE.equalsIgnoreCase(database.trim())) {
+      throw catalog("Elasticsearch 仅暴露虚拟 Catalog database: elasticsearch");
+    }
+  }
+
+  private String indexFromPath(String tablePath) {
+    if (tablePath == null || tablePath.isBlank()) throw catalog("Elasticsearch index 不能为空");
+    String normalized = tablePath.trim();
+    String prefix = ElasticsearchConnection.VIRTUAL_DATABASE + ".";
+    if (normalized.regionMatches(true, 0, prefix, 0, prefix.length())) {
+      return requireIndex(normalized.substring(prefix.length()));
+    }
+    return requireIndex(normalized);
+  }
+
+  private String requireIndex(String value) {
+    if (value == null || value.trim().isEmpty()) throw catalog("Elasticsearch index 不能为空");
+    String index = value.trim();
+    if (index.contains("*") || index.contains(",")) {
+      throw catalog("当前阶段仅支持一个明确的 Elasticsearch index/alias，不支持 wildcard 或多 index");
+    }
+    return index;
+  }
+
+  private DataSourcePluginException unsupportedRead(String message) {
+    return new DataSourcePluginException(Operation.CATALOG, message);
+  }
+
+  private DataSourcePluginException catalog(String message) {
+    return new DataSourcePluginException(Operation.CATALOG, message);
+  }
+}

--- a/yak-ops-plugins/yak-ops-plugin-datasource/yak-ops-plugin-datasource-elasticsearch/src/main/java/io/yak/ops/plugin/database/elasticsearch/ElasticsearchHttpClient.java
+++ b/yak-ops-plugins/yak-ops-plugin-datasource/yak-ops-plugin-datasource-elasticsearch/src/main/java/io/yak/ops/plugin/database/elasticsearch/ElasticsearchHttpClient.java
@@ -1,0 +1,122 @@
+package io.yak.ops.plugin.database.elasticsearch;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.yak.ops.spi.datasource.DataSourcePluginException;
+import io.yak.ops.spi.datasource.DataSourcePluginException.Operation;
+import java.io.IOException;
+import java.net.URI;
+import java.net.URLEncoder;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
+import java.nio.charset.StandardCharsets;
+import java.time.Duration;
+import java.util.Base64;
+
+/** Minimal Elasticsearch management client. Vendor SDKs deliberately stay in Link-Up. */
+class ElasticsearchHttpClient {
+
+  private static final ObjectMapper MAPPER = new ObjectMapper();
+
+  private final ElasticsearchConnection connection;
+  private final Duration timeout;
+  private final HttpClient httpClient;
+
+  ElasticsearchHttpClient(ElasticsearchConnection connection, int timeoutSeconds) {
+    this.connection = connection;
+    this.timeout = Duration.ofSeconds(Math.max(1, timeoutSeconds));
+    this.httpClient = HttpClient.newBuilder().connectTimeout(timeout).build();
+  }
+
+  JsonNode get(String path, Operation operation) {
+    HttpResponse<String> response = send(path, operation);
+    if (response.statusCode() < 200 || response.statusCode() >= 300) {
+      throw failure(operation, path, response.statusCode(), response.body());
+    }
+    return parse(operation, path, response.body());
+  }
+
+  JsonNode getOrNull(String path, Operation operation) {
+    HttpResponse<String> response = send(path, operation);
+    if (response.statusCode() == 404) return null;
+    if (response.statusCode() < 200 || response.statusCode() >= 300) {
+      throw failure(operation, path, response.statusCode(), response.body());
+    }
+    return parse(operation, path, response.body());
+  }
+
+  String encodePathSegment(String value) {
+    if (value == null || value.trim().isEmpty()) {
+      throw new DataSourcePluginException(Operation.PARAMETER, "Elasticsearch index 不能为空");
+    }
+    return URLEncoder.encode(value.trim(), StandardCharsets.UTF_8).replace("+", "%20");
+  }
+
+  private HttpResponse<String> send(String path, Operation operation) {
+    String normalizedPath = path == null || path.isBlank() ? "/" : path;
+    if (!normalizedPath.startsWith("/")) normalizedPath = "/" + normalizedPath;
+    URI uri;
+    try {
+      uri = URI.create(connection.primaryHost() + normalizedPath);
+    } catch (IllegalArgumentException exception) {
+      throw new DataSourcePluginException(operation, "Elasticsearch 请求地址不合法", exception);
+    }
+
+    HttpRequest.Builder request =
+        HttpRequest.newBuilder(uri)
+            .timeout(timeout)
+            .header("Accept", "application/json")
+            .GET();
+    if (connection.username() != null && !connection.username().isBlank()) {
+      String credential =
+          connection.username() + ":" + (connection.password() == null ? "" : connection.password());
+      request.header(
+          "Authorization",
+          "Basic "
+              + Base64.getEncoder()
+                  .encodeToString(credential.getBytes(StandardCharsets.UTF_8)));
+    }
+
+    try {
+      return httpClient.send(
+          request.build(), HttpResponse.BodyHandlers.ofString(StandardCharsets.UTF_8));
+    } catch (InterruptedException exception) {
+      Thread.currentThread().interrupt();
+      throw new DataSourcePluginException(operation, "Elasticsearch 请求被中断", exception);
+    } catch (IOException exception) {
+      throw new DataSourcePluginException(
+          operation, "无法连接 Elasticsearch：" + connection.primaryHost(), exception);
+    }
+  }
+
+  private JsonNode parse(Operation operation, String path, String body) {
+    try {
+      return body == null || body.isBlank() ? MAPPER.createObjectNode() : MAPPER.readTree(body);
+    } catch (JsonProcessingException exception) {
+      throw new DataSourcePluginException(
+          operation, "Elasticsearch 返回了无法解析的 JSON：" + path, exception);
+    }
+  }
+
+  private DataSourcePluginException failure(
+      Operation operation, String path, int statusCode, String body) {
+    String message = null;
+    if (body != null && !body.isBlank()) {
+      try {
+        JsonNode error = MAPPER.readTree(body);
+        message = error.path("error").path("reason").asText(null);
+        if (message == null || message.isBlank()) {
+          message = error.path("error").asText(null);
+        }
+      } catch (JsonProcessingException ignored) {
+        // Keep the status-only fallback and never copy arbitrary HTML/proxy bodies into errors.
+      }
+    }
+    String suffix = message == null || message.isBlank() ? "" : "：" + message;
+    return new DataSourcePluginException(
+        operation,
+        "Elasticsearch HTTP " + statusCode + " " + path + suffix);
+  }
+}

--- a/yak-ops-plugins/yak-ops-plugin-datasource/yak-ops-plugin-datasource-elasticsearch/src/main/resources/META-INF/services/io.yak.ops.spi.datasource.DataSourcePlugin
+++ b/yak-ops-plugins/yak-ops-plugin-datasource/yak-ops-plugin-datasource-elasticsearch/src/main/resources/META-INF/services/io.yak.ops.spi.datasource.DataSourcePlugin
@@ -1,0 +1,2 @@
+io.yak.ops.plugin.database.elasticsearch.Elasticsearch7DataSourcePlugin
+io.yak.ops.plugin.database.elasticsearch.Elasticsearch8DataSourcePlugin

--- a/yak-ops-plugins/yak-ops-plugin-datasource/yak-ops-plugin-datasource-elasticsearch/src/test/java/io/yak/ops/plugin/database/elasticsearch/ElasticsearchDataSourcePluginTest.java
+++ b/yak-ops-plugins/yak-ops-plugin-datasource/yak-ops-plugin-datasource-elasticsearch/src/test/java/io/yak/ops/plugin/database/elasticsearch/ElasticsearchDataSourcePluginTest.java
@@ -1,0 +1,158 @@
+package io.yak.ops.plugin.database.elasticsearch;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.yak.ops.common.enums.datasource.DataSourceDbType;
+import io.yak.ops.spi.datasource.DataSourceCapability;
+import io.yak.ops.spi.datasource.DataSourcePluginException.Operation;
+import io.yak.ops.spi.datasource.catalog.DataSourceCatalogQuery;
+import io.yak.ops.spi.datasource.catalog.DataSourceTablePath;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import org.junit.jupiter.api.Test;
+
+class ElasticsearchDataSourcePluginTest {
+
+  private final ObjectMapper mapper = new ObjectMapper();
+
+  @Test
+  void versionedPluginsNormalizeSdkFreeConnectionsAndOnlyExposeManagementCapabilities() throws Exception {
+    Elasticsearch7DataSourcePlugin plugin = new Elasticsearch7DataSourcePlugin();
+
+    ElasticsearchConnection connection =
+        (ElasticsearchConnection)
+            plugin.parseConnection(
+                """
+                {
+                  "scheme":"https",
+                  "host":"es.example.test",
+                  "port":9243,
+                  "username":"elastic",
+                  "password":"secret",
+                  "hosts":"https://es.example.test:9243,https://es-b.example.test:9243"
+                }
+                """);
+
+    assertThat(plugin.dbType()).isEqualTo(DataSourceDbType.ELASTICSEARCH7);
+    assertThat(connection.hosts())
+        .containsExactly("https://es.example.test:9243", "https://es-b.example.test:9243");
+    assertThat(connection.driverClassName()).isNull();
+    assertThat(plugin.descriptor().capabilities())
+        .containsExactlyInAnyOrder(
+            DataSourceCapability.CONNECTION_TEST,
+            DataSourceCapability.CATALOG_METADATA);
+    assertThat(plugin.descriptor().secretFieldKeys()).contains("password");
+    assertThat(plugin.descriptor().capabilities())
+        .doesNotContain(DataSourceCapability.CATALOG_READ, DataSourceCapability.TRANSACTIONS);
+    assertThat(connection.normalizedJson()).contains("ELASTICSEARCH7", "hosts", "username");
+  }
+
+  @Test
+  void catalogListsConcreteIndicesAndOnlySingleTargetAliasesAndFlattensMappings() throws Exception {
+    ElasticsearchConnection connection =
+        new ElasticsearchConnection(
+            DataSourceDbType.ELASTICSEARCH7,
+            List.of("http://es:9200"),
+            null,
+            null,
+            "{}");
+    FakeClient client = new FakeClient(connection, mapper);
+    client.add(
+        "/",
+        """
+        {"version":{"number":"7.17.29"}}
+        """);
+    client.add(
+        "/_aliases",
+        """
+        {
+          "orders-0001":{"aliases":{"orders-current":{},"orders-all":{}}},
+          "orders-0002":{"aliases":{"orders-all":{}}},
+          "customers":{"aliases":{"customers-current":{}}}
+        }
+        """);
+    client.add(
+        "/orders-current/_mapping",
+        """
+        {
+          "orders-0001":{
+            "mappings":{
+              "properties":{
+                "id":{"type":"long"},
+                "created_at":{"type":"date"},
+                "customer":{"properties":{"name":{"type":"keyword"}}}
+              }
+            }
+          }
+        }
+        """);
+
+    ElasticsearchHttpCatalog catalog = new ElasticsearchHttpCatalog(client, 7);
+
+    assertThat(catalog.listDatabases()).containsExactly("elasticsearch");
+    assertThat(catalog.listTables(new DataSourceCatalogQuery("elasticsearch", null, null)))
+        .extracting(value -> value.getName() + ":" + value.getType())
+        .contains(
+            "orders-0001:INDEX",
+            "orders-0002:INDEX",
+            "customers:INDEX",
+            "orders-current:ALIAS",
+            "customers-current:ALIAS")
+        .doesNotContain("orders-all:ALIAS");
+
+    assertThat(
+            catalog.listColumns(
+                new DataSourceTablePath("elasticsearch", null, "orders-current")))
+        .extracting(column -> column.getName() + ":" + column.getTypeName())
+        .containsExactly(
+            "id:long",
+            "created_at:date",
+            "customer:object",
+            "customer.name:keyword");
+  }
+
+  @Test
+  void catalogRejectsWrongServerMajor() throws Exception {
+    ElasticsearchConnection connection =
+        new ElasticsearchConnection(
+            DataSourceDbType.ELASTICSEARCH8,
+            List.of("http://es:9200"),
+            null,
+            null,
+            "{}");
+    FakeClient client = new FakeClient(connection, mapper);
+    client.add("/", "{\"version\":{\"number\":\"7.17.29\"}}");
+
+    ElasticsearchHttpCatalog catalog = new ElasticsearchHttpCatalog(client, 8);
+    assertThatThrownBy(catalog::listDatabases)
+        .hasMessageContaining("期望 major=8")
+        .hasMessageContaining("7.17.29");
+  }
+
+  private static final class FakeClient extends ElasticsearchHttpClient {
+    private final ObjectMapper mapper;
+    private final Map<String, JsonNode> responses = new LinkedHashMap<>();
+
+    private FakeClient(ElasticsearchConnection connection, ObjectMapper mapper) {
+      super(connection, 1);
+      this.mapper = mapper;
+    }
+
+    private void add(String path, String json) throws Exception {
+      responses.put(path, mapper.readTree(json));
+    }
+
+    @Override
+    JsonNode get(String path, Operation operation) {
+      JsonNode value = responses.get(path);
+      if (value == null) {
+        throw new IllegalStateException("missing fake response for " + path);
+      }
+      return value.deepCopy();
+    }
+  }
+}

--- a/yak-ops-plugins/yak-ops-plugin-datasource/yak-ops-plugin-datasource-elasticsearch/src/test/java/io/yak/ops/plugin/database/elasticsearch/ElasticsearchSdkIsolationTest.java
+++ b/yak-ops-plugins/yak-ops-plugin-datasource/yak-ops-plugin-datasource-elasticsearch/src/test/java/io/yak/ops/plugin/database/elasticsearch/ElasticsearchSdkIsolationTest.java
@@ -1,0 +1,56 @@
+package io.yak.ops.plugin.database.elasticsearch;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.stream.Stream;
+import org.junit.jupiter.api.Test;
+
+/** Guards the control-plane/runtime boundary: vendor Elasticsearch SDKs belong to Link-Up plugins. */
+class ElasticsearchSdkIsolationTest {
+
+  @Test
+  void productionSourcesDoNotImportElasticsearchVendorSdks() throws IOException {
+    Path root = sourceRoot();
+    try (Stream<Path> files = Files.walk(root)) {
+      for (Path file : files.filter(path -> path.toString().endsWith(".java")).toList()) {
+        String source = Files.readString(file);
+        assertThat(source)
+            .as("%s must remain SDK-free", file.getFileName())
+            .doesNotContain("import org.elasticsearch.")
+            .doesNotContain("import co.elastic.clients.")
+            .doesNotContain("org.elasticsearch.client")
+            .doesNotContain("co.elastic.clients");
+      }
+    }
+  }
+
+  @Test
+  void modulePomDoesNotDeclareElasticsearchVendorArtifacts() throws IOException {
+    String pom = Files.readString(moduleRoot().resolve("pom.xml"));
+    assertThat(pom)
+        .doesNotContain("org.elasticsearch")
+        .doesNotContain("co.elastic.clients")
+        .doesNotContain("elasticsearch-java")
+        .doesNotContain("elasticsearch-rest-high-level-client");
+  }
+
+  private Path moduleRoot() {
+    Path local = Path.of("").toAbsolutePath().normalize();
+    if (Files.isDirectory(local.resolve("src/main/java"))) return local;
+
+    Path repository = Path.of(
+        "yak-ops-plugins",
+        "yak-ops-plugin-datasource",
+        "yak-ops-plugin-datasource-elasticsearch");
+    if (Files.isDirectory(repository.resolve("src/main/java"))) return repository;
+
+    throw new IllegalStateException("Elasticsearch datasource module root is unavailable");
+  }
+
+  private Path sourceRoot() {
+    return moduleRoot().resolve("src/main/java");
+  }
+}

--- a/yak-ops-plugins/yak-ops-plugin-datasource/yak-ops-plugin-datasource-jdbc/src/main/java/io/yak/ops/plugin/database/jdbc/GenericJdbcCatalog.java
+++ b/yak-ops-plugins/yak-ops-plugin-datasource/yak-ops-plugin-datasource-jdbc/src/main/java/io/yak/ops/plugin/database/jdbc/GenericJdbcCatalog.java
@@ -343,6 +343,8 @@ public class GenericJdbcCatalog implements DataSourceCatalog {
                 : query + " LIMIT " + limit;
         case MYSQL, POSTGRE_SQL, DORIS, STARROCKS, CLICKHOUSE, KINGBASE, OPEN_GAUSS ->
             query + " LIMIT " + limit;
+        case ELASTICSEARCH7, ELASTICSEARCH8 ->
+            throw new IllegalStateException("Elasticsearch must not use GenericJdbcCatalog");
       };
     }
 
@@ -359,6 +361,8 @@ public class GenericJdbcCatalog implements DataSourceCatalog {
               : "SELECT * FROM (" + query + ") yak_ops_preview LIMIT " + limit;
       case MYSQL, POSTGRE_SQL, DORIS, STARROCKS, CLICKHOUSE, KINGBASE, OPEN_GAUSS ->
           "SELECT * FROM (" + query + ") yak_ops_preview LIMIT " + limit;
+      case ELASTICSEARCH7, ELASTICSEARCH8 ->
+          throw new IllegalStateException("Elasticsearch must not use GenericJdbcCatalog");
     };
   }
 

--- a/yak-ops-ui/src/components/data-source/icons/DatabaseIcons.tsx
+++ b/yak-ops-ui/src/components/data-source/icons/DatabaseIcons.tsx
@@ -48,6 +48,8 @@ const DatabaseIcons = ({
     case 'doris':
       return <DorisIcon width={width} height={height} />;
     case 'elasticsearch':
+    case 'elasticsearch7':
+    case 'elasticsearch8':
       return <ElasticSearchIcon width={width} height={height} />;
     case 'postgre_sql':
     case 'postgresql':

--- a/yak-ops-ui/src/locales/en-US/batch-link-up.ts
+++ b/yak-ops-ui/src/locales/en-US/batch-link-up.ts
@@ -60,6 +60,8 @@ export default {
   'pages.batchLinkUp.create.mode.singleDescription': 'Configure an offline sync task from one source table to one target table',
   'pages.batchLinkUp.create.mode.multi': 'Multi-table Sync',
   'pages.batchLinkUp.create.mode.multiDescription': 'Select multiple source tables and write them to the target using rules',
+  'pages.batchLinkUp.create.mode.profileSingleOnlyDescription': 'The selected data source profile currently supports only single-table / single-index offline sync',
+  'pages.batchLinkUp.create.mode.profileSingleOnlyError': 'The selected data source profile cannot create a multi-table sync task',
   'pages.batchLinkUp.create.defaultJobName': '{source} → {target} Offline Sync',
   'pages.batchLinkUp.create.success': 'Task draft created. Continue configuring data sources and sync tables.',
   'pages.batchLinkUp.create.failed': 'Failed to create sync task',

--- a/yak-ops-ui/src/locales/en-US/data-source.ts
+++ b/yak-ops-ui/src/locales/en-US/data-source.ts
@@ -58,6 +58,7 @@ export default {
 
   'pages.datasource.group.relational': 'Relational Databases',
   'pages.datasource.group.olap': 'OLAP Databases',
+  'pages.datasource.group.search': 'Search Engines',
   'pages.datasource.typeSelector.title': 'Select a Data Source',
   'pages.datasource.typeSelector.searchPlaceholder': 'Search data sources',
   'pages.datasource.typeSelector.allCategories': 'All categories',

--- a/yak-ops-ui/src/locales/zh-CN/batch-link-up.ts
+++ b/yak-ops-ui/src/locales/zh-CN/batch-link-up.ts
@@ -60,6 +60,8 @@ export default {
   'pages.batchLinkUp.create.mode.singleDescription': '配置一张来源表到一张目标表的离线同步任务',
   'pages.batchLinkUp.create.mode.multi': '多表同步',
   'pages.batchLinkUp.create.mode.multiDescription': '批量选择多张来源表，并按规则写入目标端',
+  'pages.batchLinkUp.create.mode.profileSingleOnlyDescription': '当前选择的数据源 Profile 仅开放单表 / 单索引离线同步',
+  'pages.batchLinkUp.create.mode.profileSingleOnlyError': '当前选择的数据源 Profile 不支持创建多表同步任务',
   'pages.batchLinkUp.create.defaultJobName': '{source} → {target} 离线同步',
   'pages.batchLinkUp.create.success': '任务草稿已创建，请继续配置数据源和同步表',
   'pages.batchLinkUp.create.failed': '创建同步任务失败',

--- a/yak-ops-ui/src/locales/zh-CN/data-source.ts
+++ b/yak-ops-ui/src/locales/zh-CN/data-source.ts
@@ -58,6 +58,7 @@ export default {
 
   'pages.datasource.group.relational': '关系型数据库',
   'pages.datasource.group.olap': 'OLAP 数据库',
+  'pages.datasource.group.search': '搜索引擎',
   'pages.datasource.typeSelector.title': '选择数据源',
   'pages.datasource.typeSelector.searchPlaceholder': '搜索数据源',
   'pages.datasource.typeSelector.allCategories': '全部分类',

--- a/yak-ops-ui/src/pages/data-source/components/DataSourceToolbar.tsx
+++ b/yak-ops-ui/src/pages/data-source/components/DataSourceToolbar.tsx
@@ -34,6 +34,10 @@ const DB_TYPE_LABELS: Record<string, string> = {
   SQL_SERVER: 'SQL Server',
   OCEANBASE: 'OceanBase',
   DORIS: 'Doris',
+  STARROCKS: 'StarRocks',
+  CLICKHOUSE: 'ClickHouse',
+  ELASTICSEARCH7: 'Elasticsearch 7',
+  ELASTICSEARCH8: 'Elasticsearch 8',
   KINGBASE: 'KINGBASE',
   DAMENG: 'DAMENG',
 };

--- a/yak-ops-ui/src/pages/data-source/constants.tsx
+++ b/yak-ops-ui/src/pages/data-source/constants.tsx
@@ -39,6 +39,8 @@ export const COMMON_DB_OPTIONS: DataSourceOptionItem[] = [
   { label: 'DORIS', value: 'DORIS' },
   { label: 'STARROCKS', value: 'STARROCKS' },
   { label: 'CLICKHOUSE', value: 'CLICKHOUSE' },
+  { label: 'ELASTICSEARCH7', value: 'ELASTICSEARCH7' },
+  { label: 'ELASTICSEARCH8', value: 'ELASTICSEARCH8' },
   { label: 'KINGBASE', value: 'KINGBASE' },
   { label: 'DAMENG', value: 'DAMENG' },
 ];
@@ -56,7 +58,7 @@ const relationalDataSource = (dbType: string) => ({
   connectorType: 'Jdbc',
 });
 
-const olapDataSource = (dbType: string, connectorType: string) => ({
+const nativeDataSource = (dbType: string, connectorType: string) => ({
   onlyDiScript: false,
   dbType,
   type: dbType,
@@ -83,9 +85,17 @@ export const getDataSourceGroupList = (intl: IntlFormatter): DataSourceGroup[] =
     groupKey: 'olap',
     groupName: intl.formatMessage({ id: 'pages.datasource.group.olap' }),
     datasourceList: [
-      olapDataSource('DORIS', 'Doris'),
-      olapDataSource('STARROCKS', 'StarRocks'),
-      olapDataSource('CLICKHOUSE', 'ClickHouse'),
+      nativeDataSource('DORIS', 'Doris'),
+      nativeDataSource('STARROCKS', 'StarRocks'),
+      nativeDataSource('CLICKHOUSE', 'ClickHouse'),
+    ],
+  },
+  {
+    groupKey: 'search',
+    groupName: intl.formatMessage({ id: 'pages.datasource.group.search' }),
+    datasourceList: [
+      nativeDataSource('ELASTICSEARCH7', 'Elasticsearch7'),
+      nativeDataSource('ELASTICSEARCH8', 'Elasticsearch8'),
     ],
   },
 ];

--- a/yak-ops-ui/src/pages/integration/batch-link-up/DataSourceSelect.tsx
+++ b/yak-ops-ui/src/pages/integration/batch-link-up/DataSourceSelect.tsx
@@ -32,6 +32,8 @@ const DATA_SOURCE_TYPES = [
   { value: 'DORIS', displayName: 'Doris' },
   { value: 'STARROCKS', displayName: 'StarRocks' },
   { value: 'CLICKHOUSE', displayName: 'ClickHouse' },
+  { value: 'ELASTICSEARCH7', displayName: 'Elasticsearch 7' },
+  { value: 'ELASTICSEARCH8', displayName: 'Elasticsearch 8' },
   { value: 'KINGBASE', displayName: 'KINGBASE' },
   { value: 'DAMENG', displayName: 'DAMENG' },
 ] as const;

--- a/yak-ops-ui/src/pages/integration/batch-link-up/components/CreateSyncTaskDrawer.tsx
+++ b/yak-ops-ui/src/pages/integration/batch-link-up/components/CreateSyncTaskDrawer.tsx
@@ -42,6 +42,7 @@ import {
 import { generateDataSourceOptions } from '../DataSourceSelect';
 import {
   connectorIdForNewDataSourceType,
+  isGuideMultiEnabledForDataSourceType,
   type OfflineSyncConnectorRole,
 } from '../connectorProfiles';
 import {
@@ -112,6 +113,9 @@ export default function CreateSyncTaskDrawer({
 
   const sourceDbType = Form.useWatch('sourceDbType', form);
   const targetDbType = Form.useWatch('targetDbType', form);
+  const guideMultiEnabled =
+    isGuideMultiEnabledForDataSourceType(sourceDbType) &&
+    isGuideMultiEnabledForDataSourceType(targetDbType);
 
   const modeOptions: Array<{
     value: SyncMode;
@@ -132,9 +136,12 @@ export default function CreateSyncTaskDrawer({
       value: 'GUIDE_MULTI',
       title: intl.formatMessage({ id: 'pages.batchLinkUp.create.mode.multi' }),
       description: intl.formatMessage({
-        id: 'pages.batchLinkUp.create.mode.multiDescription',
+        id: guideMultiEnabled
+          ? 'pages.batchLinkUp.create.mode.multiDescription'
+          : 'pages.batchLinkUp.create.mode.profileSingleOnlyDescription',
       }),
       icon: <DatabaseOutlined />,
+      disabled: !guideMultiEnabled,
     },
   ];
 
@@ -171,6 +178,12 @@ export default function CreateSyncTaskDrawer({
     });
   }, [connectorOptions, form, open]);
 
+  useEffect(() => {
+    if (!guideMultiEnabled && form.getFieldValue('mode') === 'GUIDE_MULTI') {
+      form.setFieldValue('mode', 'GUIDE_SINGLE');
+    }
+  }, [form, guideMultiEnabled]);
+
   const updateAutoJobName = (side: 'source' | 'target', value: string) => {
     const nextSourceDbType =
       side === 'source' ? value : form.getFieldValue('sourceDbType') || '';
@@ -205,6 +218,17 @@ export default function CreateSyncTaskDrawer({
       const values = await form.validateFields();
       const source = resolveEndpoint(values.sourceDbType, connectorOptions, 'SOURCE');
       const sink = resolveEndpoint(values.targetDbType, connectorOptions, 'SINK');
+      if (
+        values.mode === 'GUIDE_MULTI' &&
+        (!isGuideMultiEnabledForDataSourceType(values.sourceDbType) ||
+          !isGuideMultiEnabledForDataSourceType(values.targetDbType))
+      ) {
+        throw new Error(
+          intl.formatMessage({
+            id: 'pages.batchLinkUp.create.mode.profileSingleOnlyError',
+          }),
+        );
+      }
 
       const normalizedValues: CreateSyncTaskValues = {
         jobName: values.jobName.trim(),

--- a/yak-ops-ui/src/pages/integration/batch-link-up/connectorProfiles.test.ts
+++ b/yak-ops-ui/src/pages/integration/batch-link-up/connectorProfiles.test.ts
@@ -2,10 +2,11 @@ import {
   connectorIdForDataSourceType,
   connectorIdForNewDataSourceType,
   defaultOfflineSyncConnectorProfile,
+  isGuideMultiEnabledForDataSourceType,
   OFFLINE_SYNC_CONNECTOR_PROFILES,
 } from './connectorProfiles';
 
-test('uses native profiles for new OLAP tasks while keeping JDBC profiles explicit', () => {
+test('uses native profiles for new OLAP and versioned Elasticsearch tasks while keeping JDBC explicit', () => {
   expect(OFFLINE_SYNC_CONNECTOR_PROFILES.map((profile) => profile.dbType)).toEqual([
     'MYSQL',
     'ORACLE',
@@ -17,6 +18,8 @@ test('uses native profiles for new OLAP tasks while keeping JDBC profiles explic
     'DORIS',
     'STARROCKS',
     'CLICKHOUSE',
+    'ELASTICSEARCH7',
+    'ELASTICSEARCH8',
     'KINGBASE',
     'DAMENG',
   ]);
@@ -33,6 +36,18 @@ test('uses native profiles for new OLAP tasks while keeping JDBC profiles explic
     profileId: 'clickhouse-native',
     sourceConnectorId: 'clickhouse',
   });
+  expect(defaultOfflineSyncConnectorProfile('ELASTICSEARCH7')).toMatchObject({
+    profileId: 'elasticsearch7-native',
+    sourceConnectorId: 'elasticsearch7',
+    sinkConnectorId: 'elasticsearch7',
+    guideMultiEnabled: false,
+  });
+  expect(defaultOfflineSyncConnectorProfile('ELASTICSEARCH8')).toMatchObject({
+    profileId: 'elasticsearch8-native',
+    sourceConnectorId: 'elasticsearch8',
+    sinkConnectorId: 'elasticsearch8',
+    guideMultiEnabled: false,
+  });
   expect(defaultOfflineSyncConnectorProfile('DB2')?.sourceConnectorId).toBe('jdbc');
 });
 
@@ -43,6 +58,8 @@ test('separates legacy inference from new-task profile selection', () => {
   expect(connectorIdForNewDataSourceType('DORIS')).toBe('doris');
   expect(connectorIdForNewDataSourceType('STARROCKS')).toBe('starrocks');
   expect(connectorIdForNewDataSourceType('CLICKHOUSE')).toBe('clickhouse');
+  expect(connectorIdForNewDataSourceType('ES7')).toBe('elasticsearch7');
+  expect(connectorIdForNewDataSourceType('ELASTICSEARCH_8')).toBe('elasticsearch8');
 });
 
 test('resolves datasource aliases from one frontend registry', () => {
@@ -58,4 +75,15 @@ test('resolves datasource aliases from one frontend registry', () => {
     profileId: 'postgresql-jdbc',
     dbType: 'POSTGRE_SQL',
   });
+  expect(defaultOfflineSyncConnectorProfile('ES8')).toMatchObject({
+    dbType: 'ELASTICSEARCH8',
+    sourceConnectorId: 'elasticsearch8',
+  });
+});
+
+test('keeps Elasticsearch on the single-table guide without hardcoding drawer connector sets', () => {
+  expect(isGuideMultiEnabledForDataSourceType('MYSQL')).toBe(true);
+  expect(isGuideMultiEnabledForDataSourceType('DORIS')).toBe(true);
+  expect(isGuideMultiEnabledForDataSourceType('ELASTICSEARCH7')).toBe(false);
+  expect(isGuideMultiEnabledForDataSourceType('ES8')).toBe(false);
 });

--- a/yak-ops-ui/src/pages/integration/batch-link-up/connectorProfiles.ts
+++ b/yak-ops-ui/src/pages/integration/batch-link-up/connectorProfiles.ts
@@ -9,6 +9,8 @@ export interface OfflineSyncConnectorProfile {
   connectorType: string;
   pluginName: string;
   defaultProfile: boolean;
+  /** Product-level guide policy. Backend adapters remain the final enforcement boundary. */
+  guideMultiEnabled?: boolean;
 }
 
 /** Control-plane default execution profiles for datasource types exposed by Yak Ops. */
@@ -54,6 +56,18 @@ export const OFFLINE_SYNC_CONNECTOR_PROFILES: readonly OfflineSyncConnectorProfi
     connectorType: 'ClickHouse', pluginName: 'CLICKHOUSE', defaultProfile: true,
   },
   {
+    profileId: 'elasticsearch7-native', dbType: 'ELASTICSEARCH7',
+    sourceConnectorId: 'elasticsearch7', sinkConnectorId: 'elasticsearch7',
+    connectorType: 'Elasticsearch7', pluginName: 'ELASTICSEARCH7', defaultProfile: true,
+    guideMultiEnabled: false,
+  },
+  {
+    profileId: 'elasticsearch8-native', dbType: 'ELASTICSEARCH8',
+    sourceConnectorId: 'elasticsearch8', sinkConnectorId: 'elasticsearch8',
+    connectorType: 'Elasticsearch8', pluginName: 'ELASTICSEARCH8', defaultProfile: true,
+    guideMultiEnabled: false,
+  },
+  {
     profileId: 'kingbase-jdbc', dbType: 'KINGBASE', sourceConnectorId: 'jdbc', sinkConnectorId: 'jdbc',
     connectorType: 'Jdbc', pluginName: 'JDBC-KINGBASE', defaultProfile: true,
   },
@@ -77,6 +91,10 @@ const DB_TYPE_ALIASES: Record<string, string> = {
   OPENGAUSS: 'OPEN_GAUSS',
   SQLSERVER: 'SQL_SERVER',
   MSSQL: 'SQL_SERVER',
+  ELASTICSEARCH_7: 'ELASTICSEARCH7',
+  ES7: 'ELASTICSEARCH7',
+  ELASTICSEARCH_8: 'ELASTICSEARCH8',
+  ES8: 'ELASTICSEARCH8',
 };
 
 const normalizeDbType = (value?: string): string => {
@@ -92,6 +110,9 @@ export const defaultOfflineSyncConnectorProfile = (
     (profile) => profile.defaultProfile && profile.dbType === normalized,
   );
 };
+
+export const isGuideMultiEnabledForDataSourceType = (dbType?: string): boolean =>
+  defaultOfflineSyncConnectorProfile(dbType)?.guideMultiEnabled !== false;
 
 /** Compatibility inference used only when a persisted endpoint has no durable connectorId. */
 export const connectorIdForDataSourceType = (


### PR DESCRIPTION
## Summary

PR 8 of the Yak Ops offline connector adaptation plan.

This PR adds first-class Elasticsearch 7 / Elasticsearch 8 control-plane support with a deliberately narrow initial execution scope:

```text
ELASTICSEARCH7 -> Link-Up elasticsearch7
ELASTICSEARCH8 -> Link-Up elasticsearch8

GUIDE_SINGLE only
one concrete index / one alias -> one concrete index
bounded Source + bounded Sink
```

It does not opt Elasticsearch into PR 7 FAN_OUT yet and does not add CDC/realtime semantics.

## Runtime prerequisite — completed

The Link-Up runtime prerequisite is already merged:

- weifuwan/yak-link-up#113 `chore(elasticsearch): package ES7 and ES8 as isolated runtime plugins` ✅ merged

#113 keeps ES7 and ES8 in separate plugin directories / ConnectorClassLoaders so their incompatible Elasticsearch client dependencies never share the Worker flat classpath.

Deployment requirement is now simply: use a Link-Up Worker build that contains #113, then confirm runtime discovery reports `elasticsearch7` / `elasticsearch8` SOURCE and SINK schemas. Worker discovery remains runtime truth.

## What changed

### 1. Separate versioned datasource types

Add `ELASTICSEARCH7` and `ELASTICSEARCH8` as first-class datasource types, with aliases such as `ES7`, `ES8`, `ELASTICSEARCH_7` and `ELASTICSEARCH_8`.

Version selection is explicit at datasource creation time rather than hidden behind one generic Elasticsearch type/version flag.

### 2. SDK-free Elasticsearch datasource plugin

Add `yak-ops-plugin-datasource-elasticsearch` with two ServiceLoader providers backed by one shared HTTP implementation.

Yak Ops deliberately does **not** depend on `org.elasticsearch.*`, `co.elastic.clients.*`, the Rest High Level Client or the Elasticsearch Java API Client.

The control plane uses only JDK `HttpClient` + Jackson for:
- connection test
- server major-version verification
- index/alias discovery
- mapping discovery

Actual Scroll/Bulk execution stays inside Link-Up. An architecture test prevents vendor SDK dependencies/imports from creeping into Yak Ops later.

### 3. Version-aware connection validation

Connection test calls Elasticsearch `/` and validates `version.number`:
- `ELASTICSEARCH7` rejects an ES8 server
- `ELASTICSEARCH8` rejects an ES7 server

Connection config supports HTTP/HTTPS, host/port, optional Basic Auth and a normalized hosts list.

### 4. Catalog mapping without inventing SQL semantics

The datasource Catalog exposes one stable virtual namespace:

```text
database: elasticsearch
schema:   none
index:    table
mapping property: column
```

Behavior:
- concrete indices appear as `INDEX`
- aliases appear only when they resolve to exactly one concrete index
- aliases spanning multiple indices are not exposed as single-table candidates
- nested mapping properties are flattened to dotted field paths
- wildcard/comma multi-index paths are rejected

The plugin advertises only `CONNECTION_TEST` + `CATALOG_METADATA`; it does not advertise SQL preview, transactions or local document-read semantics.

### 5. Versioned offline Connector Profiles

```text
elasticsearch7-native
  sourceConnectorId = elasticsearch7
  sinkConnectorId   = elasticsearch7

elasticsearch8-native
  sourceConnectorId = elasticsearch8
  sinkConnectorId   = elasticsearch8
```

New tasks persist the versioned connector identity directly.

### 6. GUIDE_SINGLE execution adapter

Add one shared `ElasticsearchOfflineSyncConnectorAdapter` for ES7/ES8.

Source:
- one explicit index / one single-index alias
- bounded Link-Up Source
- Query DSL supported through connector options
- JSON Query DSL objects normalized to the String JSON contract expected by Link-Up
- projection/scroll/slice options remain capability-driven connector options

Sink:
- one existing target index / single-index alias
- append product semantics only
- no auto-create index
- no exposed overwrite/upsert capability
- `document_id_field` stays an advanced stable-`_id` option; it is **not** translated to Yak Ops UPSERT
- Link-Up retry/batch options pass through unchanged

Datasource-owned fields (`hosts`, endpoint fields, credentials, connection params/timeouts) are removed from both durable `definition_json` and logical JobSpec, then injected only at execution time. Direct/malicious task payloads cannot persist ES connection credentials through endpoint/options/config/connectorOptions shapes.

### 7. PR 8 intentionally does not opt into PR 7 FAN_OUT

Even though Yak Ops now has generic FAN_OUT orchestration, Elasticsearch remains `GUIDE_SINGLE` in this stage.

Backend rejects `GUIDE_MULTI`, wildcard and comma-separated index selections. Frontend uses a generic Connector Profile policy (`guideMultiEnabled: false`) rather than a hard-coded ES connector set in the drawer.

A later focused PR can opt ES into multi-index FAN_OUT only after deployed ES7/ES8 single-index behavior is validated end-to-end.

### 8. UI integration

- expose Elasticsearch 7 / 8 in datasource creation
- add a Search Engines datasource group
- reuse the existing Elasticsearch icon for both versioned types
- expose ES7/ES8 in offline task source/target selection
- show friendly version labels in datasource filters
- disable multi-table creation through generic profile policy
- keep runtime schema/capability-driven advanced options

### 9. Existing JDBC behavior remains explicit

Adding the new enum values surfaced exhaustive JDBC preview switches. `GenericJdbcCatalog` explicitly rejects ES7/ES8 if they somehow enter the JDBC path; no fake Elasticsearch SQL dialect is introduced.

## Tests

Added/updated focused coverage for:
- datasource enum parsing and stable version labels
- ServiceLoader discovery of both ES datasource plugins
- SDK-free dependency/source boundary
- connection normalization and management-only capabilities
- Catalog index/alias discovery and multi-target alias exclusion
- mapping -> dotted column flattening
- server major-version mismatch rejection
- ES7/ES8 Connector Profile mapping
- credentials stripped from every persisted task-definition shape
- credential-free logical JobSpec + execution-time datasource injection
- Query DSL object -> Link-Up string JSON normalization
- `document_id_field` remains non-UPSERT advanced config
- auto-create / upsert / wildcard / multi-index rejection
- GUIDE_MULTI rejection despite generic PR7 FAN_OUT support
- frontend aliases and single-guide policy

## Non-goals

This PR deliberately does **not**:
- add Elasticsearch SDK dependencies to Yak Ops
- add Elasticsearch SQL semantics or local document preview
- auto-create indices or evolve mappings
- expose UPSERT merely because a stable `_id` can be configured
- enable multi-index / GUIDE_MULTI / FAN_OUT
- add CDC, realtime or RowKind semantics
- change PR 7 FAN_OUT orchestration

## Validation status

- based directly on `main` after PR #1029 merge (`86ea2fbdbc7a0768c269f3aebb06419f358f1826`)
- branch is ahead by 1 focused commit and behind by 0
- final head: `5f2b9a9d892d6d3b551a150600f3fcb0275475a4`
- Java/plugin/frontend regression tests are committed
- no local Maven success is claimed because this environment does not have the repository's private Yak Framework dependency setup
- GitHub Actions on the final head is the current validation gate; if Yak Framework access is unavailable, Java setup/package may be skipped even when frontend validation succeeds

## Roadmap status

```text
PR 6    #1028  Native OLAP single-table       ✅ merged
PR 7    #1029  Multi-table execution strategy ✅ merged
Stage 5 #113   ES7/ES8 Worker isolation        ✅ merged
PR 8    #1030  Elasticsearch 7/8 control-plane 🟡 Draft
```