### PR TITLE
feat(hana): add datasource and offline sync control-plane support

### DIFF
--- a/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-offline/src/main/java/io/yak/ops/business/sync/offline/engine/connector/OfflineSyncConnectorRegistry.java
+++ b/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-offline/src/main/java/io/yak/ops/business/sync/offline/engine/connector/OfflineSyncConnectorRegistry.java
@@ -23,6 +23,7 @@ public final class OfflineSyncConnectorRegistry {
   private static final List<OfflineSyncConnectorProfile> PROFILES = List.of(
       jdbcProfile("mysql-jdbc", DataSourceDbType.MYSQL, "JDBC-MYSQL"),
       jdbcProfile("tidb-jdbc", DataSourceDbType.TIDB, "JDBC-TIDB"),
+      jdbcProfile("hana-jdbc", DataSourceDbType.HANA, "JDBC-HANA"),
       jdbcProfile("oracle-jdbc", DataSourceDbType.ORACLE, "JDBC-ORACLE"),
       jdbcProfile("postgresql-jdbc", DataSourceDbType.POSTGRE_SQL, "JDBC-POSTGRESQL"),
       jdbcProfile("db2-jdbc", DataSourceDbType.DB2, "JDBC-DB2"),
@@ -67,6 +68,8 @@ public final class OfflineSyncConnectorRegistry {
       Map.entry("POSTGRESQL", DataSourceDbType.POSTGRE_SQL),
       Map.entry("POSTGRES", DataSourceDbType.POSTGRE_SQL),
       Map.entry("TI_DB", DataSourceDbType.TIDB),
+      Map.entry("SAP_HANA", DataSourceDbType.HANA),
+      Map.entry("SAPHANA", DataSourceDbType.HANA),
       Map.entry("OPENGAUSS", DataSourceDbType.OPEN_GAUSS),
       Map.entry("SQLSERVER", DataSourceDbType.SQL_SERVER),
       Map.entry("MSSQL", DataSourceDbType.SQL_SERVER),

--- a/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-offline/src/test/java/io/yak/ops/business/sync/offline/engine/connector/OfflineSyncConnectorRegistryTest.java
+++ b/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-offline/src/test/java/io/yak/ops/business/sync/offline/engine/connector/OfflineSyncConnectorRegistryTest.java
@@ -31,6 +31,7 @@ class OfflineSyncConnectorRegistryTest {
 
     for (DataSourceDbType dbType : new DataSourceDbType[] {
       DataSourceDbType.TIDB,
+      DataSourceDbType.HANA,
       DataSourceDbType.DB2,
       DataSourceDbType.OPEN_GAUSS,
       DataSourceDbType.SQL_SERVER,
@@ -54,6 +55,9 @@ class OfflineSyncConnectorRegistryTest {
     assertThat(OfflineSyncConnectorRegistry.defaultConnectorId("POSTGRESQL")).contains("jdbc");
     assertThat(OfflineSyncConnectorRegistry.defaultConnectorId("TIDB")).contains("jdbc");
     assertThat(OfflineSyncConnectorRegistry.defaultConnectorId("TI-DB")).contains("jdbc");
+    assertThat(OfflineSyncConnectorRegistry.defaultConnectorId("HANA")).contains("jdbc");
+    assertThat(OfflineSyncConnectorRegistry.defaultConnectorId("SAP-HANA")).contains("jdbc");
+    assertThat(OfflineSyncConnectorRegistry.defaultConnectorId("SAPHANA")).contains("jdbc");
     assertThat(OfflineSyncConnectorRegistry.defaultConnectorId("YASHANDB")).contains("jdbc");
     assertThat(OfflineSyncConnectorRegistry.defaultConnectorId("HGDB")).contains("jdbc");
     assertThat(OfflineSyncConnectorRegistry.defaultConnectorId("XUGUDB")).contains("jdbc");

--- a/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-offline/src/test/java/io/yak/ops/business/sync/offline/engine/connector/adapter/JdbcOfflineSyncConnectorAdapterExecutionTest.java
+++ b/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-offline/src/test/java/io/yak/ops/business/sync/offline/engine/connector/adapter/JdbcOfflineSyncConnectorAdapterExecutionTest.java
@@ -65,4 +65,33 @@ class JdbcOfflineSyncConnectorAdapterExecutionTest {
     assertThat(options.path("dialect").asText()).isEqualTo("tidb");
     assertThat(options.path("password").asText()).isEqualTo("secret");
   }
+
+  @Test
+  void injectsHanaDialectAndSchemaFromDatasourceOwnedConnection() {
+    ObjectMapper mapper = new ObjectMapper();
+    JdbcOfflineSyncConnectorAdapter adapter = new JdbcOfflineSyncConnectorAdapter(mapper);
+    DataSourcePO dataSource = new DataSourcePO();
+    dataSource.setId(12L);
+    dataSource.setName("hana");
+    dataSource.setDbType(DataSourceDbType.HANA);
+    dataSource.setConnectionParams(
+        "{\"jdbcUrl\":\"jdbc:sap://127.0.0.1:30013/?databaseName=HXE\","
+            + "\"driverClassName\":\"com.sap.db.jdbc.Driver\","
+            + "\"username\":\"SYSTEM\",\"password\":\"secret\","
+            + "\"schema\":\"SALES\",\"dialect\":\"hana\"}");
+
+    ObjectNode options = mapper.createObjectNode();
+    options.put("url", "jdbc:mysql://stale:3306/source");
+    options.put("dialect", "mysql");
+    options.put("table_path", "SALES.ORDERS");
+    adapter.resolveForExecution(
+        new ExecutionContext("jdbc", Role.SINK, "目标端", dataSource, options));
+
+    assertThat(options.path("url").asText())
+        .isEqualTo("jdbc:sap://127.0.0.1:30013/?databaseName=HXE");
+    assertThat(options.path("driver").asText()).isEqualTo("com.sap.db.jdbc.Driver");
+    assertThat(options.path("dialect").asText()).isEqualTo("hana");
+    assertThat(options.path("schema").asText()).isEqualTo("SALES");
+    assertThat(options.path("password").asText()).isEqualTo("secret");
+  }
 }

--- a/yak-ops-common/src/main/java/io/yak/ops/common/enums/datasource/DataSourceDbType.java
+++ b/yak-ops-common/src/main/java/io/yak/ops/common/enums/datasource/DataSourceDbType.java
@@ -11,6 +11,7 @@ public enum DataSourceDbType {
 
   MYSQL("MySQL"),
   TIDB("TiDB"),
+  HANA("SAP HANA"),
   ORACLE("Oracle"),
   POSTGRE_SQL("PostgreSQL"),
   DB2("IBM Db2"),
@@ -42,6 +43,8 @@ public enum DataSourceDbType {
       normalized = "POSTGRE_SQL";
     } else if ("TI_DB".equals(normalized)) {
       normalized = "TIDB";
+    } else if ("SAP_HANA".equals(normalized) || "SAPHANA".equals(normalized)) {
+      normalized = "HANA";
     } else if ("OPENGAUSS".equals(normalized)) {
       normalized = "OPEN_GAUSS";
     } else if ("SQLSERVER".equals(normalized) || "MSSQL".equals(normalized)) {

--- a/yak-ops-common/src/test/java/io/yak/ops/common/enums/datasource/DataSourceDbTypeTest.java
+++ b/yak-ops-common/src/test/java/io/yak/ops/common/enums/datasource/DataSourceDbTypeTest.java
@@ -17,6 +17,12 @@ class DataSourceDbTypeTest {
         .isEqualTo(DataSourceDbType.TIDB);
     assertThat(DataSourceDbType.parse("ti-db"))
         .isEqualTo(DataSourceDbType.TIDB);
+    assertThat(DataSourceDbType.parse("hana"))
+        .isEqualTo(DataSourceDbType.HANA);
+    assertThat(DataSourceDbType.parse("sap-hana"))
+        .isEqualTo(DataSourceDbType.HANA);
+    assertThat(DataSourceDbType.parse("saphana"))
+        .isEqualTo(DataSourceDbType.HANA);
     assertThat(DataSourceDbType.parse("opengauss"))
         .isEqualTo(DataSourceDbType.OPEN_GAUSS);
     assertThat(DataSourceDbType.parse("SQLSERVER"))
@@ -48,6 +54,7 @@ class DataSourceDbTypeTest {
     assertThat(DataSourceDbType.values())
         .contains(
             DataSourceDbType.TIDB,
+            DataSourceDbType.HANA,
             DataSourceDbType.DB2,
             DataSourceDbType.OPEN_GAUSS,
             DataSourceDbType.SQL_SERVER,
@@ -63,6 +70,7 @@ class DataSourceDbTypeTest {
             DataSourceDbType.ELASTICSEARCH7,
             DataSourceDbType.ELASTICSEARCH8);
     assertThat(DataSourceDbType.TIDB.getDisplayName()).isEqualTo("TiDB");
+    assertThat(DataSourceDbType.HANA.getDisplayName()).isEqualTo("SAP HANA");
     assertThat(DataSourceDbType.YASHAN_DB.getDisplayName()).isEqualTo("YashanDB");
     assertThat(DataSourceDbType.HIGHGO.getDisplayName()).isEqualTo("HighGo");
     assertThat(DataSourceDbType.IRIS.getDisplayName()).isEqualTo("InterSystems IRIS");

--- a/yak-ops-plugins/yak-ops-plugin-datasource/yak-ops-plugin-datasource-all/src/test/java/io/yak/ops/plugin/datasource/AllDataSourcePluginsTest.java
+++ b/yak-ops-plugins/yak-ops-plugin-datasource/yak-ops-plugin-datasource-all/src/test/java/io/yak/ops/plugin/datasource/AllDataSourcePluginsTest.java
@@ -22,6 +22,7 @@ class AllDataSourcePluginsTest {
         .containsExactlyInAnyOrder(
             DataSourceDbType.MYSQL,
             DataSourceDbType.TIDB,
+            DataSourceDbType.HANA,
             DataSourceDbType.POSTGRE_SQL,
             DataSourceDbType.ORACLE,
             DataSourceDbType.KINGBASE,

--- a/yak-ops-plugins/yak-ops-plugin-datasource/yak-ops-plugin-datasource-jdbc/pom.xml
+++ b/yak-ops-plugins/yak-ops-plugin-datasource/yak-ops-plugin-datasource-jdbc/pom.xml
@@ -47,6 +47,12 @@
             <scope>runtime</scope>
         </dependency>
         <dependency>
+            <groupId>com.sap.cloud.db.jdbc</groupId>
+            <artifactId>ngdbc</artifactId>
+            <version>2.29.7</version>
+            <scope>runtime</scope>
+        </dependency>
+        <dependency>
             <groupId>org.opengauss</groupId>
             <artifactId>opengauss-jdbc</artifactId>
             <version>6.0.3</version>

--- a/yak-ops-plugins/yak-ops-plugin-datasource/yak-ops-plugin-datasource-jdbc/src/main/java/io/yak/ops/plugin/database/jdbc/GenericJdbcCatalog.java
+++ b/yak-ops-plugins/yak-ops-plugin-datasource/yak-ops-plugin-datasource-jdbc/src/main/java/io/yak/ops/plugin/database/jdbc/GenericJdbcCatalog.java
@@ -88,7 +88,7 @@ public class GenericJdbcCatalog implements DataSourceCatalog {
     try (Connection opened = openConnection()) {
       Set<String> schemas = new LinkedHashSet<>();
       DatabaseMetaData metadata = opened.getMetaData();
-      String catalog = usesOracleStyle() ? null : trimToNull(database);
+      String catalog = metadataCatalog(database);
       try (ResultSet resultSet = schemas(metadata, catalog)) {
         while (resultSet.next()) {
           String schema = resultSet.getString("TABLE_SCHEM");
@@ -341,7 +341,7 @@ public class GenericJdbcCatalog implements DataSourceCatalog {
             oceanBaseOracleMode()
                 ? query + " WHERE ROWNUM <= " + limit
                 : query + " LIMIT " + limit;
-        case MYSQL, TIDB, POSTGRE_SQL, DORIS, STARROCKS, CLICKHOUSE, KINGBASE, OPEN_GAUSS ->
+        case MYSQL, TIDB, HANA, POSTGRE_SQL, DORIS, STARROCKS, CLICKHOUSE, KINGBASE, OPEN_GAUSS ->
             query + " LIMIT " + limit;
         case YASHAN_DB, HIGHGO, IRIS, XUGU, DUCKDB -> query;
         case ELASTICSEARCH7, ELASTICSEARCH8 ->
@@ -360,7 +360,7 @@ public class GenericJdbcCatalog implements DataSourceCatalog {
           oceanBaseOracleMode()
               ? "SELECT * FROM (" + query + ") yak_ops_preview WHERE ROWNUM <= " + limit
               : "SELECT * FROM (" + query + ") yak_ops_preview LIMIT " + limit;
-      case MYSQL, TIDB, POSTGRE_SQL, DORIS, STARROCKS, CLICKHOUSE, KINGBASE, OPEN_GAUSS ->
+      case MYSQL, TIDB, HANA, POSTGRE_SQL, DORIS, STARROCKS, CLICKHOUSE, KINGBASE, OPEN_GAUSS ->
           "SELECT * FROM (" + query + ") yak_ops_preview LIMIT " + limit;
       case YASHAN_DB, HIGHGO, IRIS, XUGU, DUCKDB -> query;
       case ELASTICSEARCH7, ELASTICSEARCH8 ->
@@ -406,7 +406,7 @@ public class GenericJdbcCatalog implements DataSourceCatalog {
   }
 
   private String metadataCatalog(String requestedDatabase) {
-    if (usesOracleStyle()) {
+    if (usesOracleStyle() || connection.dbType() == DataSourceDbType.HANA) {
       return null;
     }
     return firstNonBlank(requestedDatabase, connection.database());

--- a/yak-ops-plugins/yak-ops-plugin-datasource/yak-ops-plugin-datasource-jdbc/src/main/java/io/yak/ops/plugin/database/jdbc/hana/HanaDataSourcePlugin.java
+++ b/yak-ops-plugins/yak-ops-plugin-datasource/yak-ops-plugin-datasource-jdbc/src/main/java/io/yak/ops/plugin/database/jdbc/hana/HanaDataSourcePlugin.java
@@ -1,0 +1,152 @@
+package io.yak.ops.plugin.database.jdbc.hana;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import io.yak.ops.common.enums.datasource.DataSourceDbType;
+import io.yak.ops.plugin.database.jdbc.AbstractJdbcDataSourcePlugin;
+import io.yak.ops.plugin.database.jdbc.GenericJdbcCatalog;
+import io.yak.ops.plugin.database.jdbc.JdbcConnectionProperties;
+import io.yak.ops.spi.datasource.DataSourceCatalog;
+import java.net.URLDecoder;
+import java.nio.charset.StandardCharsets;
+import java.sql.Connection;
+import java.util.List;
+import java.util.Locale;
+import java.util.Properties;
+
+/** SAP HANA JDBC datasource plugin backed by SAP ngdbc. */
+public final class HanaDataSourcePlugin extends AbstractJdbcDataSourcePlugin {
+
+  private static final String URL_PREFIX = "jdbc:sap://";
+
+  @Override
+  public DataSourceDbType dbType() {
+    return DataSourceDbType.HANA;
+  }
+
+  @Override
+  protected String jdbcUrlTemplate() {
+    return "jdbc:sap://{host}:{port}/?databaseName={database}";
+  }
+
+  @Override
+  protected int defaultPort() {
+    // 30015 is the common SQL port for instance 00 / the initial tenant.
+    // Additional tenant databases can use other SQL ports, so the form keeps this editable.
+    return 30015;
+  }
+
+  @Override
+  protected String defaultDriverClassName() {
+    return "com.sap.db.jdbc.Driver";
+  }
+
+  @Override
+  protected String buildJdbcUrl(
+      String host, int port, String database, JsonNode connectionJson) {
+    return URL_PREFIX + host + ":" + port + "/?databaseName=" + database;
+  }
+
+  @Override
+  public boolean acceptsUrl(String jdbcUrl) {
+    return jdbcUrl != null
+        && jdbcUrl.trim().toLowerCase(Locale.ROOT).startsWith(URL_PREFIX);
+  }
+
+  @Override
+  protected String inferDatabase(String jdbcUrl) {
+    if (!acceptsUrl(jdbcUrl)) {
+      return null;
+    }
+    int queryStart = jdbcUrl.indexOf('?');
+    if (queryStart < 0 || queryStart == jdbcUrl.length() - 1) {
+      return null;
+    }
+    String query = jdbcUrl.substring(queryStart + 1);
+    for (String item : query.split("&")) {
+      int equals = item.indexOf('=');
+      if (equals <= 0) {
+        continue;
+      }
+      String key = decode(item.substring(0, equals));
+      if (!"databaseName".equalsIgnoreCase(key.trim())) {
+        continue;
+      }
+      String value = decode(item.substring(equals + 1)).trim();
+      return value.isEmpty() ? null : value;
+    }
+    return null;
+  }
+
+  @Override
+  protected void appendNormalizedFields(JsonNode source, ObjectNode normalized) {
+    // Keep datasource-owned dialect identity next to the connection parameters. Offline JobSpec
+    // strips it while editing and resolves it again immediately before Link-Up submission.
+    normalized.put("dialect", "hana");
+  }
+
+  @Override
+  protected Properties connectionProperties(JdbcConnectionProperties connection) {
+    Properties properties = super.connectionProperties(connection);
+    if (connection.schema() != null
+        && !connection.schema().trim().isEmpty()
+        && !containsKeyIgnoreCase(properties, "currentSchema")) {
+      properties.setProperty("currentSchema", connection.schema().trim());
+    }
+    return properties;
+  }
+
+  /**
+   * HANA metadata is schema-scoped; tenant database selection belongs to the JDBC connection.
+   * System schemas are hidden from the normal datasource browser to keep table selection usable.
+   */
+  @Override
+  protected DataSourceCatalog createJdbcCatalog(
+      JdbcConnectionProperties connection,
+      int connectionTimeoutSeconds,
+      int queryTimeoutSeconds) {
+    return new GenericJdbcCatalog(connection, connectionTimeoutSeconds, queryTimeoutSeconds) {
+      @Override
+      public List<String> listDatabases() {
+        String database = connection.database();
+        return database == null || database.trim().isEmpty()
+            ? List.of()
+            : List.of(database.trim());
+      }
+
+      @Override
+      protected Connection openConnection() throws Exception {
+        return HanaDataSourcePlugin.this.openJdbcConnection(
+            connection, connectionTimeoutSeconds);
+      }
+
+      @Override
+      protected boolean includeSchema(String schema) {
+        if (!super.includeSchema(schema)) {
+          return false;
+        }
+        String normalized = schema.trim().toUpperCase(Locale.ROOT);
+        return !"SYS".equals(normalized)
+            && !normalized.startsWith("_SYS_")
+            && !"SAP_HANA_INTERNAL".equals(normalized);
+      }
+    };
+  }
+
+  private static boolean containsKeyIgnoreCase(Properties properties, String key) {
+    for (Object propertyKey : properties.keySet()) {
+      if (propertyKey != null && key.equalsIgnoreCase(propertyKey.toString())) {
+        return true;
+      }
+    }
+    return false;
+  }
+
+  private static String decode(String value) {
+    try {
+      return URLDecoder.decode(value, StandardCharsets.UTF_8.name());
+    } catch (Exception ignored) {
+      return value;
+    }
+  }
+}

--- a/yak-ops-plugins/yak-ops-plugin-datasource/yak-ops-plugin-datasource-jdbc/src/main/resources/META-INF/services/io.yak.ops.spi.datasource.DataSourcePlugin
+++ b/yak-ops-plugins/yak-ops-plugin-datasource/yak-ops-plugin-datasource-jdbc/src/main/resources/META-INF/services/io.yak.ops.spi.datasource.DataSourcePlugin
@@ -1,5 +1,6 @@
 io.yak.ops.plugin.database.jdbc.mysql.MySqlDataSourcePlugin
 io.yak.ops.plugin.database.jdbc.tidb.TiDbDataSourcePlugin
+io.yak.ops.plugin.database.jdbc.hana.HanaDataSourcePlugin
 io.yak.ops.plugin.database.jdbc.postgresql.PostgreSqlDataSourcePlugin
 io.yak.ops.plugin.database.jdbc.oracle.OracleDataSourcePlugin
 io.yak.ops.plugin.database.jdbc.kingbase.KingbaseDataSourcePlugin

--- a/yak-ops-plugins/yak-ops-plugin-datasource/yak-ops-plugin-datasource-jdbc/src/test/java/io/yak/ops/plugin/database/jdbc/hana/HanaDataSourcePluginTest.java
+++ b/yak-ops-plugins/yak-ops-plugin-datasource/yak-ops-plugin-datasource-jdbc/src/test/java/io/yak/ops/plugin/database/jdbc/hana/HanaDataSourcePluginTest.java
@@ -1,0 +1,72 @@
+package io.yak.ops.plugin.database.jdbc.hana;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.yak.ops.common.enums.datasource.DataSourceDbType;
+import io.yak.ops.spi.datasource.DataSourceCapability;
+import io.yak.ops.spi.datasource.DataSourceConnection;
+import org.junit.jupiter.api.Test;
+
+class HanaDataSourcePluginTest {
+
+  private static final ObjectMapper MAPPER = new ObjectMapper();
+
+  @Test
+  void shouldUseNgdbcAndBuildHanaDatabaseUrl() throws Exception {
+    HanaDataSourcePlugin plugin = new HanaDataSourcePlugin();
+    DataSourceConnection connection =
+        plugin.parseConnection(
+            "{\"dbType\":\"HANA\",\"host\":\"127.0.0.1\","
+                + "\"database\":\"HXE\",\"schema\":\"SALES\","
+                + "\"username\":\"SYSTEM\"}");
+
+    assertThat(connection.dbType()).isEqualTo(DataSourceDbType.HANA);
+    assertThat(connection.jdbcUrl())
+        .isEqualTo("jdbc:sap://127.0.0.1:30015/?databaseName=HXE");
+    assertThat(connection.driverClassName()).isEqualTo("com.sap.db.jdbc.Driver");
+    assertThat(plugin.acceptsUrl(connection.jdbcUrl())).isTrue();
+
+    JsonNode normalized = MAPPER.readTree(connection.normalizedJson());
+    assertThat(normalized.path("database").asText()).isEqualTo("HXE");
+    assertThat(normalized.path("schema").asText()).isEqualTo("SALES");
+    assertThat(normalized.path("dialect").asText()).isEqualTo("hana");
+  }
+
+  @Test
+  void shouldInferDatabaseNameFromExplicitSapJdbcUrl() throws Exception {
+    HanaDataSourcePlugin plugin = new HanaDataSourcePlugin();
+    DataSourceConnection connection =
+        plugin.parseConnection(
+            "{\"dbType\":\"SAP-HANA\","
+                + "\"jdbcUrl\":\"jdbc:sap://hana:30013/?databaseName=TENANT%5F01&encrypt=true\","
+                + "\"username\":\"SYSTEM\"}");
+
+    JsonNode normalized = MAPPER.readTree(connection.normalizedJson());
+    assertThat(normalized.path("database").asText()).isEqualTo("TENANT_01");
+    assertThat(normalized.path("dialect").asText()).isEqualTo("hana");
+  }
+
+  @Test
+  void shouldExposeOfflineControlPlaneCapabilities() {
+    HanaDataSourcePlugin plugin = new HanaDataSourcePlugin();
+
+    assertThat(plugin.descriptor().displayName()).isEqualTo("SAP HANA");
+    assertThat(plugin.descriptor().capabilities())
+        .contains(
+            DataSourceCapability.CONNECTION_TEST,
+            DataSourceCapability.CATALOG_METADATA,
+            DataSourceCapability.CATALOG_READ,
+            DataSourceCapability.SQL_EXECUTION,
+            DataSourceCapability.TRANSACTIONS,
+            DataSourceCapability.SSH_TUNNEL);
+    assertThat(plugin.descriptor().connectionForm().sections().get(0).fields().stream()
+            .filter(field -> "jdbcUrl".equals(field.key()))
+            .findFirst()
+            .orElseThrow()
+            .jdbcUrlLinkage()
+            .template())
+        .isEqualTo("jdbc:sap://{host}:{port}/?databaseName={database}");
+  }
+}

--- a/yak-ops-ui/src/pages/data-source/components/DataSourceToolbar.tsx
+++ b/yak-ops-ui/src/pages/data-source/components/DataSourceToolbar.tsx
@@ -28,6 +28,7 @@ interface DataSourceToolbarProps {
 const DB_TYPE_LABELS: Record<string, string> = {
   MYSQL: 'MYSQL',
   TIDB: 'TiDB',
+  HANA: 'SAP HANA',
   ORACLE: 'ORACLE',
   POSTGRE_SQL: 'PostgreSQL',
   DB2: 'IBM Db2',

--- a/yak-ops-ui/src/pages/data-source/constants.tsx
+++ b/yak-ops-ui/src/pages/data-source/constants.tsx
@@ -31,6 +31,7 @@ export const EMPTY_DATA_SOURCE_SUMMARY: DataSourceSummary = {
 export const COMMON_DB_OPTIONS: DataSourceOptionItem[] = [
   { label: 'MYSQL', value: 'MYSQL' },
   { label: 'TIDB', value: 'TIDB' },
+  { label: 'HANA', value: 'HANA' },
   { label: 'ORACLE', value: 'ORACLE' },
   { label: 'POSTGRE_SQL', value: 'POSTGRE_SQL' },
   { label: 'DB2', value: 'DB2' },
@@ -78,6 +79,7 @@ export const getDataSourceGroupList = (intl: IntlFormatter): DataSourceGroup[] =
     datasourceList: [
       relationalDataSource('MYSQL'),
       relationalDataSource('TIDB'),
+      relationalDataSource('HANA'),
       relationalDataSource('ORACLE'),
       relationalDataSource('POSTGRE_SQL'),
       relationalDataSource('DB2'),

--- a/yak-ops-ui/src/pages/integration/batch-link-up/DataSourceSelect.tsx
+++ b/yak-ops-ui/src/pages/integration/batch-link-up/DataSourceSelect.tsx
@@ -24,6 +24,7 @@ const executionMetadata = (dbType: string) => {
 const DATA_SOURCE_TYPES = [
   { value: 'MYSQL', displayName: 'MYSQL' },
   { value: 'TIDB', displayName: 'TiDB' },
+  { value: 'HANA', displayName: 'SAP HANA' },
   { value: 'ORACLE', displayName: 'ORACLE' },
   { value: 'POSTGRE_SQL', displayName: 'PostgreSQL' },
   { value: 'DB2', displayName: 'IBM Db2' },

--- a/yak-ops-ui/src/pages/integration/batch-link-up/connectorProfiles.test.ts
+++ b/yak-ops-ui/src/pages/integration/batch-link-up/connectorProfiles.test.ts
@@ -10,6 +10,7 @@ test('uses native profiles where needed while keeping JDBC datasource expansion 
   expect(OFFLINE_SYNC_CONNECTOR_PROFILES.map((profile) => profile.dbType)).toEqual([
     'MYSQL',
     'TIDB',
+    'HANA',
     'ORACLE',
     'POSTGRE_SQL',
     'DB2',
@@ -35,6 +36,16 @@ test('uses native profiles where needed while keeping JDBC datasource expansion 
     sinkConnectorId: 'jdbc',
     pluginName: 'JDBC-TIDB',
   });
+  expect(defaultOfflineSyncConnectorProfile('HANA')).toMatchObject({
+    profileId: 'hana-jdbc',
+    sourceConnectorId: 'jdbc',
+    sinkConnectorId: 'jdbc',
+    pluginName: 'JDBC-HANA',
+  });
+  expect(defaultOfflineSyncConnectorProfile('SAP-HANA')).toMatchObject({
+    profileId: 'hana-jdbc',
+    dbType: 'HANA',
+  });
   expect(defaultOfflineSyncConnectorProfile('DORIS')).toMatchObject({
     profileId: 'doris-native',
     sourceConnectorId: 'doris',
@@ -48,7 +59,7 @@ test('uses native profiles where needed while keeping JDBC datasource expansion 
     profileId: 'clickhouse-native',
     sourceConnectorId: 'clickhouse',
   });
-  for (const dbType of ['YASHAN_DB', 'HIGHGO', 'IRIS', 'XUGU', 'DUCKDB']) {
+  for (const dbType of ['HANA', 'YASHAN_DB', 'HIGHGO', 'IRIS', 'XUGU', 'DUCKDB']) {
     expect(defaultOfflineSyncConnectorProfile(dbType)).toMatchObject({
       dbType,
       sourceConnectorId: 'jdbc',
@@ -78,6 +89,9 @@ test('separates legacy inference from new-task profile selection', () => {
   expect(connectorIdForNewDataSourceType('CLICKHOUSE')).toBe('clickhouse');
   expect(connectorIdForNewDataSourceType('TIDB')).toBe('jdbc');
   expect(connectorIdForNewDataSourceType('TI-DB')).toBe('jdbc');
+  expect(connectorIdForNewDataSourceType('HANA')).toBe('jdbc');
+  expect(connectorIdForNewDataSourceType('SAP-HANA')).toBe('jdbc');
+  expect(connectorIdForNewDataSourceType('SAPHANA')).toBe('jdbc');
   expect(connectorIdForNewDataSourceType('YASHANDB')).toBe('jdbc');
   expect(connectorIdForNewDataSourceType('HGDB')).toBe('jdbc');
   expect(connectorIdForNewDataSourceType('XUGUDB')).toBe('jdbc');
@@ -89,6 +103,9 @@ test('separates legacy inference from new-task profile selection', () => {
 test('resolves datasource aliases from one frontend registry', () => {
   expect(connectorIdForDataSourceType('POSTGRESQL')).toBe('jdbc');
   expect(connectorIdForDataSourceType('TIDB')).toBe('jdbc');
+  expect(connectorIdForDataSourceType('HANA')).toBe('jdbc');
+  expect(connectorIdForDataSourceType('SAP-HANA')).toBe('jdbc');
+  expect(connectorIdForDataSourceType('SAPHANA')).toBe('jdbc');
   expect(connectorIdForDataSourceType('DB2')).toBe('jdbc');
   expect(connectorIdForDataSourceType('opengauss')).toBe('jdbc');
   expect(connectorIdForDataSourceType('SQLSERVER')).toBe('jdbc');
@@ -105,6 +122,10 @@ test('resolves datasource aliases from one frontend registry', () => {
     profileId: 'postgresql-jdbc',
     dbType: 'POSTGRE_SQL',
   });
+  expect(defaultOfflineSyncConnectorProfile('SAPHANA')).toMatchObject({
+    profileId: 'hana-jdbc',
+    dbType: 'HANA',
+  });
   expect(defaultOfflineSyncConnectorProfile('ES8')).toMatchObject({
     dbType: 'ELASTICSEARCH8',
     sourceConnectorId: 'elasticsearch8',
@@ -114,6 +135,8 @@ test('resolves datasource aliases from one frontend registry', () => {
 test('keeps multi-table guide policy connector-profile driven', () => {
   expect(isGuideMultiEnabledForDataSourceType('MYSQL')).toBe(true);
   expect(isGuideMultiEnabledForDataSourceType('TIDB')).toBe(true);
+  expect(isGuideMultiEnabledForDataSourceType('HANA')).toBe(true);
+  expect(isGuideMultiEnabledForDataSourceType('SAP-HANA')).toBe(true);
   expect(isGuideMultiEnabledForDataSourceType('YASHAN_DB')).toBe(true);
   expect(isGuideMultiEnabledForDataSourceType('DUCKDB')).toBe(true);
   expect(isGuideMultiEnabledForDataSourceType('DORIS')).toBe(true);

--- a/yak-ops-ui/src/pages/integration/batch-link-up/connectorProfiles.ts
+++ b/yak-ops-ui/src/pages/integration/batch-link-up/connectorProfiles.ts
@@ -24,6 +24,10 @@ export const OFFLINE_SYNC_CONNECTOR_PROFILES: readonly OfflineSyncConnectorProfi
     connectorType: 'Jdbc', pluginName: 'JDBC-TIDB', defaultProfile: true,
   },
   {
+    profileId: 'hana-jdbc', dbType: 'HANA', sourceConnectorId: 'jdbc', sinkConnectorId: 'jdbc',
+    connectorType: 'Jdbc', pluginName: 'JDBC-HANA', defaultProfile: true,
+  },
+  {
     profileId: 'oracle-jdbc', dbType: 'ORACLE', sourceConnectorId: 'jdbc', sinkConnectorId: 'jdbc',
     connectorType: 'Jdbc', pluginName: 'JDBC-ORACLE', defaultProfile: true,
   },
@@ -113,6 +117,8 @@ const DB_TYPE_ALIASES: Record<string, string> = {
   POSTGRESQL: 'POSTGRE_SQL',
   POSTGRES: 'POSTGRE_SQL',
   TI_DB: 'TIDB',
+  SAP_HANA: 'HANA',
+  SAPHANA: 'HANA',
   OPENGAUSS: 'OPEN_GAUSS',
   SQLSERVER: 'SQL_SERVER',
   MSSQL: 'SQL_SERVER',


### PR DESCRIPTION
## Summary

Add first-class SAP HANA support to Yak Ops datasource management and bounded/offline synchronization, aligned with the HANA JDBC Source/Sink work in `weifuwan/yak-link-up#115` and `weifuwan/yak-link-up#116`.

### Datasource management

- add `HANA` as a first-class `DataSourceDbType`, with `hana`, `sap-hana` and `saphana` parsing
- add an SAP HANA JDBC datasource plugin backed by SAP `ngdbc`
- use `com.sap.db.jdbc.Driver` and `jdbc:sap://.../?databaseName=...`
- expose an editable default SQL port of `30015` while still supporting explicit HANA JDBC URLs / tenant-specific ports
- persist `dialect=hana` as datasource-owned normalized connection metadata
- map the optional Yak Ops `schema` field to HANA `currentSchema`
- keep HANA tenant database selection connection-scoped while browsing tables by `schema.table`
- hide HANA system schemas from the normal datasource browser
- expose connection test, metadata/read, SQL execution, transactions and SSH tunnel capabilities
- register the plugin through the existing `ServiceLoader` contract

### Offline sync control plane

- add the default `hana-jdbc` connector profile (`jdbc` Source + Sink, `JDBC-HANA` UI/plugin identity)
- support guided single-table and multi-table offline synchronization through the existing JDBC adapter
- resolve datasource-owned HANA `url`, `driver`, `schema`, credentials and `dialect=hana` immediately before Link-Up submission
- keep those connection options out of the durable logical JobSpec
- preserve HANA `schema.table` semantics instead of treating the tenant database as a JDBC catalog

### UI

- expose SAP HANA in datasource creation and datasource filtering
- expose SAP HANA in offline Source/Sink datasource selection
- enable the existing JDBC multi-table guide policy for HANA
- reuse the generic database icon fallback for now; this PR does not add a new brand asset

### Tests

- HANA datasource type and aliases
- HANA JDBC plugin URL/driver/defaults/capabilities and normalized `dialect=hana`
- ServiceLoader discovery
- HANA offline connector profile and aliases
- execution-time HANA connection/dialect/schema restoration
- frontend profile/alias/multi-table policy

## Scope

This PR is intentionally offline-only. It does **not** add HANA CDC, SAP SLT, realtime synchronization or streaming checkpoint semantics.

## Link-Up dependency

The execution contract targets the HANA JDBC implementation introduced by:

- Source / metadata: https://github.com/weifuwan/yak-link-up/pull/115
- Sink / DDL / INSERT / MERGE UPSERT: https://github.com/weifuwan/yak-link-up/pull/116

## Validation

- branch is based directly on current `main` and contains one HANA control-plane commit
- the final diff is limited to datasource management, offline-sync control-plane integration, UI exposure and focused tests
- HANA has been added to the exhaustive JDBC preview switch and uses `null` JDBC catalog metadata with schema-scoped table discovery
- no live SAP HANA environment is available in this session, so environment-backed connectivity/catalog/offline-sync verification is still required before marking this PR ready
