### PR TITLE
feat(tidb): add datasource and offline sync control-plane support

### DIFF
--- a/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-offline/src/main/java/io/yak/ops/business/sync/offline/engine/connector/OfflineSyncConnectorRegistry.java
+++ b/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-offline/src/main/java/io/yak/ops/business/sync/offline/engine/connector/OfflineSyncConnectorRegistry.java
@@ -22,6 +22,7 @@ public final class OfflineSyncConnectorRegistry {
 
   private static final List<OfflineSyncConnectorProfile> PROFILES = List.of(
       jdbcProfile("mysql-jdbc", DataSourceDbType.MYSQL, "JDBC-MYSQL"),
+      jdbcProfile("tidb-jdbc", DataSourceDbType.TIDB, "JDBC-TIDB"),
       jdbcProfile("oracle-jdbc", DataSourceDbType.ORACLE, "JDBC-ORACLE"),
       jdbcProfile("postgresql-jdbc", DataSourceDbType.POSTGRE_SQL, "JDBC-POSTGRESQL"),
       jdbcProfile("db2-jdbc", DataSourceDbType.DB2, "JDBC-DB2"),
@@ -65,6 +66,7 @@ public final class OfflineSyncConnectorRegistry {
   private static final Map<String, DataSourceDbType> DATA_SOURCE_ALIASES = Map.ofEntries(
       Map.entry("POSTGRESQL", DataSourceDbType.POSTGRE_SQL),
       Map.entry("POSTGRES", DataSourceDbType.POSTGRE_SQL),
+      Map.entry("TI_DB", DataSourceDbType.TIDB),
       Map.entry("OPENGAUSS", DataSourceDbType.OPEN_GAUSS),
       Map.entry("SQLSERVER", DataSourceDbType.SQL_SERVER),
       Map.entry("MSSQL", DataSourceDbType.SQL_SERVER),

--- a/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-offline/src/main/java/io/yak/ops/business/sync/offline/engine/connector/adapter/JdbcOfflineSyncConnectorAdapter.java
+++ b/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-offline/src/main/java/io/yak/ops/business/sync/offline/engine/connector/adapter/JdbcOfflineSyncConnectorAdapter.java
@@ -184,6 +184,9 @@ public class JdbcOfflineSyncConnectorAdapter implements OfflineSyncConnectorAdap
   private void appendConnection(ObjectNode options, ConnectionDetails connection) {
     options.put("url", connection.url());
     options.put("driver", connection.driver());
+    if (StringUtils.hasText(connection.dialect())) {
+      options.put("dialect", connection.dialect().trim().toLowerCase(Locale.ROOT));
+    }
     if (connection.username() != null) {
       options.put("username", connection.username());
     }
@@ -230,6 +233,13 @@ public class JdbcOfflineSyncConnectorAdapter implements OfflineSyncConnectorAdap
       throw new IllegalArgumentException("数据源 " + dataSource.getName() + " 缺少 JDBC Driver");
     }
 
+    String dialect = firstText(parameters, "dialect");
+    if (!StringUtils.hasText(dialect)
+        && dataSource.getDbType() != null
+        && "TIDB".equals(dataSource.getDbType().name())) {
+      dialect = "tidb";
+    }
+
     JsonNode properties = parameters.get("properties");
     if (properties != null && !properties.isObject()) {
       properties = null;
@@ -242,6 +252,7 @@ public class JdbcOfflineSyncConnectorAdapter implements OfflineSyncConnectorAdap
         firstTextAllowEmpty(parameters, "password", "passwd"),
         firstText(parameters, "schema", "schemaName", "schema_name"),
         properties == null ? null : properties.deepCopy(),
+        dialect,
         firstText(parameters, "compatibleMode", "compatible_mode"));
   }
 
@@ -449,7 +460,9 @@ public class JdbcOfflineSyncConnectorAdapter implements OfflineSyncConnectorAdap
     if (normalized.contains("db2")) {
       return "com.ibm.db2.jcc.DB2Driver";
     }
-    if (normalized.contains("mysql") || normalized.contains("doris")) {
+    if (normalized.contains("tidb")
+        || normalized.contains("mysql")
+        || normalized.contains("doris")) {
       return "com.mysql.cj.jdbc.Driver";
     }
     if (normalized.contains("postgres")) {
@@ -525,5 +538,6 @@ public class JdbcOfflineSyncConnectorAdapter implements OfflineSyncConnectorAdap
       String password,
       String schema,
       JsonNode properties,
+      String dialect,
       String compatibleMode) {}
 }

--- a/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-offline/src/test/java/io/yak/ops/business/sync/offline/engine/connector/OfflineSyncConnectorRegistryTest.java
+++ b/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-offline/src/test/java/io/yak/ops/business/sync/offline/engine/connector/OfflineSyncConnectorRegistryTest.java
@@ -30,6 +30,7 @@ class OfflineSyncConnectorRegistryTest {
         .isEqualTo("elasticsearch8");
 
     for (DataSourceDbType dbType : new DataSourceDbType[] {
+      DataSourceDbType.TIDB,
       DataSourceDbType.DB2,
       DataSourceDbType.OPEN_GAUSS,
       DataSourceDbType.SQL_SERVER,
@@ -51,6 +52,8 @@ class OfflineSyncConnectorRegistryTest {
     assertThat(OfflineSyncConnectorRegistry.defaultConnectorId("STARROCKS")).contains("jdbc");
     assertThat(OfflineSyncConnectorRegistry.defaultConnectorId("CLICKHOUSE")).contains("jdbc");
     assertThat(OfflineSyncConnectorRegistry.defaultConnectorId("POSTGRESQL")).contains("jdbc");
+    assertThat(OfflineSyncConnectorRegistry.defaultConnectorId("TIDB")).contains("jdbc");
+    assertThat(OfflineSyncConnectorRegistry.defaultConnectorId("TI-DB")).contains("jdbc");
     assertThat(OfflineSyncConnectorRegistry.defaultConnectorId("YASHANDB")).contains("jdbc");
     assertThat(OfflineSyncConnectorRegistry.defaultConnectorId("HGDB")).contains("jdbc");
     assertThat(OfflineSyncConnectorRegistry.defaultConnectorId("XUGUDB")).contains("jdbc");

--- a/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-offline/src/test/java/io/yak/ops/business/sync/offline/engine/connector/adapter/JdbcOfflineSyncConnectorAdapterExecutionTest.java
+++ b/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-offline/src/test/java/io/yak/ops/business/sync/offline/engine/connector/adapter/JdbcOfflineSyncConnectorAdapterExecutionTest.java
@@ -39,4 +39,30 @@ class JdbcOfflineSyncConnectorAdapterExecutionTest {
     assertThat(options.path("properties").path("connectTimeout").asText()).isEqualTo("30000");
     assertThat(options.path("password").asText()).isEqualTo("secret");
   }
+
+  @Test
+  void injectsExplicitTiDbDialectForMysqlProtocolUrls() {
+    ObjectMapper mapper = new ObjectMapper();
+    JdbcOfflineSyncConnectorAdapter adapter = new JdbcOfflineSyncConnectorAdapter(mapper);
+    DataSourcePO dataSource = new DataSourcePO();
+    dataSource.setId(11L);
+    dataSource.setName("tidb");
+    dataSource.setDbType(DataSourceDbType.TIDB);
+    dataSource.setConnectionParams(
+        "{\"jdbcUrl\":\"jdbc:mysql://127.0.0.1:4000/app\","
+            + "\"driverClassName\":\"com.mysql.cj.jdbc.Driver\","
+            + "\"username\":\"root\",\"password\":\"secret\"}");
+
+    ObjectNode options = mapper.createObjectNode();
+    options.put("dialect", "mysql");
+    options.put("table_path", "app.orders");
+    adapter.resolveForExecution(
+        new ExecutionContext("jdbc", Role.SOURCE, "来源端", dataSource, options));
+
+    assertThat(options.path("url").asText())
+        .isEqualTo("jdbc:mysql://127.0.0.1:4000/app");
+    assertThat(options.path("driver").asText()).isEqualTo("com.mysql.cj.jdbc.Driver");
+    assertThat(options.path("dialect").asText()).isEqualTo("tidb");
+    assertThat(options.path("password").asText()).isEqualTo("secret");
+  }
 }

--- a/yak-ops-common/src/main/java/io/yak/ops/common/enums/datasource/DataSourceDbType.java
+++ b/yak-ops-common/src/main/java/io/yak/ops/common/enums/datasource/DataSourceDbType.java
@@ -10,6 +10,7 @@ import lombok.RequiredArgsConstructor;
 public enum DataSourceDbType {
 
   MYSQL("MySQL"),
+  TIDB("TiDB"),
   ORACLE("Oracle"),
   POSTGRE_SQL("PostgreSQL"),
   DB2("IBM Db2"),
@@ -39,6 +40,8 @@ public enum DataSourceDbType {
     String normalized = value.trim().toUpperCase(Locale.ROOT).replace('-', '_');
     if ("POSTGRESQL".equals(normalized) || "POSTGRES".equals(normalized)) {
       normalized = "POSTGRE_SQL";
+    } else if ("TI_DB".equals(normalized)) {
+      normalized = "TIDB";
     } else if ("OPENGAUSS".equals(normalized)) {
       normalized = "OPEN_GAUSS";
     } else if ("SQLSERVER".equals(normalized) || "MSSQL".equals(normalized)) {

--- a/yak-ops-common/src/test/java/io/yak/ops/common/enums/datasource/DataSourceDbTypeTest.java
+++ b/yak-ops-common/src/test/java/io/yak/ops/common/enums/datasource/DataSourceDbTypeTest.java
@@ -13,6 +13,10 @@ class DataSourceDbTypeTest {
         .isEqualTo(DataSourceDbType.POSTGRE_SQL);
     assertThat(DataSourceDbType.parse("POSTGRES"))
         .isEqualTo(DataSourceDbType.POSTGRE_SQL);
+    assertThat(DataSourceDbType.parse("tidb"))
+        .isEqualTo(DataSourceDbType.TIDB);
+    assertThat(DataSourceDbType.parse("ti-db"))
+        .isEqualTo(DataSourceDbType.TIDB);
     assertThat(DataSourceDbType.parse("opengauss"))
         .isEqualTo(DataSourceDbType.OPEN_GAUSS);
     assertThat(DataSourceDbType.parse("SQLSERVER"))
@@ -43,6 +47,7 @@ class DataSourceDbTypeTest {
   void shouldExposeCurrentDatasourceTypesAsFirstClassTypes() {
     assertThat(DataSourceDbType.values())
         .contains(
+            DataSourceDbType.TIDB,
             DataSourceDbType.DB2,
             DataSourceDbType.OPEN_GAUSS,
             DataSourceDbType.SQL_SERVER,
@@ -57,6 +62,7 @@ class DataSourceDbTypeTest {
             DataSourceDbType.CLICKHOUSE,
             DataSourceDbType.ELASTICSEARCH7,
             DataSourceDbType.ELASTICSEARCH8);
+    assertThat(DataSourceDbType.TIDB.getDisplayName()).isEqualTo("TiDB");
     assertThat(DataSourceDbType.YASHAN_DB.getDisplayName()).isEqualTo("YashanDB");
     assertThat(DataSourceDbType.HIGHGO.getDisplayName()).isEqualTo("HighGo");
     assertThat(DataSourceDbType.IRIS.getDisplayName()).isEqualTo("InterSystems IRIS");

--- a/yak-ops-plugins/yak-ops-plugin-datasource/yak-ops-plugin-datasource-all/src/test/java/io/yak/ops/plugin/datasource/AllDataSourcePluginsTest.java
+++ b/yak-ops-plugins/yak-ops-plugin-datasource/yak-ops-plugin-datasource-all/src/test/java/io/yak/ops/plugin/datasource/AllDataSourcePluginsTest.java
@@ -21,6 +21,7 @@ class AllDataSourcePluginsTest {
     assertThat(discovered)
         .containsExactlyInAnyOrder(
             DataSourceDbType.MYSQL,
+            DataSourceDbType.TIDB,
             DataSourceDbType.POSTGRE_SQL,
             DataSourceDbType.ORACLE,
             DataSourceDbType.KINGBASE,

--- a/yak-ops-plugins/yak-ops-plugin-datasource/yak-ops-plugin-datasource-jdbc/src/main/java/io/yak/ops/plugin/database/jdbc/GenericJdbcCatalog.java
+++ b/yak-ops-plugins/yak-ops-plugin-datasource/yak-ops-plugin-datasource-jdbc/src/main/java/io/yak/ops/plugin/database/jdbc/GenericJdbcCatalog.java
@@ -341,7 +341,7 @@ public class GenericJdbcCatalog implements DataSourceCatalog {
             oceanBaseOracleMode()
                 ? query + " WHERE ROWNUM <= " + limit
                 : query + " LIMIT " + limit;
-        case MYSQL, POSTGRE_SQL, DORIS, STARROCKS, CLICKHOUSE, KINGBASE, OPEN_GAUSS ->
+        case MYSQL, TIDB, POSTGRE_SQL, DORIS, STARROCKS, CLICKHOUSE, KINGBASE, OPEN_GAUSS ->
             query + " LIMIT " + limit;
         case YASHAN_DB, HIGHGO, IRIS, XUGU, DUCKDB -> query;
         case ELASTICSEARCH7, ELASTICSEARCH8 ->
@@ -360,7 +360,7 @@ public class GenericJdbcCatalog implements DataSourceCatalog {
           oceanBaseOracleMode()
               ? "SELECT * FROM (" + query + ") yak_ops_preview WHERE ROWNUM <= " + limit
               : "SELECT * FROM (" + query + ") yak_ops_preview LIMIT " + limit;
-      case MYSQL, POSTGRE_SQL, DORIS, STARROCKS, CLICKHOUSE, KINGBASE, OPEN_GAUSS ->
+      case MYSQL, TIDB, POSTGRE_SQL, DORIS, STARROCKS, CLICKHOUSE, KINGBASE, OPEN_GAUSS ->
           "SELECT * FROM (" + query + ") yak_ops_preview LIMIT " + limit;
       case YASHAN_DB, HIGHGO, IRIS, XUGU, DUCKDB -> query;
       case ELASTICSEARCH7, ELASTICSEARCH8 ->
@@ -522,6 +522,7 @@ public class GenericJdbcCatalog implements DataSourceCatalog {
 
   private boolean usesCatalogAsNamespace() {
     return connection.dbType() == DataSourceDbType.MYSQL
+        || connection.dbType() == DataSourceDbType.TIDB
         || connection.dbType() == DataSourceDbType.DORIS
         || connection.dbType() == DataSourceDbType.STARROCKS
         || connection.dbType() == DataSourceDbType.CLICKHOUSE

--- a/yak-ops-plugins/yak-ops-plugin-datasource/yak-ops-plugin-datasource-jdbc/src/main/java/io/yak/ops/plugin/database/jdbc/tidb/TiDbDataSourcePlugin.java
+++ b/yak-ops-plugins/yak-ops-plugin-datasource/yak-ops-plugin-datasource-jdbc/src/main/java/io/yak/ops/plugin/database/jdbc/tidb/TiDbDataSourcePlugin.java
@@ -1,0 +1,72 @@
+package io.yak.ops.plugin.database.jdbc.tidb;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import io.yak.ops.common.enums.datasource.DataSourceDbType;
+import io.yak.ops.plugin.database.jdbc.AbstractJdbcDataSourcePlugin;
+import io.yak.ops.plugin.database.jdbc.JdbcConnectionProperties;
+import io.yak.ops.spi.datasource.DataSourceCatalog;
+import java.util.Locale;
+
+/** TiDB datasource plugin backed by the MySQL wire protocol and Connector/J. */
+public final class TiDbDataSourcePlugin extends AbstractJdbcDataSourcePlugin {
+
+  @Override
+  public DataSourceDbType dbType() {
+    return DataSourceDbType.TIDB;
+  }
+
+  @Override
+  protected String jdbcUrlTemplate() {
+    return "jdbc:mysql://{host}:{port}/{database}";
+  }
+
+  @Override
+  protected int defaultPort() {
+    return 4000;
+  }
+
+  @Override
+  protected String defaultDriverClassName() {
+    return "com.mysql.cj.jdbc.Driver";
+  }
+
+  @Override
+  protected String buildJdbcUrl(String host, int port, String database, JsonNode connectionJson) {
+    return "jdbc:mysql://" + host + ":" + port + "/" + database;
+  }
+
+  @Override
+  public boolean acceptsUrl(String jdbcUrl) {
+    return jdbcUrl != null
+        && jdbcUrl.trim().toLowerCase(Locale.ROOT).startsWith("jdbc:mysql:");
+  }
+
+  /**
+   * TiDB exposes MySQL-compatible catalogs, schemas, identifier quoting and preview SQL. Keep the
+   * datasource identity as TIDB while reusing the mature MySQL metadata path internally.
+   */
+  @Override
+  protected DataSourceCatalog createJdbcCatalog(
+      JdbcConnectionProperties connection,
+      int connectionTimeoutSeconds,
+      int queryTimeoutSeconds) {
+    JdbcConnectionProperties mysqlCompatible =
+        new JdbcConnectionProperties(
+            DataSourceDbType.MYSQL,
+            connection.host(),
+            connection.port(),
+            connection.jdbcUrl(),
+            connection.driverClassName(),
+            connection.username(),
+            connection.password(),
+            connection.database(),
+            connection.schema(),
+            connection.properties(),
+            connection.sshTunnel(),
+            connection.normalizedJson());
+    return super.createJdbcCatalog(
+        mysqlCompatible,
+        connectionTimeoutSeconds,
+        queryTimeoutSeconds);
+  }
+}

--- a/yak-ops-plugins/yak-ops-plugin-datasource/yak-ops-plugin-datasource-jdbc/src/main/resources/META-INF/services/io.yak.ops.spi.datasource.DataSourcePlugin
+++ b/yak-ops-plugins/yak-ops-plugin-datasource/yak-ops-plugin-datasource-jdbc/src/main/resources/META-INF/services/io.yak.ops.spi.datasource.DataSourcePlugin
@@ -1,4 +1,5 @@
 io.yak.ops.plugin.database.jdbc.mysql.MySqlDataSourcePlugin
+io.yak.ops.plugin.database.jdbc.tidb.TiDbDataSourcePlugin
 io.yak.ops.plugin.database.jdbc.postgresql.PostgreSqlDataSourcePlugin
 io.yak.ops.plugin.database.jdbc.oracle.OracleDataSourcePlugin
 io.yak.ops.plugin.database.jdbc.kingbase.KingbaseDataSourcePlugin

--- a/yak-ops-plugins/yak-ops-plugin-datasource/yak-ops-plugin-datasource-jdbc/src/test/java/io/yak/ops/plugin/database/jdbc/tidb/TiDbDataSourcePluginTest.java
+++ b/yak-ops-plugins/yak-ops-plugin-datasource/yak-ops-plugin-datasource-jdbc/src/test/java/io/yak/ops/plugin/database/jdbc/tidb/TiDbDataSourcePluginTest.java
@@ -1,0 +1,47 @@
+package io.yak.ops.plugin.database.jdbc.tidb;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.yak.ops.common.enums.datasource.DataSourceDbType;
+import io.yak.ops.spi.datasource.DataSourceCapability;
+import io.yak.ops.spi.datasource.DataSourceConnection;
+import org.junit.jupiter.api.Test;
+
+class TiDbDataSourcePluginTest {
+
+  @Test
+  void shouldUseMysqlConnectorJWithTiDbDefaults() {
+    TiDbDataSourcePlugin plugin = new TiDbDataSourcePlugin();
+    DataSourceConnection connection =
+        plugin.parseConnection(
+            "{\"dbType\":\"TIDB\",\"host\":\"127.0.0.1\","
+                + "\"database\":\"demo\",\"username\":\"root\"}");
+
+    assertThat(connection.dbType()).isEqualTo(DataSourceDbType.TIDB);
+    assertThat(connection.jdbcUrl()).isEqualTo("jdbc:mysql://127.0.0.1:4000/demo");
+    assertThat(connection.driverClassName()).isEqualTo("com.mysql.cj.jdbc.Driver");
+    assertThat(plugin.acceptsUrl(connection.jdbcUrl())).isTrue();
+  }
+
+  @Test
+  void shouldExposeOfflineControlPlaneCapabilities() {
+    TiDbDataSourcePlugin plugin = new TiDbDataSourcePlugin();
+
+    assertThat(plugin.descriptor().displayName()).isEqualTo("TiDB");
+    assertThat(plugin.descriptor().capabilities())
+        .contains(
+            DataSourceCapability.CONNECTION_TEST,
+            DataSourceCapability.CATALOG_METADATA,
+            DataSourceCapability.CATALOG_READ,
+            DataSourceCapability.SQL_EXECUTION,
+            DataSourceCapability.TRANSACTIONS,
+            DataSourceCapability.SSH_TUNNEL);
+    assertThat(plugin.descriptor().connectionForm().sections().get(0).fields().stream()
+            .filter(field -> "jdbcUrl".equals(field.key()))
+            .findFirst()
+            .orElseThrow()
+            .jdbcUrlLinkage()
+            .template())
+        .isEqualTo("jdbc:mysql://{host}:{port}/{database}");
+  }
+}

--- a/yak-ops-ui/src/pages/data-source/components/DataSourceToolbar.tsx
+++ b/yak-ops-ui/src/pages/data-source/components/DataSourceToolbar.tsx
@@ -27,6 +27,7 @@ interface DataSourceToolbarProps {
 
 const DB_TYPE_LABELS: Record<string, string> = {
   MYSQL: 'MYSQL',
+  TIDB: 'TiDB',
   ORACLE: 'ORACLE',
   POSTGRE_SQL: 'PostgreSQL',
   DB2: 'IBM Db2',

--- a/yak-ops-ui/src/pages/data-source/constants.tsx
+++ b/yak-ops-ui/src/pages/data-source/constants.tsx
@@ -30,6 +30,7 @@ export const EMPTY_DATA_SOURCE_SUMMARY: DataSourceSummary = {
 
 export const COMMON_DB_OPTIONS: DataSourceOptionItem[] = [
   { label: 'MYSQL', value: 'MYSQL' },
+  { label: 'TIDB', value: 'TIDB' },
   { label: 'ORACLE', value: 'ORACLE' },
   { label: 'POSTGRE_SQL', value: 'POSTGRE_SQL' },
   { label: 'DB2', value: 'DB2' },
@@ -76,6 +77,7 @@ export const getDataSourceGroupList = (intl: IntlFormatter): DataSourceGroup[] =
     groupName: intl.formatMessage({ id: 'pages.datasource.group.relational' }),
     datasourceList: [
       relationalDataSource('MYSQL'),
+      relationalDataSource('TIDB'),
       relationalDataSource('ORACLE'),
       relationalDataSource('POSTGRE_SQL'),
       relationalDataSource('DB2'),

--- a/yak-ops-ui/src/pages/integration/batch-link-up/DataSourceSelect.tsx
+++ b/yak-ops-ui/src/pages/integration/batch-link-up/DataSourceSelect.tsx
@@ -23,6 +23,7 @@ const executionMetadata = (dbType: string) => {
 
 const DATA_SOURCE_TYPES = [
   { value: 'MYSQL', displayName: 'MYSQL' },
+  { value: 'TIDB', displayName: 'TiDB' },
   { value: 'ORACLE', displayName: 'ORACLE' },
   { value: 'POSTGRE_SQL', displayName: 'PostgreSQL' },
   { value: 'DB2', displayName: 'IBM Db2' },

--- a/yak-ops-ui/src/pages/integration/batch-link-up/connectorProfiles.test.ts
+++ b/yak-ops-ui/src/pages/integration/batch-link-up/connectorProfiles.test.ts
@@ -9,6 +9,7 @@ import {
 test('uses native profiles where needed while keeping JDBC datasource expansion explicit', () => {
   expect(OFFLINE_SYNC_CONNECTOR_PROFILES.map((profile) => profile.dbType)).toEqual([
     'MYSQL',
+    'TIDB',
     'ORACLE',
     'POSTGRE_SQL',
     'DB2',
@@ -28,6 +29,12 @@ test('uses native profiles where needed while keeping JDBC datasource expansion 
     'KINGBASE',
     'DAMENG',
   ]);
+  expect(defaultOfflineSyncConnectorProfile('TIDB')).toMatchObject({
+    profileId: 'tidb-jdbc',
+    sourceConnectorId: 'jdbc',
+    sinkConnectorId: 'jdbc',
+    pluginName: 'JDBC-TIDB',
+  });
   expect(defaultOfflineSyncConnectorProfile('DORIS')).toMatchObject({
     profileId: 'doris-native',
     sourceConnectorId: 'doris',
@@ -69,6 +76,8 @@ test('separates legacy inference from new-task profile selection', () => {
   expect(connectorIdForNewDataSourceType('DORIS')).toBe('doris');
   expect(connectorIdForNewDataSourceType('STARROCKS')).toBe('starrocks');
   expect(connectorIdForNewDataSourceType('CLICKHOUSE')).toBe('clickhouse');
+  expect(connectorIdForNewDataSourceType('TIDB')).toBe('jdbc');
+  expect(connectorIdForNewDataSourceType('TI-DB')).toBe('jdbc');
   expect(connectorIdForNewDataSourceType('YASHANDB')).toBe('jdbc');
   expect(connectorIdForNewDataSourceType('HGDB')).toBe('jdbc');
   expect(connectorIdForNewDataSourceType('XUGUDB')).toBe('jdbc');
@@ -79,6 +88,7 @@ test('separates legacy inference from new-task profile selection', () => {
 
 test('resolves datasource aliases from one frontend registry', () => {
   expect(connectorIdForDataSourceType('POSTGRESQL')).toBe('jdbc');
+  expect(connectorIdForDataSourceType('TIDB')).toBe('jdbc');
   expect(connectorIdForDataSourceType('DB2')).toBe('jdbc');
   expect(connectorIdForDataSourceType('opengauss')).toBe('jdbc');
   expect(connectorIdForDataSourceType('SQLSERVER')).toBe('jdbc');
@@ -103,6 +113,7 @@ test('resolves datasource aliases from one frontend registry', () => {
 
 test('keeps multi-table guide policy connector-profile driven', () => {
   expect(isGuideMultiEnabledForDataSourceType('MYSQL')).toBe(true);
+  expect(isGuideMultiEnabledForDataSourceType('TIDB')).toBe(true);
   expect(isGuideMultiEnabledForDataSourceType('YASHAN_DB')).toBe(true);
   expect(isGuideMultiEnabledForDataSourceType('DUCKDB')).toBe(true);
   expect(isGuideMultiEnabledForDataSourceType('DORIS')).toBe(true);

--- a/yak-ops-ui/src/pages/integration/batch-link-up/connectorProfiles.ts
+++ b/yak-ops-ui/src/pages/integration/batch-link-up/connectorProfiles.ts
@@ -20,6 +20,10 @@ export const OFFLINE_SYNC_CONNECTOR_PROFILES: readonly OfflineSyncConnectorProfi
     connectorType: 'Jdbc', pluginName: 'JDBC-MYSQL', defaultProfile: true,
   },
   {
+    profileId: 'tidb-jdbc', dbType: 'TIDB', sourceConnectorId: 'jdbc', sinkConnectorId: 'jdbc',
+    connectorType: 'Jdbc', pluginName: 'JDBC-TIDB', defaultProfile: true,
+  },
+  {
     profileId: 'oracle-jdbc', dbType: 'ORACLE', sourceConnectorId: 'jdbc', sinkConnectorId: 'jdbc',
     connectorType: 'Jdbc', pluginName: 'JDBC-ORACLE', defaultProfile: true,
   },
@@ -108,6 +112,7 @@ const LEGACY_JDBC_TYPES = new Set([
 const DB_TYPE_ALIASES: Record<string, string> = {
   POSTGRESQL: 'POSTGRE_SQL',
   POSTGRES: 'POSTGRE_SQL',
+  TI_DB: 'TIDB',
   OPENGAUSS: 'OPEN_GAUSS',
   SQLSERVER: 'SQL_SERVER',
   MSSQL: 'SQL_SERVER',


### PR DESCRIPTION
## Summary

Add first-class TiDB support to Yak Ops as an offline JDBC datasource/control-plane integration, aligned with the TiDB JDBC Source + Sink work in `weifuwan/yak-link-up#114`.

### Datasource management

- add `TIDB` as a first-class `DataSourceDbType` with stable `tidb` / `ti-db` parsing
- add a TiDB JDBC datasource plugin
- use TiDB's default SQL port `4000`
- reuse the existing MySQL Connector/J runtime dependency (`com.mysql.cj.jdbc.Driver`)
- keep TiDB as a distinct datasource identity while reusing MySQL-compatible catalog/identifier/preview behavior internally
- expose connection test, catalog metadata/read, SQL execution, transactions, and SSH tunnel capabilities
- register the plugin through the existing `ServiceLoader` contract

### Offline sync control plane

- add the default `tidb-jdbc` connector profile (`jdbc` Source + Sink, `JDBC-TIDB` UI/plugin identity)
- enable single-table and multi-table guided offline sync through the existing JDBC adapter
- inject `dialect=tidb` at execution time for TiDB datasources
- keep datasource-owned connection/dialect options out of the durable logical JobSpec and resolve them immediately before Worker submission
- preserve MySQL Connector/J URL/driver semantics while preventing TiDB from being interpreted as ordinary MySQL by Link-Up

### UI

- expose TiDB in datasource creation/filtering
- expose TiDB in offline sync datasource selection
- reuse the existing TiDB database icon
- enable the existing JDBC multi-table guide behavior for TiDB

### Tests

- TiDB datasource type and aliases
- TiDB JDBC plugin defaults and capabilities
- ServiceLoader discovery
- offline connector profile resolution
- execution-time `dialect=tidb` injection over a `jdbc:mysql://...` URL
- frontend connector profile/alias/multi-table policy

## Scope

This PR is intentionally offline-only. It does **not** add TiCDC, realtime sync, CDC semantics, TiKV/TiFlash native reads, or streaming checkpoint behavior.

## Link-Up dependency

The execution-time `dialect=tidb` contract targets the TiDB JDBC dialect introduced by:

- https://github.com/weifuwan/yak-link-up/pull/114
