### PR TITLE
feat(mongodb): add datasource management and offline sync support

### DIFF
--- a/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-offline/src/main/java/io/yak/ops/business/sync/offline/engine/OfflineDefinitionModelAdapter.java
+++ b/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-offline/src/main/java/io/yak/ops/business/sync/offline/engine/OfflineDefinitionModelAdapter.java
@@ -112,6 +112,8 @@ public final class OfflineDefinitionModelAdapter {
       return definition;
     }
     ObjectNode adapted = (ObjectNode) definition.deepCopy();
+    // Notification and editor metadata are Yak Ops control-plane concerns. They must never alter
+    // engine JobSpec, execution snapshots or config digests when only UI preferences change.
     adapted.remove("notification");
     adapted.remove("editorMeta");
     String mode = text(adapted.path("basic"), "mode", "GUIDE_SINGLE");
@@ -120,7 +122,10 @@ public final class OfflineDefinitionModelAdapter {
     return adapted;
   }
 
-  /** 清理由数据源负责维护的连接字段，防止凭据进入 definition_json。 */
+  /**
+   * 清理由数据源负责维护的连接字段，防止凭据进入 definition_json。
+   * 非数据源拥有的 Task Connector options 保持原样。
+   */
   public static void sanitizeForPersistence(ObjectNode definition) {
     if (definition == null) {
       return;

--- a/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-offline/src/main/java/io/yak/ops/business/sync/offline/engine/OfflineDefinitionModelAdapter.java
+++ b/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-offline/src/main/java/io/yak/ops/business/sync/offline/engine/OfflineDefinitionModelAdapter.java
@@ -61,6 +61,23 @@ public final class OfflineDefinitionModelAdapter {
       "connection_params",
       "connect_timeout_ms",
       "socket_timeout_ms");
+  private static final Set<String> MONGODB_DATASOURCE_OWNED_FIELDS = Set.of(
+      "uri",
+      "url",
+      "host",
+      "hosts",
+      "hostname",
+      "port",
+      "username",
+      "user",
+      "password",
+      "passwd",
+      "authSource",
+      "auth_source",
+      "connectionParams",
+      "connection_params",
+      "connect_timeout_ms",
+      "socket_timeout_ms");
 
   private static final List<String> SOURCE_FIELDS = List.of(
       "database",
@@ -68,6 +85,7 @@ public final class OfflineDefinitionModelAdapter {
       "table",
       "tables",
       "tablePattern",
+      "fields",
       "sql",
       "whereCondition",
       "fetchSize");
@@ -94,8 +112,6 @@ public final class OfflineDefinitionModelAdapter {
       return definition;
     }
     ObjectNode adapted = (ObjectNode) definition.deepCopy();
-    // Notification and editor metadata are Yak Ops control-plane concerns. They must never alter
-    // engine JobSpec, execution snapshots or config digests when only UI preferences change.
     adapted.remove("notification");
     adapted.remove("editorMeta");
     String mode = text(adapted.path("basic"), "mode", "GUIDE_SINGLE");
@@ -104,10 +120,7 @@ public final class OfflineDefinitionModelAdapter {
     return adapted;
   }
 
-  /**
-   * 清理由数据源负责维护的连接字段，防止凭据进入 definition_json。
-   * 非数据源拥有的 Task Connector options 保持原样。
-   */
+  /** 清理由数据源负责维护的连接字段，防止凭据进入 definition_json。 */
   public static void sanitizeForPersistence(ObjectNode definition) {
     if (definition == null) {
       return;
@@ -160,6 +173,9 @@ public final class OfflineDefinitionModelAdapter {
     if ("elasticsearch7".equalsIgnoreCase(connectorId)
         || "elasticsearch8".equalsIgnoreCase(connectorId)) {
       return ELASTICSEARCH_DATASOURCE_OWNED_FIELDS;
+    }
+    if ("mongodb".equalsIgnoreCase(connectorId)) {
+      return MONGODB_DATASOURCE_OWNED_FIELDS;
     }
     return Set.of();
   }

--- a/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-offline/src/main/java/io/yak/ops/business/sync/offline/engine/connector/OfflineSyncConnectorRegistry.java
+++ b/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-offline/src/main/java/io/yak/ops/business/sync/offline/engine/connector/OfflineSyncConnectorRegistry.java
@@ -23,6 +23,7 @@ public final class OfflineSyncConnectorRegistry {
   private static final List<OfflineSyncConnectorProfile> PROFILES = List.of(
       jdbcProfile("mysql-jdbc", DataSourceDbType.MYSQL, "JDBC-MYSQL"),
       jdbcProfile("tidb-jdbc", DataSourceDbType.TIDB, "JDBC-TIDB"),
+      jdbcProfile("goldendb-jdbc", DataSourceDbType.GOLDENDB, "JDBC-GOLDENDB"),
       jdbcProfile("hana-jdbc", DataSourceDbType.HANA, "JDBC-HANA"),
       jdbcProfile("oracle-jdbc", DataSourceDbType.ORACLE, "JDBC-ORACLE"),
       jdbcProfile("postgresql-jdbc", DataSourceDbType.POSTGRE_SQL, "JDBC-POSTGRESQL"),
@@ -69,6 +70,8 @@ public final class OfflineSyncConnectorRegistry {
       Map.entry("POSTGRESQL", DataSourceDbType.POSTGRE_SQL),
       Map.entry("POSTGRES", DataSourceDbType.POSTGRE_SQL),
       Map.entry("TI_DB", DataSourceDbType.TIDB),
+      Map.entry("GOLDEN_DB", DataSourceDbType.GOLDENDB),
+      Map.entry("ZTE_GOLDENDB", DataSourceDbType.GOLDENDB),
       Map.entry("SAP_HANA", DataSourceDbType.HANA),
       Map.entry("SAPHANA", DataSourceDbType.HANA),
       Map.entry("OPENGAUSS", DataSourceDbType.OPEN_GAUSS),

--- a/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-offline/src/main/java/io/yak/ops/business/sync/offline/engine/connector/OfflineSyncConnectorRegistry.java
+++ b/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-offline/src/main/java/io/yak/ops/business/sync/offline/engine/connector/OfflineSyncConnectorRegistry.java
@@ -48,6 +48,7 @@ public final class OfflineSyncConnectorRegistry {
           DataSourceDbType.ELASTICSEARCH8,
           "elasticsearch8",
           "ELASTICSEARCH8"),
+      nativeProfile("mongodb-native", DataSourceDbType.MONGODB, "mongodb", "MONGODB"),
       jdbcProfile("kingbase-jdbc", DataSourceDbType.KINGBASE, "JDBC-KINGBASE"),
       jdbcProfile("dameng-jdbc", DataSourceDbType.DAMENG, "JDBC-DAMENG"));
 
@@ -83,7 +84,9 @@ public final class OfflineSyncConnectorRegistry {
       Map.entry("ELASTICSEARCH_7", DataSourceDbType.ELASTICSEARCH7),
       Map.entry("ES7", DataSourceDbType.ELASTICSEARCH7),
       Map.entry("ELASTICSEARCH_8", DataSourceDbType.ELASTICSEARCH8),
-      Map.entry("ES8", DataSourceDbType.ELASTICSEARCH8));
+      Map.entry("ES8", DataSourceDbType.ELASTICSEARCH8),
+      Map.entry("MONGO", DataSourceDbType.MONGODB),
+      Map.entry("MONGO_DB", DataSourceDbType.MONGODB));
 
   private static final Map<DataSourceDbType, OfflineSyncConnectorProfile> DEFAULTS =
       buildDefaults();

--- a/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-offline/src/main/java/io/yak/ops/business/sync/offline/engine/connector/adapter/MongoOfflineSyncConnectorAdapter.java
+++ b/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-offline/src/main/java/io/yak/ops/business/sync/offline/engine/connector/adapter/MongoOfflineSyncConnectorAdapter.java
@@ -185,23 +185,19 @@ public class MongoOfflineSyncConnectorAdapter implements OfflineSyncConnectorAda
   private MongoPath path(String configuredDatabase, String rawTable, String message) {
     if (!StringUtils.hasText(rawTable)) throw new IllegalArgumentException(message);
     String database = trim(configuredDatabase);
-    String table = rawTable.trim();
+    String collection = rawTable.trim();
 
     if (database != null) {
       String prefix = database + ".";
-      if (table.regionMatches(true, 0, prefix, 0, prefix.length())) {
-        table = table.substring(prefix.length());
+      if (collection.regionMatches(true, 0, prefix, 0, prefix.length())) {
+        collection = collection.substring(prefix.length());
       }
-      return new MongoPath(database, requireCollection(table));
+      return new MongoPath(database, requireCollection(collection));
     }
 
-    int separator = table.indexOf('.');
-    if (separator > 0 && separator < table.length() - 1) {
-      return new MongoPath(
-          table.substring(0, separator),
-          requireCollection(table.substring(separator + 1)));
-    }
-    return new MongoPath(null, requireCollection(table));
+    // Collection names may contain dots. Without an explicit database field, keep the entire value
+    // as the collection name and inherit the datasource default database at execution time.
+    return new MongoPath(null, requireCollection(collection));
   }
 
   private String normalizeSeed(String value, int defaultPort) {

--- a/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-offline/src/main/java/io/yak/ops/business/sync/offline/engine/connector/adapter/MongoOfflineSyncConnectorAdapter.java
+++ b/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-offline/src/main/java/io/yak/ops/business/sync/offline/engine/connector/adapter/MongoOfflineSyncConnectorAdapter.java
@@ -1,0 +1,283 @@
+package io.yak.ops.business.sync.offline.engine.connector.adapter;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ArrayNode;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import io.yak.ops.business.sync.offline.config.ConditionalOnOfflineSyncEnabled;
+import java.net.URLEncoder;
+import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Locale;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.stereotype.Component;
+import org.springframework.util.StringUtils;
+
+/** Translates Yak Ops single-table/fan-out child definitions to the Link-Up MongoDB connector. */
+@ConditionalOnOfflineSyncEnabled
+@Component
+public class MongoOfflineSyncConnectorAdapter implements OfflineSyncConnectorAdapter {
+
+  private static final int DEFAULT_PORT = 27017;
+  private static final List<String> DATASOURCE_OWNED_OPTIONS =
+      List.of(
+          "uri",
+          "url",
+          "host",
+          "hosts",
+          "hostname",
+          "port",
+          "username",
+          "user",
+          "password",
+          "passwd",
+          "authSource",
+          "auth_source");
+
+  private final ObjectMapper objectMapper;
+
+  public MongoOfflineSyncConnectorAdapter(
+      @Qualifier("offlineSyncJsonMapper") ObjectMapper objectMapper) {
+    this.objectMapper = objectMapper;
+  }
+
+  @Override
+  public boolean supports(String connectorId, Role role) {
+    return "mongodb".equalsIgnoreCase(connectorId);
+  }
+
+  @Override
+  public boolean requiresDataSource(String connectorId, Role role) {
+    return true;
+  }
+
+  @Override
+  public BuildResult build(BuildContext context) {
+    requireSingle(context);
+    ObjectNode options = context.options();
+    removeDatasourceOwned(options);
+
+    if (context.role() == Role.SOURCE) {
+      String readMode = text(context.config(), "readMode", "table");
+      if ("sql".equalsIgnoreCase(readMode)) {
+        throw new IllegalArgumentException("MongoDB Source 不支持 SQL，请选择 Collection");
+      }
+      MongoPath path = sourcePath(context.config());
+      putDatabase(options, path.database());
+      options.put("collection", path.collection());
+      copyFields(context.config(), options);
+      if (!options.hasNonNull("fetch_size")) {
+        options.put("fetch_size", context.fetchSize());
+      }
+      return new BuildResult(options, path.qualified(), List.of(path.qualified()));
+    }
+
+    String writeMode = text(context.config(), "writeMode", "append").toLowerCase(Locale.ROOT);
+    if (!"append".equals(writeMode)) {
+      throw new IllegalArgumentException("MongoDB bounded Sink 当前仅开放 Append/INSERT 写入语义");
+    }
+    if (context.config().path("autoCreateTable").asBoolean(false)) {
+      throw new IllegalArgumentException(
+          "MongoDB Link-Up Connector 未声明 AUTO_CREATE_TABLE；请关闭自动创建能力开关");
+    }
+
+    MongoPath path = sinkPath(context.config());
+    putDatabase(options, path.database());
+    options.put("collection", path.collection());
+    if (!options.hasNonNull("batch_size")) {
+      options.put("batch_size", context.batchSize());
+    }
+    return new BuildResult(options, path.qualified(), List.of());
+  }
+
+  @Override
+  public void resolveForExecution(ExecutionContext context) {
+    if (context.dataSource() == null) {
+      throw new IllegalArgumentException("MongoDB Connector 必须选择数据源");
+    }
+    ObjectNode options = context.options();
+    removeDatasourceOwned(options);
+
+    JsonNode connection = readConnection(context.dataSource().getConnectionParams());
+    String defaultDatabase = firstText(connection, "database");
+    if (!options.hasNonNull("database") && StringUtils.hasText(defaultDatabase)) {
+      options.put("database", defaultDatabase);
+    }
+    options.put("uri", buildUri(connection));
+  }
+
+  private String buildUri(JsonNode connection) {
+    String host = firstText(connection, "host");
+    if (!StringUtils.hasText(host)) host = "127.0.0.1";
+    int port = connection == null ? DEFAULT_PORT : connection.path("port").asInt(DEFAULT_PORT);
+    if (port <= 0 || port > 65535) {
+      throw new IllegalArgumentException("MongoDB 数据源 port 必须在 1-65535 范围内");
+    }
+
+    List<String> seeds = new ArrayList<>();
+    String hosts = firstText(connection, "hosts");
+    if (StringUtils.hasText(hosts)) {
+      for (String item : hosts.split(",")) {
+        String seed = item.trim();
+        if (!seed.isEmpty()) seeds.add(normalizeSeed(seed, port));
+      }
+    }
+    if (seeds.isEmpty()) seeds.add(normalizeSeed(host, port));
+
+    String database = firstText(connection, "database");
+    if (!StringUtils.hasText(database)) {
+      throw new IllegalArgumentException("MongoDB 数据源缺少默认 Database");
+    }
+    String username = firstText(connection, "username", "user");
+    String password = valueText(connection, "password");
+    String authSource = firstText(connection, "authSource", "auth_source");
+
+    StringBuilder uri = new StringBuilder("mongodb://");
+    if (StringUtils.hasText(username)) {
+      uri.append(encode(username));
+      if (password != null) uri.append(':').append(encode(password));
+      uri.append('@');
+    }
+    uri.append(String.join(",", seeds));
+    uri.append('/').append(encode(database));
+    if (StringUtils.hasText(authSource)) {
+      uri.append("?authSource=").append(encode(authSource));
+    }
+    return uri.toString();
+  }
+
+  private void copyFields(JsonNode config, ObjectNode options) {
+    JsonNode fields = config == null ? null : config.get("fields");
+    if (fields == null || fields.isNull()) return;
+    if (!fields.isArray()) {
+      throw new IllegalArgumentException("MongoDB fields 必须是字段名数组");
+    }
+    ArrayNode normalized = objectMapper.createArrayNode();
+    for (JsonNode field : fields) {
+      if (!field.isValueNode() || !StringUtils.hasText(field.asText())) {
+        throw new IllegalArgumentException("MongoDB fields 只能包含非空字段名");
+      }
+      normalized.add(field.asText().trim());
+    }
+    if (!normalized.isEmpty()) options.set("fields", normalized);
+    else options.remove("fields");
+  }
+
+  private MongoPath sourcePath(JsonNode config) {
+    return path(
+        text(config, "database", null),
+        text(config, "table", text(config, "collection", null)),
+        "请选择来源 Collection");
+  }
+
+  private MongoPath sinkPath(JsonNode config) {
+    return path(
+        text(config, "database", null),
+        text(
+            config,
+            "targetTableName",
+            text(config, "table", text(config, "collection", null))),
+        "请选择或填写目标 Collection");
+  }
+
+  private MongoPath path(String configuredDatabase, String rawTable, String message) {
+    if (!StringUtils.hasText(rawTable)) throw new IllegalArgumentException(message);
+    String database = trim(configuredDatabase);
+    String table = rawTable.trim();
+
+    if (database != null) {
+      String prefix = database + ".";
+      if (table.regionMatches(true, 0, prefix, 0, prefix.length())) {
+        table = table.substring(prefix.length());
+      }
+      return new MongoPath(database, requireCollection(table));
+    }
+
+    int separator = table.indexOf('.');
+    if (separator > 0 && separator < table.length() - 1) {
+      return new MongoPath(
+          table.substring(0, separator),
+          requireCollection(table.substring(separator + 1)));
+    }
+    return new MongoPath(null, requireCollection(table));
+  }
+
+  private String normalizeSeed(String value, int defaultPort) {
+    if (value.contains("://") || value.contains("/") || value.contains("?") || value.contains("@")) {
+      throw new IllegalArgumentException("MongoDB Seed Host 只允许 host 或 host:port：" + value);
+    }
+    return value.contains(":") ? value : value + ":" + defaultPort;
+  }
+
+  private String requireCollection(String value) {
+    String normalized = trim(value);
+    if (normalized == null) throw new IllegalArgumentException("MongoDB Collection 不能为空");
+    return normalized;
+  }
+
+  private JsonNode readConnection(String json) {
+    if (!StringUtils.hasText(json)) return objectMapper.createObjectNode();
+    try {
+      JsonNode value = objectMapper.readTree(json);
+      return value != null && value.isObject() ? value : objectMapper.createObjectNode();
+    } catch (JsonProcessingException exception) {
+      throw new IllegalArgumentException("MongoDB 数据源连接参数不是有效 JSON", exception);
+    }
+  }
+
+  private String firstText(JsonNode node, String... fields) {
+    if (node == null || !node.isObject()) return null;
+    for (String field : fields) {
+      JsonNode value = node.get(field);
+      if (value != null && value.isValueNode() && StringUtils.hasText(value.asText())) {
+        return value.asText().trim();
+      }
+    }
+    return null;
+  }
+
+  private String valueText(JsonNode node, String field) {
+    if (node == null || !node.isObject()) return null;
+    JsonNode value = node.get(field);
+    return value == null || value.isNull() || !value.isValueNode() ? null : value.asText();
+  }
+
+  private void requireSingle(BuildContext context) {
+    if (!"GUIDE_SINGLE".equals(context.mode())) {
+      throw new IllegalArgumentException(
+          "MongoDB Link-Up Connector 当前使用单 Collection JobSpec；GUIDE_MULTI 由 Yak Ops FAN_OUT 冻结为多个子任务");
+    }
+  }
+
+  private void putDatabase(ObjectNode options, String database) {
+    if (StringUtils.hasText(database)) options.put("database", database);
+    else options.remove("database");
+  }
+
+  private String text(JsonNode node, String field, String fallback) {
+    JsonNode value = node == null ? null : node.get(field);
+    return value == null || value.isNull() || !value.isValueNode()
+        ? fallback
+        : value.asText(fallback);
+  }
+
+  private String trim(String value) {
+    return StringUtils.hasText(value) ? value.trim() : null;
+  }
+
+  private String encode(String value) {
+    return URLEncoder.encode(value, StandardCharsets.UTF_8).replace("+", "%20");
+  }
+
+  private void removeDatasourceOwned(ObjectNode options) {
+    options.remove(DATASOURCE_OWNED_OPTIONS);
+  }
+
+  private record MongoPath(String database, String collection) {
+    String qualified() {
+      return database == null ? collection : database + "." + collection;
+    }
+  }
+}

--- a/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-offline/src/test/java/io/yak/ops/business/sync/offline/engine/MongoOfflineDefinitionModelAdapterTest.java
+++ b/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-offline/src/test/java/io/yak/ops/business/sync/offline/engine/MongoOfflineDefinitionModelAdapterTest.java
@@ -1,0 +1,93 @@
+package io.yak.ops.business.sync.offline.engine;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import org.junit.jupiter.api.Test;
+
+class MongoOfflineDefinitionModelAdapterTest {
+
+  private final ObjectMapper mapper = new ObjectMapper();
+
+  @Test
+  void stripsDatasourceSecretsButKeepsMongoTaskOptions() throws Exception {
+    ObjectNode definition =
+        (ObjectNode)
+            mapper.readTree(
+                """
+                {
+                  "source": {
+                    "connectorId":"mongodb",
+                    "uri":"mongodb://user:secret@mongo/app",
+                    "password":"secret",
+                    "options": {
+                      "uri":"mongodb://user:secret@mongo/app",
+                      "password":"secret",
+                      "filter":"{\"active\":true}"
+                    },
+                    "config": {
+                      "connectorOptions": {
+                        "uri":"mongodb://user:secret@mongo/app",
+                        "password":"secret",
+                        "filter":"{\"active\":true}"
+                      }
+                    }
+                  },
+                  "sink": {
+                    "connectorId":"mongodb",
+                    "options": {
+                      "username":"yak",
+                      "password":"secret",
+                      "document_id_field":"user_id"
+                    }
+                  }
+                }
+                """);
+
+    OfflineDefinitionModelAdapter.sanitizeForPersistence(definition);
+
+    assertThat(definition.path("source").has("uri")).isFalse();
+    assertThat(definition.path("source").has("password")).isFalse();
+    assertThat(definition.path("source").path("options").has("uri")).isFalse();
+    assertThat(definition.path("source").path("options").has("password")).isFalse();
+    assertThat(definition.path("source").path("options").path("filter").asText())
+        .contains("active");
+    assertThat(
+            definition
+                .path("source")
+                .path("config")
+                .path("connectorOptions")
+                .has("uri"))
+        .isFalse();
+    assertThat(definition.path("sink").path("options").has("username")).isFalse();
+    assertThat(definition.path("sink").path("options").has("password")).isFalse();
+    assertThat(definition.path("sink").path("options").path("document_id_field").asText())
+        .isEqualTo("user_id");
+  }
+
+  @Test
+  void copiesMongoFieldSelectionIntoJobSpecConfig() throws Exception {
+    ObjectNode definition =
+        (ObjectNode)
+            mapper.readTree(
+                """
+                {
+                  "basic":{"mode":"GUIDE_SINGLE"},
+                  "source":{
+                    "connectorId":"mongodb",
+                    "table":"users",
+                    "fields":["_id","address.city"]
+                  },
+                  "sink":{"connectorId":"jdbc"}
+                }
+                """);
+
+    ObjectNode adapted =
+        (ObjectNode) OfflineDefinitionModelAdapter.forJobSpec(definition, mapper);
+
+    assertThat(adapted.path("source").path("config").path("fields")).hasSize(2);
+    assertThat(adapted.path("source").path("config").path("fields").get(1).asText())
+        .isEqualTo("address.city");
+  }
+}

--- a/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-offline/src/test/java/io/yak/ops/business/sync/offline/engine/connector/MongoOfflineSyncConnectorRegistryTest.java
+++ b/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-offline/src/test/java/io/yak/ops/business/sync/offline/engine/connector/MongoOfflineSyncConnectorRegistryTest.java
@@ -1,0 +1,22 @@
+package io.yak.ops.business.sync.offline.engine.connector;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.yak.ops.common.enums.datasource.DataSourceDbType;
+import org.junit.jupiter.api.Test;
+
+class MongoOfflineSyncConnectorRegistryTest {
+
+  @Test
+  void mongodbUsesNativeConnectorProfileForNewDefinitions() {
+    OfflineSyncConnectorProfile profile =
+        OfflineSyncConnectorRegistry.defaultProfile("mongodb").orElseThrow();
+
+    assertThat(profile.profileId()).isEqualTo("mongodb-native");
+    assertThat(profile.dbType()).isEqualTo(DataSourceDbType.MONGODB);
+    assertThat(profile.sourceConnectorId()).isEqualTo("mongodb");
+    assertThat(profile.sinkConnectorId()).isEqualTo("mongodb");
+    assertThat(profile.defaultProfile()).isTrue();
+    assertThat(OfflineSyncConnectorRegistry.defaultProfile("mongo_db")).contains(profile);
+  }
+}

--- a/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-offline/src/test/java/io/yak/ops/business/sync/offline/engine/connector/adapter/MongoOfflineSyncConnectorAdapterTest.java
+++ b/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-offline/src/test/java/io/yak/ops/business/sync/offline/engine/connector/adapter/MongoOfflineSyncConnectorAdapterTest.java
@@ -1,0 +1,129 @@
+package io.yak.ops.business.sync.offline.engine.connector.adapter;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import io.yak.ops.business.sync.offline.engine.connector.adapter.OfflineSyncConnectorAdapter.BuildContext;
+import io.yak.ops.business.sync.offline.engine.connector.adapter.OfflineSyncConnectorAdapter.ExecutionContext;
+import io.yak.ops.business.sync.offline.engine.connector.adapter.OfflineSyncConnectorAdapter.Role;
+import io.yak.ops.common.bean.po.datasource.DataSourcePO;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+
+class MongoOfflineSyncConnectorAdapterTest {
+
+  private final ObjectMapper mapper = new ObjectMapper();
+  private final MongoOfflineSyncConnectorAdapter adapter =
+      new MongoOfflineSyncConnectorAdapter(mapper);
+
+  @Test
+  void buildsFieldSelectedSourceWithoutPersistingDatasourceSecrets() throws Exception {
+    ObjectNode config =
+        (ObjectNode)
+            mapper.readTree(
+                """
+                {
+                  "table":"users",
+                  "fields":["_id","name","address.city"],
+                  "connectorOptions":{
+                    "filter":"{\"status\":\"ACTIVE\"}",
+                    "uri":"mongodb://must-not-persist",
+                    "password":"must-not-persist"
+                  }
+                }
+                """);
+    ObjectNode options = (ObjectNode) config.path("connectorOptions").deepCopy();
+
+    var result = adapter.build(context(Role.SOURCE, "GUIDE_SINGLE", config, options));
+
+    assertThat(result.options().path("collection").asText()).isEqualTo("users");
+    assertThat(result.options().path("fields")).hasSize(3);
+    assertThat(result.options().path("filter").asText()).contains("ACTIVE");
+    assertThat(result.options().path("fetch_size").asInt()).isEqualTo(1000);
+    assertThat(result.options().has("uri")).isFalse();
+    assertThat(result.options().has("password")).isFalse();
+
+    DataSourcePO dataSource = new DataSourcePO();
+    dataSource.setConnectionParams(
+        "{\"host\":\"mongo-a\",\"port\":27017,\"hosts\":\"mongo-a:27017,mongo-b:27017\","
+            + "\"database\":\"business\",\"username\":\"yak user\","
+            + "\"password\":\"s ecret\",\"authSource\":\"admin\"}");
+    adapter.resolveForExecution(
+        new ExecutionContext("mongodb", Role.SOURCE, "source", dataSource, result.options()));
+
+    assertThat(result.options().path("database").asText()).isEqualTo("business");
+    assertThat(result.options().path("uri").asText())
+        .isEqualTo(
+            "mongodb://yak%20user:s%20ecret@mongo-a:27017,mongo-b:27017/business?authSource=admin");
+  }
+
+  @Test
+  void buildsInsertOnlySinkAndKeepsDocumentIdAsAdvancedOption() throws Exception {
+    ObjectNode config =
+        (ObjectNode)
+            mapper.readTree(
+                """
+                {
+                  "table":"users_copy",
+                  "autoCreateTable":false,
+                  "writeMode":"append",
+                  "connectorOptions":{
+                    "document_id_field":"user_id",
+                    "batch_size":200
+                  }
+                }
+                """);
+    ObjectNode options = (ObjectNode) config.path("connectorOptions").deepCopy();
+
+    var result = adapter.build(context(Role.SINK, "GUIDE_SINGLE", config, options));
+
+    assertThat(result.options().path("collection").asText()).isEqualTo("users_copy");
+    assertThat(result.options().path("document_id_field").asText()).isEqualTo("user_id");
+    assertThat(result.options().path("batch_size").asInt()).isEqualTo(200);
+  }
+
+  @Test
+  void rejectsUnsupportedSqlUpsertAndDirectGuideMulti() throws Exception {
+    ObjectNode source =
+        (ObjectNode) mapper.readTree("{\"readMode\":\"sql\",\"sql\":\"select 1\"}");
+    assertThatThrownBy(
+            () -> adapter.build(context(Role.SOURCE, "GUIDE_SINGLE", source, mapper.createObjectNode())))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining("不支持 SQL");
+
+    ObjectNode sink =
+        (ObjectNode)
+            mapper.readTree(
+                "{\"table\":\"users\",\"autoCreateTable\":false,\"writeMode\":\"upsert\"}");
+    assertThatThrownBy(
+            () -> adapter.build(context(Role.SINK, "GUIDE_SINGLE", sink, mapper.createObjectNode())))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining("Append/INSERT");
+
+    ObjectNode multi = (ObjectNode) mapper.readTree("{\"table\":\"users\"}");
+    assertThatThrownBy(
+            () -> adapter.build(context(Role.SOURCE, "GUIDE_MULTI", multi, mapper.createObjectNode())))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining("FAN_OUT");
+  }
+
+  private BuildContext context(
+      Role role,
+      String mode,
+      ObjectNode config,
+      ObjectNode options) {
+    return new BuildContext(
+        "mongodb",
+        role,
+        mode,
+        "mongo-test",
+        config,
+        mapper.createObjectNode(),
+        options,
+        1000,
+        500,
+        role == Role.SINK ? List.of("users") : List.of());
+  }
+}

--- a/yak-ops-common/src/main/java/io/yak/ops/common/enums/datasource/DataSourceDbType.java
+++ b/yak-ops-common/src/main/java/io/yak/ops/common/enums/datasource/DataSourceDbType.java
@@ -28,6 +28,7 @@ public enum DataSourceDbType {
   CLICKHOUSE("ClickHouse"),
   ELASTICSEARCH7("Elasticsearch 7"),
   ELASTICSEARCH8("Elasticsearch 8"),
+  MONGODB("MongoDB"),
   KINGBASE("KingbaseES"),
   DAMENG("达梦");
 
@@ -63,6 +64,8 @@ public enum DataSourceDbType {
       normalized = "ELASTICSEARCH7";
     } else if ("ELASTICSEARCH_8".equals(normalized) || "ES8".equals(normalized)) {
       normalized = "ELASTICSEARCH8";
+    } else if ("MONGO".equals(normalized) || "MONGO_DB".equals(normalized)) {
+      normalized = "MONGODB";
     }
 
     try {

--- a/yak-ops-common/src/main/java/io/yak/ops/common/enums/datasource/DataSourceDbType.java
+++ b/yak-ops-common/src/main/java/io/yak/ops/common/enums/datasource/DataSourceDbType.java
@@ -11,6 +11,7 @@ public enum DataSourceDbType {
 
   MYSQL("MySQL"),
   TIDB("TiDB"),
+  GOLDENDB("GoldenDB"),
   HANA("SAP HANA"),
   ORACLE("Oracle"),
   POSTGRE_SQL("PostgreSQL"),
@@ -44,6 +45,8 @@ public enum DataSourceDbType {
       normalized = "POSTGRE_SQL";
     } else if ("TI_DB".equals(normalized)) {
       normalized = "TIDB";
+    } else if ("GOLDEN_DB".equals(normalized) || "ZTE_GOLDENDB".equals(normalized)) {
+      normalized = "GOLDENDB";
     } else if ("SAP_HANA".equals(normalized) || "SAPHANA".equals(normalized)) {
       normalized = "HANA";
     } else if ("OPENGAUSS".equals(normalized)) {

--- a/yak-ops-plugins/yak-ops-plugin-datasource/pom.xml
+++ b/yak-ops-plugins/yak-ops-plugin-datasource/pom.xml
@@ -22,6 +22,7 @@
         <module>yak-ops-plugin-datasource-jdbc</module>
         <module>yak-ops-plugin-datasource-doris</module>
         <module>yak-ops-plugin-datasource-elasticsearch</module>
+        <module>yak-ops-plugin-datasource-mongodb</module>
         <module>yak-ops-plugin-datasource-all</module>
     </modules>
 </project>

--- a/yak-ops-plugins/yak-ops-plugin-datasource/yak-ops-plugin-datasource-jdbc/src/main/java/io/yak/ops/plugin/database/jdbc/GenericJdbcCatalog.java
+++ b/yak-ops-plugins/yak-ops-plugin-datasource/yak-ops-plugin-datasource-jdbc/src/main/java/io/yak/ops/plugin/database/jdbc/GenericJdbcCatalog.java
@@ -341,7 +341,7 @@ public class GenericJdbcCatalog implements DataSourceCatalog {
             oceanBaseOracleMode()
                 ? query + " WHERE ROWNUM <= " + limit
                 : query + " LIMIT " + limit;
-        case MYSQL, TIDB, HANA, POSTGRE_SQL, DORIS, STARROCKS, CLICKHOUSE, KINGBASE, OPEN_GAUSS ->
+        case MYSQL, TIDB, GOLDENDB, HANA, POSTGRE_SQL, DORIS, STARROCKS, CLICKHOUSE, KINGBASE, OPEN_GAUSS ->
             query + " LIMIT " + limit;
         case YASHAN_DB, HIGHGO, IRIS, XUGU, DUCKDB -> query;
         case ELASTICSEARCH7, ELASTICSEARCH8, MONGODB ->
@@ -360,7 +360,7 @@ public class GenericJdbcCatalog implements DataSourceCatalog {
           oceanBaseOracleMode()
               ? "SELECT * FROM (" + query + ") yak_ops_preview WHERE ROWNUM <= " + limit
               : "SELECT * FROM (" + query + ") yak_ops_preview LIMIT " + limit;
-      case MYSQL, TIDB, HANA, POSTGRE_SQL, DORIS, STARROCKS, CLICKHOUSE, KINGBASE, OPEN_GAUSS ->
+      case MYSQL, TIDB, GOLDENDB, HANA, POSTGRE_SQL, DORIS, STARROCKS, CLICKHOUSE, KINGBASE, OPEN_GAUSS ->
           "SELECT * FROM (" + query + ") yak_ops_preview LIMIT " + limit;
       case YASHAN_DB, HIGHGO, IRIS, XUGU, DUCKDB -> query;
       case ELASTICSEARCH7, ELASTICSEARCH8, MONGODB ->
@@ -523,6 +523,7 @@ public class GenericJdbcCatalog implements DataSourceCatalog {
   private boolean usesCatalogAsNamespace() {
     return connection.dbType() == DataSourceDbType.MYSQL
         || connection.dbType() == DataSourceDbType.TIDB
+        || connection.dbType() == DataSourceDbType.GOLDENDB
         || connection.dbType() == DataSourceDbType.DORIS
         || connection.dbType() == DataSourceDbType.STARROCKS
         || connection.dbType() == DataSourceDbType.CLICKHOUSE

--- a/yak-ops-plugins/yak-ops-plugin-datasource/yak-ops-plugin-datasource-jdbc/src/main/java/io/yak/ops/plugin/database/jdbc/GenericJdbcCatalog.java
+++ b/yak-ops-plugins/yak-ops-plugin-datasource/yak-ops-plugin-datasource-jdbc/src/main/java/io/yak/ops/plugin/database/jdbc/GenericJdbcCatalog.java
@@ -344,8 +344,8 @@ public class GenericJdbcCatalog implements DataSourceCatalog {
         case MYSQL, TIDB, HANA, POSTGRE_SQL, DORIS, STARROCKS, CLICKHOUSE, KINGBASE, OPEN_GAUSS ->
             query + " LIMIT " + limit;
         case YASHAN_DB, HIGHGO, IRIS, XUGU, DUCKDB -> query;
-        case ELASTICSEARCH7, ELASTICSEARCH8 ->
-            throw new IllegalStateException("Elasticsearch must not use GenericJdbcCatalog");
+        case ELASTICSEARCH7, ELASTICSEARCH8, MONGODB ->
+            throw new IllegalStateException("Non-JDBC datasource must not use GenericJdbcCatalog");
       };
     }
 
@@ -363,8 +363,8 @@ public class GenericJdbcCatalog implements DataSourceCatalog {
       case MYSQL, TIDB, HANA, POSTGRE_SQL, DORIS, STARROCKS, CLICKHOUSE, KINGBASE, OPEN_GAUSS ->
           "SELECT * FROM (" + query + ") yak_ops_preview LIMIT " + limit;
       case YASHAN_DB, HIGHGO, IRIS, XUGU, DUCKDB -> query;
-      case ELASTICSEARCH7, ELASTICSEARCH8 ->
-          throw new IllegalStateException("Elasticsearch must not use GenericJdbcCatalog");
+      case ELASTICSEARCH7, ELASTICSEARCH8, MONGODB ->
+          throw new IllegalStateException("Non-JDBC datasource must not use GenericJdbcCatalog");
     };
   }
 

--- a/yak-ops-plugins/yak-ops-plugin-datasource/yak-ops-plugin-datasource-mongodb/pom.xml
+++ b/yak-ops-plugins/yak-ops-plugin-datasource/yak-ops-plugin-datasource-mongodb/pom.xml
@@ -11,29 +11,24 @@
         <relativePath>../pom.xml</relativePath>
     </parent>
 
-    <artifactId>yak-ops-plugin-datasource-all</artifactId>
+    <artifactId>yak-ops-plugin-datasource-mongodb</artifactId>
 
-    <name>Yak Ops All Datasource Plugins</name>
-    <description>Runtime aggregation of all built-in Yak Ops datasource plugins</description>
+    <name>Yak Ops MongoDB Datasource Plugin</name>
+    <description>MongoDB control-plane datasource integration for connection, catalog and preview</description>
 
     <dependencies>
         <dependency>
             <groupId>io.yak.ops</groupId>
-            <artifactId>yak-ops-plugin-datasource-jdbc</artifactId>
+            <artifactId>yak-ops-plugin-datasource-api</artifactId>
         </dependency>
         <dependency>
-            <groupId>io.yak.ops</groupId>
-            <artifactId>yak-ops-plugin-datasource-doris</artifactId>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-databind</artifactId>
         </dependency>
         <dependency>
-            <groupId>io.yak.ops</groupId>
-            <artifactId>yak-ops-plugin-datasource-elasticsearch</artifactId>
-            <version>${project.version}</version>
-        </dependency>
-        <dependency>
-            <groupId>io.yak.ops</groupId>
-            <artifactId>yak-ops-plugin-datasource-mongodb</artifactId>
-            <version>${project.version}</version>
+            <groupId>org.mongodb</groupId>
+            <artifactId>mongodb-driver-sync</artifactId>
+            <version>4.11.5</version>
         </dependency>
         <dependency>
             <groupId>org.springframework.boot</groupId>

--- a/yak-ops-plugins/yak-ops-plugin-datasource/yak-ops-plugin-datasource-mongodb/src/main/java/io/yak/ops/plugin/database/mongodb/MongoClientFactory.java
+++ b/yak-ops-plugins/yak-ops-plugin-datasource/yak-ops-plugin-datasource-mongodb/src/main/java/io/yak/ops/plugin/database/mongodb/MongoClientFactory.java
@@ -1,0 +1,29 @@
+package io.yak.ops.plugin.database.mongodb;
+
+import com.mongodb.ConnectionString;
+import com.mongodb.MongoClientSettings;
+import com.mongodb.client.MongoClient;
+import com.mongodb.client.MongoClients;
+import java.util.concurrent.TimeUnit;
+
+/** Creates bounded MongoDB clients with Yak Ops control-plane timeouts. */
+final class MongoClientFactory {
+
+  private MongoClientFactory() {}
+
+  static MongoClient create(MongoConnection connection, int timeoutSeconds) {
+    int timeout = Math.max(1, timeoutSeconds);
+    MongoClientSettings settings =
+        MongoClientSettings.builder()
+            .applyConnectionString(new ConnectionString(connection.uri()))
+            .applyToClusterSettings(
+                builder -> builder.serverSelectionTimeout(timeout, TimeUnit.SECONDS))
+            .applyToSocketSettings(
+                builder ->
+                    builder
+                        .connectTimeout(timeout, TimeUnit.SECONDS)
+                        .readTimeout(timeout, TimeUnit.SECONDS))
+            .build();
+    return MongoClients.create(settings);
+  }
+}

--- a/yak-ops-plugins/yak-ops-plugin-datasource/yak-ops-plugin-datasource-mongodb/src/main/java/io/yak/ops/plugin/database/mongodb/MongoConnection.java
+++ b/yak-ops-plugins/yak-ops-plugin-datasource/yak-ops-plugin-datasource-mongodb/src/main/java/io/yak/ops/plugin/database/mongodb/MongoConnection.java
@@ -1,0 +1,81 @@
+package io.yak.ops.plugin.database.mongodb;
+
+import io.yak.ops.common.enums.datasource.DataSourceDbType;
+import io.yak.ops.spi.datasource.DataSourceConnection;
+import java.util.Map;
+
+/** MongoDB connection model used by the Yak Ops control-plane datasource plugin. */
+final class MongoConnection implements DataSourceConnection {
+
+  private final String uri;
+  private final String displayUrl;
+  private final String database;
+  private final String username;
+  private final String password;
+  private final String normalizedJson;
+
+  MongoConnection(
+      String uri,
+      String displayUrl,
+      String database,
+      String username,
+      String password,
+      String normalizedJson) {
+    this.uri = uri;
+    this.displayUrl = displayUrl;
+    this.database = database;
+    this.username = username;
+    this.password = password;
+    this.normalizedJson = normalizedJson;
+  }
+
+  String uri() {
+    return uri;
+  }
+
+  @Override
+  public DataSourceDbType dbType() {
+    return DataSourceDbType.MONGODB;
+  }
+
+  /** Historical SPI field; keep it credential-free because Yak Ops surfaces it as connection URL. */
+  @Override
+  public String jdbcUrl() {
+    return displayUrl;
+  }
+
+  @Override
+  public String driverClassName() {
+    return null;
+  }
+
+  @Override
+  public String username() {
+    return username;
+  }
+
+  @Override
+  public String password() {
+    return password;
+  }
+
+  @Override
+  public String database() {
+    return database;
+  }
+
+  @Override
+  public String schema() {
+    return null;
+  }
+
+  @Override
+  public Map<String, String> properties() {
+    return Map.of();
+  }
+
+  @Override
+  public String normalizedJson() {
+    return normalizedJson;
+  }
+}

--- a/yak-ops-plugins/yak-ops-plugin-datasource/yak-ops-plugin-datasource-mongodb/src/main/java/io/yak/ops/plugin/database/mongodb/MongoDataSourceCatalog.java
+++ b/yak-ops-plugins/yak-ops-plugin-datasource/yak-ops-plugin-datasource-mongodb/src/main/java/io/yak/ops/plugin/database/mongodb/MongoDataSourceCatalog.java
@@ -1,0 +1,238 @@
+package io.yak.ops.plugin.database.mongodb;
+
+import com.mongodb.client.MongoClient;
+import com.mongodb.client.MongoCollection;
+import com.mongodb.client.MongoCursor;
+import com.mongodb.client.MongoDatabase;
+import io.yak.ops.spi.datasource.DataSourceCatalog;
+import io.yak.ops.spi.datasource.DataSourcePluginException;
+import io.yak.ops.spi.datasource.DataSourcePluginException.Operation;
+import io.yak.ops.spi.datasource.catalog.DataSourceCatalogQuery;
+import io.yak.ops.spi.datasource.catalog.DataSourceCatalogReadRequest;
+import io.yak.ops.spi.datasource.catalog.DataSourceTablePath;
+import io.yak.ops.spi.datasource.metadata.DataSourceColumn;
+import io.yak.ops.spi.datasource.metadata.DataSourceTable;
+import io.yak.ops.spi.datasource.query.DataSourceQueryColumn;
+import io.yak.ops.spi.datasource.query.DataSourceQueryResult;
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+import org.bson.BsonDocument;
+
+/** Maps MongoDB databases, collections and sampled fields to the Yak Ops Catalog contract. */
+final class MongoDataSourceCatalog implements DataSourceCatalog {
+
+  private final MongoConnection connection;
+  private final int timeoutSeconds;
+
+  MongoDataSourceCatalog(MongoConnection connection, int timeoutSeconds) {
+    this.connection = connection;
+    this.timeoutSeconds = Math.max(1, timeoutSeconds);
+  }
+
+  @Override
+  public List<String> listDatabases() {
+    try (MongoClient client = client()) {
+      List<String> result = new ArrayList<>();
+      for (String database : client.listDatabaseNames()) result.add(database);
+      result.sort(String.CASE_INSENSITIVE_ORDER);
+      return List.copyOf(result);
+    } catch (RuntimeException failure) {
+      throw catalog("读取 MongoDB database 列表失败", failure);
+    }
+  }
+
+  @Override
+  public List<String> listSchemas(String database) {
+    requireDatabase(database);
+    return List.of();
+  }
+
+  @Override
+  public List<DataSourceTable> listTables(DataSourceCatalogQuery query) {
+    String database = requireDatabase(query == null ? null : query.getDatabase());
+    requireNoSchema(query == null ? null : query.getSchema());
+    String keyword = normalize(query == null ? null : query.getKeyword());
+    Integer limit = query == null ? null : query.getLimit();
+
+    try (MongoClient client = client()) {
+      List<DataSourceTable> result = new ArrayList<>();
+      for (String collection : client.getDatabase(database).listCollectionNames()) {
+        if (keyword != null
+            && !collection.toLowerCase(Locale.ROOT).contains(keyword.toLowerCase(Locale.ROOT))) {
+          continue;
+        }
+        result.add(new DataSourceTable(database, null, collection, "COLLECTION", null));
+      }
+      result.sort(Comparator.comparing(DataSourceTable::getName, String.CASE_INSENSITIVE_ORDER));
+      if (limit != null && limit > 0 && result.size() > limit) {
+        return List.copyOf(result.subList(0, limit));
+      }
+      return List.copyOf(result);
+    } catch (RuntimeException failure) {
+      throw catalog("读取 MongoDB collection 列表失败：database=" + database, failure);
+    }
+  }
+
+  @Override
+  public List<DataSourceColumn> listColumns(DataSourceTablePath tablePath) {
+    if (tablePath == null) throw catalog("MongoDB tablePath 不能为空");
+    requireNoSchema(tablePath.getSchema());
+    String database = requireDatabase(tablePath.getDatabase());
+    String collection = requireCollection(tablePath.getTable());
+    return discover(database, collection);
+  }
+
+  @Override
+  public List<DataSourceColumn> describe(DataSourceCatalogReadRequest request) {
+    if (request == null || request.sqlMode()) {
+      throw catalog("MongoDB Catalog 不支持 SQL describe，请选择 Collection");
+    }
+    Path path = resolvePath(request.tablePath());
+    return discover(path.database(), path.collection());
+  }
+
+  @Override
+  public DataSourceQueryResult preview(DataSourceCatalogReadRequest request, int limit) {
+    if (request == null || request.sqlMode()) {
+      throw catalog("MongoDB 数据预览不支持 SQL，请选择 Collection");
+    }
+    Path path = resolvePath(request.tablePath());
+    int safeLimit = Math.max(1, Math.min(200, limit));
+
+    try (MongoClient client = client()) {
+      MongoCollection<BsonDocument> collection = collection(client, path);
+      List<BsonDocument> documents = new ArrayList<>();
+      try (MongoCursor<BsonDocument> cursor = collection.find().limit(safeLimit).iterator()) {
+        while (cursor.hasNext()) documents.add(cursor.next());
+      }
+
+      List<DataSourceColumn> fields =
+          documents.isEmpty()
+              ? discover(path.database(), path.collection())
+              : MongoSchemaDiscovery.discover(documents);
+      List<DataSourceQueryColumn> columns =
+          fields.stream()
+              .map(field -> new DataSourceQueryColumn(field.getName(), field.getName(), field.getName(), true))
+              .toList();
+
+      List<Map<String, Object>> rows = new ArrayList<>();
+      for (BsonDocument document : documents) {
+        Map<String, Object> row = new LinkedHashMap<>();
+        for (DataSourceColumn field : fields) {
+          row.put(field.getName(), MongoSchemaDiscovery.previewValue(document, field.getName()));
+        }
+        rows.add(row);
+      }
+      long total = collection.estimatedDocumentCount();
+      return new DataSourceQueryResult(columns, rows, total);
+    } catch (RuntimeException failure) {
+      throw catalog("预览 MongoDB Collection 失败：" + path, failure);
+    }
+  }
+
+  @Override
+  public long count(DataSourceCatalogReadRequest request) {
+    if (request == null || request.sqlMode()) {
+      throw catalog("MongoDB count 不支持 SQL，请选择 Collection");
+    }
+    Path path = resolvePath(request.tablePath());
+    try (MongoClient client = client()) {
+      return collection(client, path).estimatedDocumentCount();
+    } catch (RuntimeException failure) {
+      throw catalog("统计 MongoDB Collection 失败：" + path, failure);
+    }
+  }
+
+  @Override
+  public String buildSqlTemplate(String tablePath) {
+    throw catalog("MongoDB 不提供 SQL 模板能力");
+  }
+
+  @Override
+  public String resolveSql(String sql, DataSourceCatalogReadRequest request) {
+    throw catalog("MongoDB 不提供 SQL 变量解析能力");
+  }
+
+  private List<DataSourceColumn> discover(String database, String collection) {
+    try (MongoClient client = client()) {
+      List<BsonDocument> samples = new ArrayList<>();
+      try (MongoCursor<BsonDocument> cursor =
+          client
+              .getDatabase(database)
+              .getCollection(collection, BsonDocument.class)
+              .find()
+              .limit(MongoSchemaDiscovery.SAMPLE_SIZE)
+              .iterator()) {
+        while (cursor.hasNext()) samples.add(cursor.next());
+      }
+      return MongoSchemaDiscovery.discover(samples);
+    } catch (RuntimeException failure) {
+      throw catalog(
+          "发现 MongoDB Collection 字段失败：" + database + "." + collection,
+          failure);
+    }
+  }
+
+  private MongoCollection<BsonDocument> collection(MongoClient client, Path path) {
+    MongoDatabase database = client.getDatabase(path.database());
+    return database.getCollection(path.collection(), BsonDocument.class);
+  }
+
+  private MongoClient client() {
+    return MongoClientFactory.create(connection, timeoutSeconds);
+  }
+
+  private Path resolvePath(String value) {
+    String path = requireCollection(value);
+    String defaultDatabase = connection.database();
+    String prefix = defaultDatabase + ".";
+    if (path.regionMatches(true, 0, prefix, 0, prefix.length())) {
+      return new Path(defaultDatabase, requireCollection(path.substring(prefix.length())));
+    }
+    // MongoDB collection names may legally contain dots. Treat an unqualified catalog-read path as
+    // a collection in the datasource default database instead of guessing database.collection.
+    return new Path(defaultDatabase, path);
+  }
+
+  private String requireDatabase(String value) {
+    String normalized = normalize(value);
+    return normalized == null ? connection.database() : normalized;
+  }
+
+  private String requireCollection(String value) {
+    String normalized = normalize(value);
+    if (normalized == null) throw catalog("MongoDB Collection 不能为空");
+    return normalized;
+  }
+
+  private void requireNoSchema(String schema) {
+    if (normalize(schema) != null) {
+      throw catalog("MongoDB 没有独立 Schema 层级，请使用 Database + Collection");
+    }
+  }
+
+  private String normalize(String value) {
+    if (value == null) return null;
+    String normalized = value.trim();
+    return normalized.isEmpty() ? null : normalized;
+  }
+
+  private DataSourcePluginException catalog(String message) {
+    return new DataSourcePluginException(Operation.CATALOG, message);
+  }
+
+  private DataSourcePluginException catalog(String message, Throwable cause) {
+    return new DataSourcePluginException(Operation.CATALOG, message, cause);
+  }
+
+  private record Path(String database, String collection) {
+    @Override
+    public String toString() {
+      return database + "." + collection;
+    }
+  }
+}

--- a/yak-ops-plugins/yak-ops-plugin-datasource/yak-ops-plugin-datasource-mongodb/src/main/java/io/yak/ops/plugin/database/mongodb/MongoDataSourcePlugin.java
+++ b/yak-ops-plugins/yak-ops-plugin-datasource/yak-ops-plugin-datasource-mongodb/src/main/java/io/yak/ops/plugin/database/mongodb/MongoDataSourcePlugin.java
@@ -1,0 +1,301 @@
+package io.yak.ops.plugin.database.mongodb;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import com.mongodb.ConnectionString;
+import com.mongodb.client.MongoClient;
+import io.yak.ops.common.enums.datasource.DataSourceDbType;
+import io.yak.ops.spi.datasource.DataSourceCapability;
+import io.yak.ops.spi.datasource.DataSourceCatalog;
+import io.yak.ops.spi.datasource.DataSourceConnection;
+import io.yak.ops.spi.datasource.DataSourcePlugin;
+import io.yak.ops.spi.datasource.DataSourcePluginDescriptor;
+import io.yak.ops.spi.datasource.DataSourcePluginDescriptor.ConnectionForm;
+import io.yak.ops.spi.datasource.DataSourcePluginDescriptor.FieldType;
+import io.yak.ops.spi.datasource.DataSourcePluginDescriptor.FormField;
+import io.yak.ops.spi.datasource.DataSourcePluginDescriptor.FormRule;
+import io.yak.ops.spi.datasource.DataSourcePluginDescriptor.FormSection;
+import io.yak.ops.spi.datasource.DataSourcePluginException;
+import io.yak.ops.spi.datasource.DataSourcePluginException.Operation;
+import java.net.URLEncoder;
+import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
+import java.util.EnumSet;
+import java.util.List;
+import org.bson.BsonDocument;
+import org.bson.BsonInt32;
+
+/** MongoDB datasource-management plugin. */
+public final class MongoDataSourcePlugin implements DataSourcePlugin {
+
+  private static final ObjectMapper MAPPER = new ObjectMapper();
+  private static final int DEFAULT_PORT = 27017;
+
+  private static final DataSourcePluginDescriptor DESCRIPTOR =
+      new DataSourcePluginDescriptor(
+          DataSourceDbType.MONGODB,
+          "MongoDB",
+          DataSourcePluginDescriptor.CURRENT_API_VERSION,
+          EnumSet.of(
+              DataSourceCapability.CONNECTION_TEST,
+              DataSourceCapability.CATALOG_METADATA,
+              DataSourceCapability.CATALOG_READ),
+          connectionForm(),
+          false,
+          null);
+
+  @Override
+  public DataSourceDbType dbType() {
+    return DataSourceDbType.MONGODB;
+  }
+
+  @Override
+  public DataSourcePluginDescriptor descriptor() {
+    return DESCRIPTOR;
+  }
+
+  @Override
+  public DataSourceConnection parseConnection(String originalJson) {
+    ObjectNode input = readObject(originalJson);
+    String host = defaultText(text(input, "host"), "127.0.0.1");
+    int port = positivePort(input.path("port").asInt(DEFAULT_PORT));
+    String hosts = text(input, "hosts");
+    String database = requireText(text(input, "database"), "database");
+    String username = text(input, "username");
+    String password = textAllowEmpty(input, "password");
+    String authSource = text(input, "authSource");
+    List<String> seeds = normalizeSeeds(hosts, host, port);
+
+    String uri = buildUri(seeds, database, username, password, authSource, true);
+    String displayUrl = buildUri(seeds, database, null, null, authSource, false);
+    parseConnectionString(uri);
+
+    ObjectNode normalized = MAPPER.createObjectNode();
+    normalized.put("dbType", DataSourceDbType.MONGODB.name());
+    normalized.put("host", host);
+    normalized.put("port", port);
+    normalized.put("database", database);
+    if (hosts != null) normalized.put("hosts", hosts);
+    if (username != null) normalized.put("username", username);
+    if (password != null) normalized.put("password", password);
+    if (authSource != null) normalized.put("authSource", authSource);
+
+    return new MongoConnection(
+        uri,
+        displayUrl,
+        database,
+        username,
+        password,
+        write(normalized));
+  }
+
+  @Override
+  public void testConnection(DataSourceConnection connection, int timeoutSeconds) {
+    MongoConnection mongo = requireConnection(connection);
+    try (MongoClient client = MongoClientFactory.create(mongo, timeoutSeconds)) {
+      client
+          .getDatabase(mongo.database())
+          .runCommand(new BsonDocument("ping", new BsonInt32(1)));
+    } catch (RuntimeException failure) {
+      throw new DataSourcePluginException(
+          Operation.CONNECTIVITY,
+          "MongoDB 连接测试失败，请检查地址、认证信息和数据库权限",
+          failure);
+    }
+  }
+
+  @Override
+  public DataSourceCatalog createCatalog(DataSourceConnection connection, int timeoutSeconds) {
+    return new MongoDataSourceCatalog(requireConnection(connection), timeoutSeconds);
+  }
+
+  @Override
+  public boolean acceptsUrl(String url) {
+    if (url == null) return false;
+    String normalized = url.trim().toLowerCase(java.util.Locale.ROOT);
+    return normalized.startsWith("mongodb://") || normalized.startsWith("mongodb+srv://");
+  }
+
+  private static MongoConnection requireConnection(DataSourceConnection connection) {
+    if (!(connection instanceof MongoConnection mongo)) {
+      throw new DataSourcePluginException(
+          Operation.PARAMETER, "MongoDB 插件收到不兼容的数据源连接模型");
+    }
+    return mongo;
+  }
+
+  private static ConnectionForm connectionForm() {
+    FormRule required = new FormRule(true, null, null, null, "不能为空");
+    FormRule portRule = new FormRule(true, null, 1, 65535, "端口范围 1-65535");
+
+    List<FormField> basic =
+        List.of(
+            field("host", "Host", FieldType.INPUT, "127.0.0.1", "127.0.0.1", List.of(required)),
+            field("port", "Port", FieldType.NUMBER, "27017", DEFAULT_PORT, List.of(portRule)),
+            field("database", "Database", FieldType.INPUT, "例如：business", null, List.of(required)),
+            field("username", "Username", FieldType.INPUT, "可选", null, List.of()),
+            field("password", "Password", FieldType.PASSWORD, "可选", null, List.of()));
+
+    List<FormField> advanced =
+        List.of(
+            field(
+                "hosts",
+                "Seed Hosts",
+                FieldType.TEXTAREA,
+                "可选，例如：mongo-1:27017,mongo-2:27017；填写后覆盖 Host/Port",
+                null,
+                List.of()),
+            field(
+                "authSource",
+                "Auth Source",
+                FieldType.INPUT,
+                "可选，例如：admin",
+                null,
+                List.of()));
+
+    return new ConnectionForm(
+        List.of(
+            new FormSection("basic", "连接信息", "MongoDB 默认数据库和认证信息", false, true, basic),
+            new FormSection(
+                "advanced",
+                "高级连接",
+                "Replica Set / 集群可填写多个 seed hosts；无需手工维护字段类型",
+                true,
+                false,
+                advanced)),
+        List.of());
+  }
+
+  private static FormField field(
+      String key,
+      String label,
+      FieldType type,
+      String placeholder,
+      Object defaultValue,
+      List<FormRule> rules) {
+    return new FormField(
+        key,
+        label,
+        type,
+        placeholder,
+        defaultValue,
+        List.of(),
+        rules,
+        List.of(),
+        List.of(),
+        null);
+  }
+
+  private static String buildUri(
+      List<String> seeds,
+      String database,
+      String username,
+      String password,
+      String authSource,
+      boolean includeCredentials) {
+    StringBuilder uri = new StringBuilder("mongodb://");
+    if (includeCredentials && username != null) {
+      uri.append(encode(username));
+      if (password != null) uri.append(':').append(encode(password));
+      uri.append('@');
+    }
+    uri.append(String.join(",", seeds));
+    uri.append('/').append(encode(database));
+    if (authSource != null) {
+      uri.append("?authSource=").append(encode(authSource));
+    }
+    return uri.toString();
+  }
+
+  private static List<String> normalizeSeeds(String hosts, String host, int port) {
+    List<String> values = new ArrayList<>();
+    if (hosts != null) {
+      for (String item : hosts.split(",")) {
+        String seed = trim(item);
+        if (seed != null) values.add(normalizeSeed(seed, port));
+      }
+    }
+    if (values.isEmpty()) values.add(normalizeSeed(requireText(host, "host"), port));
+    return List.copyOf(values);
+  }
+
+  private static String normalizeSeed(String value, int defaultPort) {
+    if (value.contains("://") || value.contains("/") || value.contains("?") || value.contains("@")) {
+      throw new DataSourcePluginException(
+          Operation.PARAMETER, "MongoDB Seed Host 只允许 host 或 host:port：" + value);
+    }
+    return value.contains(":") ? value : value + ":" + defaultPort;
+  }
+
+  private static ConnectionString parseConnectionString(String uri) {
+    try {
+      return new ConnectionString(requireText(uri, "uri"));
+    } catch (IllegalArgumentException failure) {
+      throw new DataSourcePluginException(Operation.PARAMETER, "MongoDB 连接地址格式不正确", failure);
+    }
+  }
+
+  private static ObjectNode readObject(String json) {
+    if (json == null || json.trim().isEmpty()) return MAPPER.createObjectNode();
+    try {
+      JsonNode value = MAPPER.readTree(json);
+      if (value != null && value.isObject()) return (ObjectNode) value;
+      throw new DataSourcePluginException(Operation.PARAMETER, "MongoDB 连接参数必须是 JSON 对象");
+    } catch (JsonProcessingException failure) {
+      throw new DataSourcePluginException(Operation.PARAMETER, "MongoDB 连接参数不是有效 JSON", failure);
+    }
+  }
+
+  private static String write(JsonNode value) {
+    try {
+      return MAPPER.writeValueAsString(value);
+    } catch (JsonProcessingException failure) {
+      throw new IllegalStateException("序列化 MongoDB 连接参数失败", failure);
+    }
+  }
+
+  private static String text(JsonNode node, String field) {
+    if (node == null || !node.isObject()) return null;
+    JsonNode value = node.get(field);
+    if (value == null || value.isNull() || !value.isValueNode()) return null;
+    return trim(value.asText());
+  }
+
+  private static String textAllowEmpty(JsonNode node, String field) {
+    if (node == null || !node.isObject()) return null;
+    JsonNode value = node.get(field);
+    if (value == null || value.isNull() || !value.isValueNode()) return null;
+    return value.asText();
+  }
+
+  private static int positivePort(int port) {
+    if (port <= 0 || port > 65535) {
+      throw new DataSourcePluginException(Operation.PARAMETER, "MongoDB port 必须在 1-65535 范围内");
+    }
+    return port;
+  }
+
+  private static String encode(String value) {
+    return URLEncoder.encode(value, StandardCharsets.UTF_8).replace("+", "%20");
+  }
+
+  private static String defaultText(String value, String fallback) {
+    return value == null ? fallback : value;
+  }
+
+  private static String requireText(String value, String field) {
+    String normalized = trim(value);
+    if (normalized == null) {
+      throw new DataSourcePluginException(Operation.PARAMETER, "MongoDB " + field + " 不能为空");
+    }
+    return normalized;
+  }
+
+  private static String trim(String value) {
+    if (value == null) return null;
+    String normalized = value.trim();
+    return normalized.isEmpty() ? null : normalized;
+  }
+}

--- a/yak-ops-plugins/yak-ops-plugin-datasource/yak-ops-plugin-datasource-mongodb/src/main/java/io/yak/ops/plugin/database/mongodb/MongoSchemaDiscovery.java
+++ b/yak-ops-plugins/yak-ops-plugin-datasource/yak-ops-plugin-datasource-mongodb/src/main/java/io/yak/ops/plugin/database/mongodb/MongoSchemaDiscovery.java
@@ -1,0 +1,226 @@
+package io.yak.ops.plugin.database.mongodb;
+
+import io.yak.ops.spi.datasource.metadata.DataSourceColumn;
+import java.sql.Types;
+import java.time.Instant;
+import java.util.ArrayList;
+import java.util.Base64;
+import java.util.Collections;
+import java.util.LinkedHashMap;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import org.bson.BsonDocument;
+import org.bson.BsonType;
+import org.bson.BsonValue;
+
+/** Sampled MongoDB schema discovery aligned with the Link-Up bounded connector policy. */
+final class MongoSchemaDiscovery {
+
+  static final int SAMPLE_SIZE = 1000;
+  static final int MAX_DEPTH = 8;
+  private static final int DECIMAL_PRECISION = 34;
+  private static final int DECIMAL_SCALE = 18;
+
+  private MongoSchemaDiscovery() {}
+
+  static List<DataSourceColumn> discover(Iterable<BsonDocument> documents) {
+    Map<String, FieldState> fields = new LinkedHashMap<>();
+    int sampled = 0;
+    for (BsonDocument document : documents) {
+      if (document == null || sampled >= SAMPLE_SIZE) break;
+      sampled++;
+      observeDocument(fields, null, document, 0);
+    }
+    if (fields.isEmpty()) return List.of();
+
+    List<DataSourceColumn> result = new ArrayList<>();
+    int ordinal = 1;
+    for (Map.Entry<String, FieldState> entry : fields.entrySet()) {
+      result.add(entry.getValue().column(entry.getKey(), sampled, ordinal++));
+    }
+    return List.copyOf(result);
+  }
+
+  static Object previewValue(BsonDocument document, String path) {
+    BsonValue value = extract(document, path);
+    return portableValue(value);
+  }
+
+  private static void observeDocument(
+      Map<String, FieldState> fields,
+      String parent,
+      BsonDocument document,
+      int depth) {
+    for (Map.Entry<String, BsonValue> entry : document.entrySet()) {
+      String path = parent == null ? entry.getKey() : parent + "." + entry.getKey();
+      FieldState state = fields.computeIfAbsent(path, ignored -> new FieldState());
+      BsonValue value = entry.getValue();
+      state.observe(value);
+      if (value != null
+          && value.getBsonType() == BsonType.DOCUMENT
+          && depth < MAX_DEPTH) {
+        observeDocument(fields, path, value.asDocument(), depth + 1);
+      }
+    }
+  }
+
+  private static BsonValue extract(BsonDocument document, String path) {
+    if (document == null || path == null || path.isBlank()) return null;
+    String[] segments = path.split("\\.");
+    BsonDocument current = document;
+    for (int i = 0; i < segments.length; i++) {
+      BsonValue value = current.get(segments[i]);
+      if (value == null || value.getBsonType() == BsonType.NULL) return value;
+      if (i == segments.length - 1) return value;
+      if (value.getBsonType() != BsonType.DOCUMENT) return null;
+      current = value.asDocument();
+    }
+    return null;
+  }
+
+  private static Object portableValue(BsonValue value) {
+    if (value == null || value.getBsonType() == BsonType.NULL) return null;
+    return switch (value.getBsonType()) {
+      case STRING -> value.asString().getValue();
+      case OBJECT_ID -> value.asObjectId().getValue().toHexString();
+      case BOOLEAN -> value.asBoolean().getValue();
+      case INT32 -> value.asInt32().getValue();
+      case INT64 -> value.asInt64().getValue();
+      case DOUBLE -> value.asDouble().getValue();
+      case DECIMAL128 -> value.asDecimal128().getValue().toString();
+      case DATE_TIME -> Instant.ofEpochMilli(value.asDateTime().getValue()).toString();
+      case TIMESTAMP -> Instant.ofEpochSecond(value.asTimestamp().getTime()).toString();
+      case BINARY -> Base64.getEncoder().encodeToString(value.asBinary().getData());
+      case DOCUMENT, ARRAY -> value.toString();
+      default -> value.toString();
+    };
+  }
+
+  private static final class FieldState {
+
+    private final Set<BsonType> physicalTypes = new LinkedHashSet<>();
+    private Kind kind = Kind.NULL;
+    private int observedDocuments;
+    private boolean sawNull;
+    private boolean complex;
+
+    void observe(BsonValue value) {
+      observedDocuments++;
+      BsonType type = value == null ? BsonType.NULL : value.getBsonType();
+      physicalTypes.add(type);
+      if (type == BsonType.NULL) sawNull = true;
+      if (type == BsonType.DOCUMENT || type == BsonType.ARRAY) complex = true;
+      kind = Kind.merge(kind, Kind.from(type));
+    }
+
+    DataSourceColumn column(String name, int sampledDocuments, int ordinal) {
+      boolean nullable = sawNull || observedDocuments < sampledDocuments;
+      Integer size = kind == Kind.DECIMAL ? DECIMAL_PRECISION : null;
+      Integer scale = kind == Kind.DECIMAL ? DECIMAL_SCALE : null;
+      String remarks =
+          complex
+              ? "MongoDB complex value; offline sync uses Extended JSON boundary"
+              : physicalTypes.size() > 1 ? "MongoDB sampled heterogeneous field" : null;
+      return new DataSourceColumn(
+          name,
+          typeName(),
+          kind.jdbcType(),
+          size,
+          scale,
+          nullable,
+          ordinal,
+          "_id".equals(name),
+          remarks);
+    }
+
+    private String typeName() {
+      List<String> names = new ArrayList<>();
+      for (BsonType type : physicalTypes) {
+        if (type != BsonType.NULL) names.add(display(type));
+      }
+      if (names.isEmpty()) return "Null";
+      return String.join("|", names);
+    }
+
+    private static String display(BsonType type) {
+      return switch (type) {
+        case OBJECT_ID -> "ObjectId";
+        case INT32 -> "Int32";
+        case INT64 -> "Int64";
+        case DECIMAL128 -> "Decimal128";
+        case DATE_TIME -> "DateTime";
+        case TIMESTAMP -> "Timestamp";
+        case BINARY -> "Binary";
+        case DOCUMENT -> "Document";
+        case ARRAY -> "Array";
+        case STRING -> "String";
+        case BOOLEAN -> "Boolean";
+        case DOUBLE -> "Double";
+        default -> type.name();
+      };
+    }
+  }
+
+  private enum Kind {
+    NULL,
+    BOOLEAN,
+    INT,
+    LONG,
+    DOUBLE,
+    DECIMAL,
+    TIMESTAMP,
+    BYTES,
+    JSON,
+    STRING;
+
+    static Kind from(BsonType type) {
+      return switch (type) {
+        case NULL -> NULL;
+        case BOOLEAN -> BOOLEAN;
+        case INT32 -> INT;
+        case INT64 -> LONG;
+        case DOUBLE -> DOUBLE;
+        case DECIMAL128 -> DECIMAL;
+        case DATE_TIME, TIMESTAMP -> TIMESTAMP;
+        case BINARY -> BYTES;
+        case DOCUMENT, ARRAY -> JSON;
+        default -> STRING;
+      };
+    }
+
+    static Kind merge(Kind left, Kind right) {
+      if (left == NULL) return right;
+      if (right == NULL) return left;
+      if (left == right) return left;
+      if (numeric(left) && numeric(right)) {
+        if ((left == DECIMAL && right == DOUBLE) || (left == DOUBLE && right == DECIMAL)) {
+          return STRING;
+        }
+        if (left == DECIMAL || right == DECIMAL) return DECIMAL;
+        if (left == DOUBLE || right == DOUBLE) return DOUBLE;
+        if (left == LONG || right == LONG) return LONG;
+        return INT;
+      }
+      return STRING;
+    }
+
+    private static boolean numeric(Kind value) {
+      return value == INT || value == LONG || value == DOUBLE || value == DECIMAL;
+    }
+
+    int jdbcType() {
+      return switch (this) {
+        case BOOLEAN -> Types.BOOLEAN;
+        case INT -> Types.INTEGER;
+        case LONG -> Types.BIGINT;
+        case DOUBLE -> Types.DOUBLE;
+        case DECIMAL -> Types.DECIMAL;
+        case TIMESTAMP -> Types.TIMESTAMP;
+        case BYTES -> Types.VARBINARY;
+        case NULL, JSON, STRING -> Types.VARCHAR;
+      };
+    }
+  }
+}

--- a/yak-ops-plugins/yak-ops-plugin-datasource/yak-ops-plugin-datasource-mongodb/src/main/resources/META-INF/services/io.yak.ops.spi.datasource.DataSourcePlugin
+++ b/yak-ops-plugins/yak-ops-plugin-datasource/yak-ops-plugin-datasource-mongodb/src/main/resources/META-INF/services/io.yak.ops.spi.datasource.DataSourcePlugin
@@ -1,0 +1,1 @@
+io.yak.ops.plugin.database.mongodb.MongoDataSourcePlugin

--- a/yak-ops-plugins/yak-ops-plugin-datasource/yak-ops-plugin-datasource-mongodb/src/test/java/io/yak/ops/plugin/database/mongodb/MongoDataSourcePluginTest.java
+++ b/yak-ops-plugins/yak-ops-plugin-datasource/yak-ops-plugin-datasource-mongodb/src/test/java/io/yak/ops/plugin/database/mongodb/MongoDataSourcePluginTest.java
@@ -1,0 +1,74 @@
+package io.yak.ops.plugin.database.mongodb;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import io.yak.ops.common.enums.datasource.DataSourceDbType;
+import io.yak.ops.spi.datasource.DataSourceCapability;
+import io.yak.ops.spi.datasource.DataSourceConnection;
+import io.yak.ops.spi.datasource.DataSourcePluginException;
+import org.junit.jupiter.api.Test;
+
+class MongoDataSourcePluginTest {
+
+  private final MongoDataSourcePlugin plugin = new MongoDataSourcePlugin();
+
+  @Test
+  void normalizesStructuredConnectionWithoutDuplicatingCredentialsIntoDisplayUrl() {
+    DataSourceConnection connection =
+        plugin.parseConnection(
+            """
+            {
+              "host":"mongo-a",
+              "port":27018,
+              "hosts":"mongo-a:27018,mongo-b:27018",
+              "database":"business",
+              "username":"yak user",
+              "password":"s ecret",
+              "authSource":"admin"
+            }
+            """);
+
+    assertThat(connection.dbType()).isEqualTo(DataSourceDbType.MONGODB);
+    assertThat(connection.jdbcUrl())
+        .isEqualTo("mongodb://mongo-a:27018,mongo-b:27018/business?authSource=admin")
+        .doesNotContain("yak", "secret");
+    assertThat(connection.database()).isEqualTo("business");
+    assertThat(connection.username()).isEqualTo("yak user");
+    assertThat(connection.password()).isEqualTo("s ecret");
+    assertThat(connection.normalizedJson())
+        .contains("\"hosts\":\"mongo-a:27018,mongo-b:27018\"")
+        .contains("\"password\":\"s ecret\"")
+        .doesNotContain("\"uri\"");
+  }
+
+  @Test
+  void exposesCatalogCapabilitiesAndPasswordAsSecretField() {
+    assertThat(plugin.descriptor().capabilities())
+        .containsExactlyInAnyOrder(
+            DataSourceCapability.CONNECTION_TEST,
+            DataSourceCapability.CATALOG_METADATA,
+            DataSourceCapability.CATALOG_READ);
+    assertThat(plugin.descriptor().secretFieldKeys()).containsExactly("password");
+    assertThat(plugin.acceptsUrl("mongodb://localhost:27017/app")).isTrue();
+    assertThat(plugin.acceptsUrl("mongodb+srv://cluster.example/app")).isTrue();
+  }
+
+  @Test
+  void rejectsMalformedSeedHostAndPort() {
+    assertThatThrownBy(
+            () ->
+                plugin.parseConnection(
+                    "{\"host\":\"mongo-a\",\"port\":0,\"database\":\"app\"}"))
+        .isInstanceOf(DataSourcePluginException.class)
+        .hasMessageContaining("port");
+
+    assertThatThrownBy(
+            () ->
+                plugin.parseConnection(
+                    "{\"host\":\"mongo-a\",\"database\":\"app\","
+                        + "\"hosts\":\"mongodb://mongo-a:27017\"}"))
+        .isInstanceOf(DataSourcePluginException.class)
+        .hasMessageContaining("Seed Host");
+  }
+}

--- a/yak-ops-plugins/yak-ops-plugin-datasource/yak-ops-plugin-datasource-mongodb/src/test/java/io/yak/ops/plugin/database/mongodb/MongoSchemaDiscoveryTest.java
+++ b/yak-ops-plugins/yak-ops-plugin-datasource/yak-ops-plugin-datasource-mongodb/src/test/java/io/yak/ops/plugin/database/mongodb/MongoSchemaDiscoveryTest.java
@@ -1,0 +1,60 @@
+package io.yak.ops.plugin.database.mongodb;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.yak.ops.spi.datasource.metadata.DataSourceColumn;
+import java.sql.Types;
+import java.util.List;
+import java.util.Map;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+import org.bson.BsonDocument;
+import org.bson.BsonInt32;
+import org.bson.BsonInt64;
+import org.bson.BsonObjectId;
+import org.bson.BsonString;
+import org.bson.types.ObjectId;
+import org.junit.jupiter.api.Test;
+
+class MongoSchemaDiscoveryTest {
+
+  @Test
+  void discoversPortableTypesAndDottedNestedFieldsAcrossSamples() {
+    BsonDocument first =
+        new BsonDocument()
+            .append("_id", new BsonObjectId(new ObjectId("64b7abdecf2160b649ab6085")))
+            .append("age", new BsonInt32(18))
+            .append(
+                "address",
+                new BsonDocument("city", new BsonString("Chengdu")));
+    BsonDocument second =
+        new BsonDocument()
+            .append("_id", new BsonObjectId(new ObjectId("64b7abdecf2160b649ab6086")))
+            .append("age", new BsonInt64(20L));
+
+    List<DataSourceColumn> columns = MongoSchemaDiscovery.discover(List.of(first, second));
+    Map<String, DataSourceColumn> byName =
+        columns.stream().collect(Collectors.toMap(DataSourceColumn::getName, Function.identity()));
+
+    assertThat(byName.get("_id").isPrimaryKey()).isTrue();
+    assertThat(byName.get("_id").getTypeName()).isEqualTo("ObjectId");
+    assertThat(byName.get("age").getJdbcType()).isEqualTo(Types.BIGINT);
+    assertThat(byName.get("age").getTypeName()).contains("Int32", "Int64");
+    assertThat(byName.get("address").getJdbcType()).isEqualTo(Types.VARCHAR);
+    assertThat(byName.get("address").getRemarks()).contains("Extended JSON");
+    assertThat(byName.get("address.city").getTypeName()).isEqualTo("String");
+    assertThat(byName.get("address.city").isNullable()).isTrue();
+  }
+
+  @Test
+  void heterogeneousScalarFallsBackToTextMetadata() {
+    BsonDocument first = new BsonDocument("value", new BsonInt32(1));
+    BsonDocument second = new BsonDocument("value", new BsonString("unknown"));
+
+    DataSourceColumn value = MongoSchemaDiscovery.discover(List.of(first, second)).get(0);
+
+    assertThat(value.getJdbcType()).isEqualTo(Types.VARCHAR);
+    assertThat(value.getTypeName()).contains("Int32", "String");
+    assertThat(value.getRemarks()).contains("heterogeneous");
+  }
+}

--- a/yak-ops-ui/src/locales/en-US/data-source.ts
+++ b/yak-ops-ui/src/locales/en-US/data-source.ts
@@ -58,6 +58,7 @@ export default {
 
   'pages.datasource.group.relational': 'Relational Databases',
   'pages.datasource.group.olap': 'OLAP Databases',
+  'pages.datasource.group.document': 'Document Databases',
   'pages.datasource.group.search': 'Search Engines',
   'pages.datasource.typeSelector.title': 'Select a Data Source',
   'pages.datasource.typeSelector.searchPlaceholder': 'Search data sources',

--- a/yak-ops-ui/src/locales/zh-CN/data-source.ts
+++ b/yak-ops-ui/src/locales/zh-CN/data-source.ts
@@ -58,6 +58,7 @@ export default {
 
   'pages.datasource.group.relational': '关系型数据库',
   'pages.datasource.group.olap': 'OLAP 数据库',
+  'pages.datasource.group.document': '文档数据库',
   'pages.datasource.group.search': '搜索引擎',
   'pages.datasource.typeSelector.title': '选择数据源',
   'pages.datasource.typeSelector.searchPlaceholder': '搜索数据源',

--- a/yak-ops-ui/src/pages/data-source/components/DataSourceToolbar.tsx
+++ b/yak-ops-ui/src/pages/data-source/components/DataSourceToolbar.tsx
@@ -28,6 +28,7 @@ interface DataSourceToolbarProps {
 const DB_TYPE_LABELS: Record<string, string> = {
   MYSQL: 'MYSQL',
   TIDB: 'TiDB',
+  GOLDENDB: 'GoldenDB',
   HANA: 'SAP HANA',
   ORACLE: 'ORACLE',
   POSTGRE_SQL: 'PostgreSQL',

--- a/yak-ops-ui/src/pages/data-source/components/DataSourceToolbar.tsx
+++ b/yak-ops-ui/src/pages/data-source/components/DataSourceToolbar.tsx
@@ -45,6 +45,7 @@ const DB_TYPE_LABELS: Record<string, string> = {
   CLICKHOUSE: 'ClickHouse',
   ELASTICSEARCH7: 'Elasticsearch 7',
   ELASTICSEARCH8: 'Elasticsearch 8',
+  MONGODB: 'MongoDB',
   KINGBASE: 'KINGBASE',
   DAMENG: 'DAMENG',
 };

--- a/yak-ops-ui/src/pages/data-source/constants.tsx
+++ b/yak-ops-ui/src/pages/data-source/constants.tsx
@@ -31,6 +31,7 @@ export const EMPTY_DATA_SOURCE_SUMMARY: DataSourceSummary = {
 export const COMMON_DB_OPTIONS: DataSourceOptionItem[] = [
   { label: 'MYSQL', value: 'MYSQL' },
   { label: 'TIDB', value: 'TIDB' },
+  { label: 'GOLDENDB', value: 'GOLDENDB' },
   { label: 'HANA', value: 'HANA' },
   { label: 'ORACLE', value: 'ORACLE' },
   { label: 'POSTGRE_SQL', value: 'POSTGRE_SQL' },
@@ -80,6 +81,7 @@ export const getDataSourceGroupList = (intl: IntlFormatter): DataSourceGroup[] =
     datasourceList: [
       relationalDataSource('MYSQL'),
       relationalDataSource('TIDB'),
+      relationalDataSource('GOLDENDB'),
       relationalDataSource('HANA'),
       relationalDataSource('ORACLE'),
       relationalDataSource('POSTGRE_SQL'),

--- a/yak-ops-ui/src/pages/data-source/constants.tsx
+++ b/yak-ops-ui/src/pages/data-source/constants.tsx
@@ -106,12 +106,16 @@ export const getDataSourceGroupList = (intl: IntlFormatter): DataSourceGroup[] =
     ],
   },
   {
+    groupKey: 'document',
+    groupName: intl.formatMessage({ id: 'pages.datasource.group.document' }),
+    datasourceList: [typedDataSource('MONGODB', 'MongoDB')],
+  },
+  {
     groupKey: 'search',
     groupName: intl.formatMessage({ id: 'pages.datasource.group.search' }),
     datasourceList: [
       typedDataSource('ELASTICSEARCH7', 'Elasticsearch7'),
       typedDataSource('ELASTICSEARCH8', 'Elasticsearch8'),
-      typedDataSource('MONGODB', 'MongoDB'),
     ],
   },
 ];

--- a/yak-ops-ui/src/pages/data-source/constants.tsx
+++ b/yak-ops-ui/src/pages/data-source/constants.tsx
@@ -48,6 +48,7 @@ export const COMMON_DB_OPTIONS: DataSourceOptionItem[] = [
   { label: 'CLICKHOUSE', value: 'CLICKHOUSE' },
   { label: 'ELASTICSEARCH7', value: 'ELASTICSEARCH7' },
   { label: 'ELASTICSEARCH8', value: 'ELASTICSEARCH8' },
+  { label: 'MONGODB', value: 'MONGODB' },
   { label: 'KINGBASE', value: 'KINGBASE' },
   { label: 'DAMENG', value: 'DAMENG' },
 ];
@@ -110,6 +111,7 @@ export const getDataSourceGroupList = (intl: IntlFormatter): DataSourceGroup[] =
     datasourceList: [
       typedDataSource('ELASTICSEARCH7', 'Elasticsearch7'),
       typedDataSource('ELASTICSEARCH8', 'Elasticsearch8'),
+      typedDataSource('MONGODB', 'MongoDB'),
     ],
   },
 ];

--- a/yak-ops-ui/src/pages/integration/batch-link-up/DataSourceSelect.tsx
+++ b/yak-ops-ui/src/pages/integration/batch-link-up/DataSourceSelect.tsx
@@ -24,6 +24,7 @@ const executionMetadata = (dbType: string) => {
 const DATA_SOURCE_TYPES = [
   { value: 'MYSQL', displayName: 'MYSQL' },
   { value: 'TIDB', displayName: 'TiDB' },
+  { value: 'GOLDENDB', displayName: 'GoldenDB' },
   { value: 'HANA', displayName: 'SAP HANA' },
   { value: 'ORACLE', displayName: 'ORACLE' },
   { value: 'POSTGRE_SQL', displayName: 'PostgreSQL' },

--- a/yak-ops-ui/src/pages/integration/batch-link-up/DataSourceSelect.tsx
+++ b/yak-ops-ui/src/pages/integration/batch-link-up/DataSourceSelect.tsx
@@ -41,6 +41,7 @@ const DATA_SOURCE_TYPES = [
   { value: 'CLICKHOUSE', displayName: 'ClickHouse' },
   { value: 'ELASTICSEARCH7', displayName: 'Elasticsearch 7' },
   { value: 'ELASTICSEARCH8', displayName: 'Elasticsearch 8' },
+  { value: 'MONGODB', displayName: 'MongoDB' },
   { value: 'KINGBASE', displayName: 'KINGBASE' },
   { value: 'DAMENG', displayName: 'DAMENG' },
 ] as const;

--- a/yak-ops-ui/src/pages/integration/batch-link-up/connectorProfiles.ts
+++ b/yak-ops-ui/src/pages/integration/batch-link-up/connectorProfiles.ts
@@ -11,6 +11,8 @@ export interface OfflineSyncConnectorProfile {
   defaultProfile: boolean;
   /** Product-level guide policy. Backend adapters remain the final enforcement boundary. */
   guideMultiEnabled?: boolean;
+  /** Product-level target DDL policy layered on top of connector-wide capabilities. */
+  autoCreateTableEnabled?: boolean;
 }
 
 /** Control-plane default execution profiles for datasource types exposed by Yak Ops. */
@@ -22,6 +24,11 @@ export const OFFLINE_SYNC_CONNECTOR_PROFILES: readonly OfflineSyncConnectorProfi
   {
     profileId: 'tidb-jdbc', dbType: 'TIDB', sourceConnectorId: 'jdbc', sinkConnectorId: 'jdbc',
     connectorType: 'Jdbc', pluginName: 'JDBC-TIDB', defaultProfile: true,
+  },
+  {
+    profileId: 'goldendb-jdbc', dbType: 'GOLDENDB', sourceConnectorId: 'jdbc', sinkConnectorId: 'jdbc',
+    connectorType: 'Jdbc', pluginName: 'JDBC-GOLDENDB', defaultProfile: true,
+    autoCreateTableEnabled: false,
   },
   {
     profileId: 'hana-jdbc', dbType: 'HANA', sourceConnectorId: 'jdbc', sinkConnectorId: 'jdbc',
@@ -122,6 +129,8 @@ const DB_TYPE_ALIASES: Record<string, string> = {
   POSTGRESQL: 'POSTGRE_SQL',
   POSTGRES: 'POSTGRE_SQL',
   TI_DB: 'TIDB',
+  GOLDEN_DB: 'GOLDENDB',
+  ZTE_GOLDENDB: 'GOLDENDB',
   SAP_HANA: 'HANA',
   SAPHANA: 'HANA',
   OPENGAUSS: 'OPEN_GAUSS',
@@ -158,6 +167,9 @@ export const defaultOfflineSyncConnectorProfile = (
 
 export const isGuideMultiEnabledForDataSourceType = (dbType?: string): boolean =>
   defaultOfflineSyncConnectorProfile(dbType)?.guideMultiEnabled !== false;
+
+export const isAutoCreateTableEnabledForDataSourceType = (dbType?: string): boolean =>
+  defaultOfflineSyncConnectorProfile(dbType)?.autoCreateTableEnabled !== false;
 
 /** Compatibility inference used only when a persisted endpoint has no durable connectorId. */
 export const connectorIdForDataSourceType = (

--- a/yak-ops-ui/src/pages/integration/batch-link-up/connectorProfiles.ts
+++ b/yak-ops-ui/src/pages/integration/batch-link-up/connectorProfiles.ts
@@ -96,6 +96,11 @@ export const OFFLINE_SYNC_CONNECTOR_PROFILES: readonly OfflineSyncConnectorProfi
     guideMultiEnabled: false,
   },
   {
+    profileId: 'mongodb-native', dbType: 'MONGODB',
+    sourceConnectorId: 'mongodb', sinkConnectorId: 'mongodb',
+    connectorType: 'MongoDB', pluginName: 'MONGODB', defaultProfile: true,
+  },
+  {
     profileId: 'kingbase-jdbc', dbType: 'KINGBASE', sourceConnectorId: 'jdbc', sinkConnectorId: 'jdbc',
     connectorType: 'Jdbc', pluginName: 'JDBC-KINGBASE', defaultProfile: true,
   },
@@ -133,6 +138,8 @@ const DB_TYPE_ALIASES: Record<string, string> = {
   ES7: 'ELASTICSEARCH7',
   ELASTICSEARCH_8: 'ELASTICSEARCH8',
   ES8: 'ELASTICSEARCH8',
+  MONGO: 'MONGODB',
+  MONGO_DB: 'MONGODB',
 };
 
 const normalizeDbType = (value?: string): string => {

--- a/yak-ops-ui/src/pages/integration/batch-link-up/detail/components/SingleTableConfigSection.tsx
+++ b/yak-ops-ui/src/pages/integration/batch-link-up/detail/components/SingleTableConfigSection.tsx
@@ -37,6 +37,7 @@ interface SingleTableConfigSectionProps {
   primaryKeyLoading: boolean;
   sourceReady: boolean;
   targetReady: boolean;
+  allowCustomTargetName?: boolean;
   sourceExtraParameters: ReactNode;
   sinkExtraParameters: ReactNode;
   onSourceTableSearch: (keyword: string) => void;
@@ -94,6 +95,7 @@ export default function SingleTableConfigSection({
   primaryKeyLoading,
   sourceReady,
   targetReady,
+  allowCustomTargetName = false,
   sourceExtraParameters,
   sinkExtraParameters,
   onSourceTableSearch,
@@ -200,7 +202,7 @@ export default function SingleTableConfigSection({
                 onDropdownVisibleChange={(open) => {
                   if (open) onSourceTableSearch('');
                 }}
-                onChange={(table: string) => onSourceChange({ table })}
+                onChange={(table: string) => onSourceChange({ table, fields: [] })}
               />
             </div>
           )}
@@ -252,6 +254,22 @@ export default function SingleTableConfigSection({
                 placeholder={targetReady ? '请输入需要创建的目标表名' : '请先选择目标数据源'}
                 onChange={(event: ChangeEvent<HTMLInputElement>) => onSinkChange({ targetTableName: event.target.value })}
               />
+            </div>
+          ) : allowCustomTargetName ? (
+            <div>
+              <FieldLabel required>目标 Collection</FieldLabel>
+              <Input
+                variant="filled"
+                disabled={!targetReady}
+                value={sinkConfig.table || ''}
+                placeholder={targetReady ? '输入已有或新的 Collection 名称' : '请先选择目标数据源'}
+                onChange={(event: ChangeEvent<HTMLInputElement>) =>
+                  onSinkChange({ table: event.target.value, primaryKey: '' })
+                }
+              />
+              <div className="mt-1.5 text-[11px] leading-5 text-[#98a2b3]">
+                MongoDB 会在首次成功 INSERT 时自然创建不存在的 Collection；这里不启用 Link-Up AUTO_CREATE_TABLE 语义。
+              </div>
             </div>
           ) : (
             <div>

--- a/yak-ops-ui/src/pages/integration/batch-link-up/detail/components/SingleTableConfigSection.tsx
+++ b/yak-ops-ui/src/pages/integration/batch-link-up/detail/components/SingleTableConfigSection.tsx
@@ -29,6 +29,7 @@ interface SingleTableConfigSectionProps {
   sinkConfig: Record<string, any>;
   sourceCapability: EndpointCapabilityState;
   sinkCapability: EndpointCapabilityState;
+  autoCreateTableEnabled: boolean;
   sourceTables: string[];
   targetTables: string[];
   sourceLoading: boolean;
@@ -87,6 +88,7 @@ export default function SingleTableConfigSection({
   sinkConfig,
   sourceCapability,
   sinkCapability,
+  autoCreateTableEnabled,
   sourceTables,
   targetTables,
   sourceLoading,
@@ -109,10 +111,14 @@ export default function SingleTableConfigSection({
     sourceCapability,
     CONNECTOR_CAPABILITY.CUSTOM_SQL,
   );
-  const supportsAutoCreate = allowsCapability(
-    sinkCapability,
-    CONNECTOR_CAPABILITY.AUTO_CREATE_TABLE,
-  );
+  const supportsAutoCreate =
+    autoCreateTableEnabled &&
+    allowsCapability(
+      sinkCapability,
+      CONNECTOR_CAPABILITY.AUTO_CREATE_TABLE,
+    );
+  const effectiveAutoCreateTable =
+    supportsAutoCreate && Boolean(sinkConfig.autoCreateTable);
   const supportsUpsert = allowsCapability(
     sinkCapability,
     CONNECTOR_CAPABILITY.UPSERT,
@@ -238,13 +244,15 @@ export default function SingleTableConfigSection({
               </div>
               {!supportsAutoCreate && sinkConfig.autoCreateTable ? (
                 <div className="mt-2 text-[11px] leading-5 text-[#b54708]">
-                  当前 Sink Connector 未声明 AUTO_CREATE_TABLE，请关闭后选择已有目标表。
+                  {autoCreateTableEnabled
+                    ? '当前 Sink Connector 未声明 AUTO_CREATE_TABLE，请关闭后选择已有目标表。'
+                    : '当前目标数据源 Stage 1 仅支持写入已有表，请关闭自动建表后选择目标表。'}
                 </div>
               ) : null}
             </div>
           ) : null}
 
-          {sinkConfig.autoCreateTable ? (
+          {effectiveAutoCreateTable ? (
             <div>
               <FieldLabel required>目标表名</FieldLabel>
               <Input

--- a/yak-ops-ui/src/pages/integration/batch-link-up/detail/components/SingleTableConfigSection.tsx
+++ b/yak-ops-ui/src/pages/integration/batch-link-up/detail/components/SingleTableConfigSection.tsx
@@ -202,7 +202,7 @@ export default function SingleTableConfigSection({
                 onDropdownVisibleChange={(open) => {
                   if (open) onSourceTableSearch('');
                 }}
-                onChange={(table: string) => onSourceChange({ table, fields: [] })}
+                onChange={(table: string) => onSourceChange({ table })}
               />
             </div>
           )}

--- a/yak-ops-ui/src/pages/integration/batch-link-up/detail/components/SyncTaskEditor.tsx
+++ b/yak-ops-ui/src/pages/integration/batch-link-up/detail/components/SyncTaskEditor.tsx
@@ -1,6 +1,7 @@
 import { Alert, Select } from 'antd';
 import type { DataSourceRecord } from '@/services/data-source';
 
+import { isAutoCreateTableEnabledForDataSourceType } from '../../connectorProfiles';
 import {
   resolveEndpointCapability,
   validateEditorCapabilities,
@@ -47,6 +48,10 @@ export default function SyncTaskEditor({
   const sourceId = editor.source.dataSourceId;
   const targetId = editor.sink.dataSourceId;
   const mappingColumns = normalizeMappings(editor.mapping?.columns);
+  const sinkAutoCreateTableEnabled =
+    isAutoCreateTableEnabledForDataSourceType(editor.sink.dbType);
+  const sinkAutoCreateTable =
+    sinkAutoCreateTableEnabled && Boolean(sinkConfig.autoCreateTable);
 
   const connectorRuntime = useOfflineConnectorRuntime();
   const sourceCapability = resolveEndpointCapability(
@@ -88,12 +93,12 @@ export default function SyncTaskEditor({
   const sourceColumnRequest = sourceConfig.readMode === 'sql'
     ? sourceConfig.sql?.trim() ? { query: sourceConfig.sql } : undefined
     : sourceConfig.table ? { table_path: sourceConfig.table } : undefined;
-  const targetColumnRequest = !sinkConfig.autoCreateTable && !isMongoSink && sinkConfig.table
+  const targetColumnRequest = !sinkAutoCreateTable && !isMongoSink && sinkConfig.table
     ? { table_path: sinkConfig.table }
     : undefined;
   const sourceColumnCatalog = useDataSourceColumns(sourceId, sourceColumnRequest);
   const targetColumnCatalog = useDataSourceColumns(targetId, targetColumnRequest);
-  const targetSchemaDerived = Boolean(sinkConfig.autoCreateTable || isMongoSink);
+  const targetSchemaDerived = Boolean(sinkAutoCreateTable || isMongoSink);
   const primaryKeyCatalog = targetSchemaDerived
     ? sourceColumnCatalog
     : targetColumnCatalog;
@@ -239,6 +244,7 @@ export default function SyncTaskEditor({
             sourceConfig={sourceConfig}
             sinkConfig={sinkConfig}
             sinkCapability={sinkCapability}
+            autoCreateTableEnabled={sinkAutoCreateTableEnabled}
             sourceTables={sourceCatalog.tables}
             sourceLoading={sourceCatalog.loading}
             sourceReady={Boolean(sourceId)}
@@ -256,6 +262,7 @@ export default function SyncTaskEditor({
             sinkConfig={sinkConfig}
             sourceCapability={sourceCapability}
             sinkCapability={sinkCapability}
+            autoCreateTableEnabled={sinkAutoCreateTableEnabled}
             sourceTables={sourceCatalog.tables}
             targetTables={targetCatalog.tables}
             sourceLoading={sourceCatalog.loading}

--- a/yak-ops-ui/src/pages/integration/batch-link-up/detail/components/SyncTaskEditor.tsx
+++ b/yak-ops-ui/src/pages/integration/batch-link-up/detail/components/SyncTaskEditor.tsx
@@ -1,4 +1,4 @@
-import { Alert } from 'antd';
+import { Alert, Select } from 'antd';
 import type { DataSourceRecord } from '@/services/data-source';
 
 import {
@@ -75,23 +75,32 @@ export default function SyncTaskEditor({
     sinkCapability.available,
   );
 
-  const sourceCatalog = useDataSourceTables(sourceId);
-  const targetCatalog = useDataSourceTables(targetId);
+  const isMongoSource =
+    editor.mode === 'GUIDE_SINGLE' &&
+    String(editor.source.connectorId || '').toLowerCase() === 'mongodb' &&
+    sourceConfig.readMode !== 'sql';
+  const isMongoSink =
+    editor.mode === 'GUIDE_SINGLE' &&
+    String(editor.sink.connectorId || '').toLowerCase() === 'mongodb';
+
+  const sourceCatalog = useDataSourceTables(sourceId, sourceConfig.database);
+  const targetCatalog = useDataSourceTables(targetId, sinkConfig.database);
   const sourceColumnRequest = sourceConfig.readMode === 'sql'
     ? sourceConfig.sql?.trim() ? { query: sourceConfig.sql } : undefined
     : sourceConfig.table ? { table_path: sourceConfig.table } : undefined;
-  const targetColumnRequest = !sinkConfig.autoCreateTable && sinkConfig.table
+  const targetColumnRequest = !sinkConfig.autoCreateTable && !isMongoSink && sinkConfig.table
     ? { table_path: sinkConfig.table }
     : undefined;
   const sourceColumnCatalog = useDataSourceColumns(sourceId, sourceColumnRequest);
   const targetColumnCatalog = useDataSourceColumns(targetId, targetColumnRequest);
-  const primaryKeyCatalog = sinkConfig.autoCreateTable
+  const targetSchemaDerived = Boolean(sinkConfig.autoCreateTable || isMongoSink);
+  const primaryKeyCatalog = targetSchemaDerived
     ? sourceColumnCatalog
     : targetColumnCatalog;
-  const mappingTargetColumns = sinkConfig.autoCreateTable
+  const mappingTargetColumns = targetSchemaDerived
     ? sourceColumnCatalog.columns
     : targetColumnCatalog.columns;
-  const mappingTargetLoading = sinkConfig.autoCreateTable
+  const mappingTargetLoading = targetSchemaDerived
     ? sourceColumnCatalog.loading
     : targetColumnCatalog.loading;
 
@@ -101,6 +110,10 @@ export default function SyncTaskEditor({
     onChange(updateEndpointConfig(editor, 'sink', patch));
   const updateMapping = (columns: FieldMappingValue[]) =>
     onChange({ ...editor, mapping: { columns } });
+
+  const selectedMongoFields = Array.isArray(sourceConfig.fields)
+    ? sourceConfig.fields.filter(Boolean).map(String)
+    : [];
 
   const runtimeNotice = (() => {
     if (connectorRuntime.loading && !connectorRuntime.snapshot) {
@@ -153,15 +166,48 @@ export default function SyncTaskEditor({
     return null;
   })();
 
+  const mongoFieldSelector = isMongoSource && sourceConfig.table ? (
+    <div className="rounded-lg border border-[#eaecf0] bg-white p-3.5">
+      <div className="mb-2 text-[12px] font-semibold text-[#344054]">
+        来源字段
+      </div>
+      <Select
+        mode="multiple"
+        allowClear
+        showSearch
+        variant="filled"
+        className="w-full"
+        loading={sourceColumnCatalog.loading}
+        disabled={!sourceId || !sourceConfig.table}
+        value={selectedMongoFields}
+        placeholder="不选择则同步全部自动发现字段"
+        options={sourceColumnCatalog.columns.map((column) => ({
+          label: column.description
+            ? `${column.label} · ${column.description}`
+            : column.label,
+          value: column.value,
+        }))}
+        optionFilterProp="label"
+        onChange={(fields) => updateSource({ fields })}
+      />
+      <div className="mt-1.5 text-[11px] leading-5 text-[#98a2b3]">
+        MongoDB 字段类型由 Catalog 自动采样推断，只选择字段名即可；嵌套字段可直接选择 address.city 这类路径。
+      </div>
+    </div>
+  ) : null;
+
   const sourceExtraParameters = (
-    <ConnectorExtraParameters
-      role="SOURCE"
-      schema={sourceSchema.schema}
-      loading={sourceSchema.loading}
-      error={sourceSchema.error}
-      config={sourceConfig}
-      onChange={updateSource}
-    />
+    <div className="space-y-3.5">
+      {mongoFieldSelector}
+      <ConnectorExtraParameters
+        role="SOURCE"
+        schema={sourceSchema.schema}
+        loading={sourceSchema.loading}
+        error={sourceSchema.error}
+        config={sourceConfig}
+        onChange={updateSource}
+      />
+    </div>
   );
   const sinkExtraParameters = (
     <ConnectorExtraParameters
@@ -218,11 +264,18 @@ export default function SyncTaskEditor({
             primaryKeyLoading={primaryKeyCatalog.loading}
             sourceReady={Boolean(sourceId)}
             targetReady={Boolean(targetId)}
+            allowCustomTargetName={isMongoSink}
             sourceExtraParameters={sourceExtraParameters}
             sinkExtraParameters={sinkExtraParameters}
             onSourceTableSearch={sourceCatalog.search}
             onTargetTableSearch={targetCatalog.search}
-            onSourceChange={updateSource}
+            onSourceChange={(patch) =>
+              updateSource(
+                isMongoSource && Object.prototype.hasOwnProperty.call(patch, 'table')
+                  ? { ...patch, fields: [] }
+                  : patch,
+              )
+            }
             onSinkChange={updateSink}
           />
         )}
@@ -256,8 +309,8 @@ export default function SyncTaskEditor({
             sourceLoading={sourceColumnCatalog.loading}
             targetLoading={mappingTargetLoading}
             sourceReady={Boolean(sourceId && sourceColumnRequest)}
-            targetReady={Boolean(targetId && (sinkConfig.autoCreateTable || targetColumnRequest))}
-            targetDerived={Boolean(sinkConfig.autoCreateTable)}
+            targetReady={Boolean(targetId && (targetSchemaDerived || targetColumnRequest))}
+            targetDerived={targetSchemaDerived}
           />
         </div>
       ) : null}

--- a/yak-ops-ui/src/pages/integration/batch-link-up/detail/form-schema/connectorTaskOptions.ts
+++ b/yak-ops-ui/src/pages/integration/batch-link-up/detail/form-schema/connectorTaskOptions.ts
@@ -57,6 +57,7 @@ const SOURCE_MANAGED_KEYS = new Set(
     'fetch_size',
     // Native product controls mapped by connector adapters.
     'table',
+    'fields',
     'doris.filter.query',
     'doris.batch.size',
     'scan_filter',

--- a/yak-ops-ui/src/pages/integration/batch-link-up/detail/hooks/useDataSourceTables.ts
+++ b/yak-ops-ui/src/pages/integration/batch-link-up/detail/hooks/useDataSourceTables.ts
@@ -20,9 +20,7 @@ const normalizeTableNames = (data: any): string[] => {
         .map((item: any) =>
           typeof item === 'string'
             ? item
-            : item?.name ||
-              item?.value ||
-              item?.label,
+            : item?.name || item?.value || item?.label,
         )
         .filter(Boolean)
         .map(String),
@@ -30,14 +28,11 @@ const normalizeTableNames = (data: any): string[] => {
   );
 };
 
-/**
- * Loads only a bounded table window and delegates filtering to the backend.
- *
- * Large hospital / warehouse catalogs can contain thousands of tables. Keeping the search term in
- * this hook avoids materializing the complete catalog in the browser while preserving the selected
- * value in the editor state.
- */
-export default function useDataSourceTables(dataSourceId: string) {
+/** Loads a bounded table/collection window and delegates filtering to the backend. */
+export default function useDataSourceTables(
+  dataSourceId: string,
+  database?: string,
+) {
   const [tables, setTables] = useState<string[]>([]);
   const [loading, setLoading] = useState(false);
   const [keyword, setKeyword] = useState('');
@@ -45,7 +40,7 @@ export default function useDataSourceTables(dataSourceId: string) {
   useEffect(() => {
     setKeyword('');
     setTables([]);
-  }, [dataSourceId]);
+  }, [dataSourceId, database]);
 
   useEffect(() => {
     if (!dataSourceId) {
@@ -63,20 +58,17 @@ export default function useDataSourceTables(dataSourceId: string) {
           dataSourceId,
           keyword.trim() || undefined,
           TABLE_SEARCH_LIMIT,
+          database?.trim() || undefined,
         )
         .then((response) => {
           if (!active) return;
           setTables(normalizeTableNames(response?.data));
         })
         .catch(() => {
-          if (active) {
-            setTables([]);
-          }
+          if (active) setTables([]);
         })
         .finally(() => {
-          if (active) {
-            setLoading(false);
-          }
+          if (active) setLoading(false);
         });
     }, TABLE_SEARCH_DEBOUNCE_MS);
 
@@ -84,15 +76,11 @@ export default function useDataSourceTables(dataSourceId: string) {
       active = false;
       window.clearTimeout(timer);
     };
-  }, [dataSourceId, keyword]);
+  }, [dataSourceId, database, keyword]);
 
   const search = useCallback((value: string) => {
     setKeyword(value);
   }, []);
 
-  return {
-    tables,
-    loading,
-    search,
-  };
+  return { tables, loading, search };
 }


### PR DESCRIPTION
## Summary

Adapt Yak Ops to the bounded/offline MongoDB connector now available in yak-link-up (#117–#119).

The product boundary stays usability-first: datasource users configure a MongoDB connection, choose Database / Collection / fields, and run offline synchronization without authoring BSON or Link-Up field types.

## Datasource management

- add first-class `MONGODB` datasource type and aliases `MONGO` / `MONGO_DB`
- add independent `yak-ops-plugin-datasource-mongodb` module rather than routing MongoDB through JDBC
- register the plugin through the existing datasource ServiceLoader aggregation
- expose a structured connection form:
  - Host / Port
  - Database
  - optional Username / Password
  - advanced Seed Hosts
  - optional Auth Source
- keep the displayed connection URL credential-free
- keep credentials in structured datasource connection parameters; do not duplicate them inside a persisted Mongo URI
- build the real Mongo URI only inside connection/Catalog/runtime boundaries
- support connection ping
- map Mongo metadata into the existing Catalog API:
  - Mongo database -> database
  - collection -> table
  - sampled BSON field -> column
- sample up to 1000 documents and discover dotted nested paths such as `address.city`
- align BSON type inference with yak-link-up's conservative schema policy
- support table/collection preview and count without exposing SQL semantics

## Offline sync control plane

- register `mongodb-native` as the default MongoDB Source/Sink profile
- add `MongoOfflineSyncConnectorAdapter`
- keep datasource-owned URI/host/credential fields out of persisted task definitions
- inject a temporary execution URI from the selected datasource immediately before Link-Up execution
- inherit the datasource default Database for ordinary single-Collection jobs
- translate Source tasks to Link-Up `database / collection / fields / filter / fetch_size`
- translate Sink tasks to `database / collection / document_id_field / batch_size`
- keep Sink semantics INSERT/Append only; no UPSERT or overwrite claims
- reject SQL Source mode and Link-Up AUTO_CREATE_TABLE semantics
- keep MongoDB multi-table execution on Yak Ops' existing FAN_OUT path so every child JobSpec remains one bounded Collection job; Link-Up `MULTI_TABLE` is not required

## UI

- expose MongoDB in datasource creation/filter/select controls
- register the `mongodb-native` offline connector profile
- when a Mongo Source Collection is selected, load fields from the datasource Catalog and show a multi-select field picker
- field types remain read-only descriptions; users only select field names
- dotted fields such as `address.city` are directly selectable
- hide Link-Up's raw `fields` option from the generic advanced-parameter editor to avoid duplicate inputs
- let Mongo Sink users type an existing or new target Collection name
- for a new Mongo target Collection, derive mapping targets from the Source schema rather than requiring target metadata to exist first
- allow table/Collection searches to be scoped by Database

## Security boundary

Mongo connection secrets remain owned by the datasource record. Persisted offline definitions strip Mongo URI / host / username / password / auth-source fields. Runtime execution reconstructs the Mongo URI from `connectionParams` and injects it into the in-memory Link-Up options only.

## Tests

Added focused coverage for:

- Mongo connection normalization and secret/display URL boundaries
- datasource descriptor/capability contract
- sampled BSON type merging and nested field discovery
- `mongodb-native` profile selection
- offline Source field translation
- runtime URI/database injection
- INSERT-only Sink translation and advanced `document_id_field`
- GUIDE_MULTI adapter boundary (FAN_OUT children remain GUIDE_SINGLE)

## Deliberate non-goals

- CDC / Change Streams / oplog
- realtime synchronization semantics
- Mongo SQL emulation
- Link-Up native `MULTI_TABLE`
- generic Source `PARTITION_SPLIT`
- exposed UPSERT/update/delete semantics
- Mongo collection validators / explicit DDL contract
- user-authored field types

## Verification

This PR includes unit tests, but the current ChatGPT execution environment cannot perform a reliable repository Maven/npm dependency run, so a passing full build is not claimed.

Suggested merge gate:

```bash
mvn --batch-mode clean verify
cd yak-ops-ui && npm run build
```

Then smoke test against the yak-link-up Worker containing MongoDB Source/Sink support:

- create/test a MongoDB datasource
- browse Database -> Collection -> fields
- preview a Collection with nested fields
- single-table Mongo -> JDBC with selected fields
- single-table JDBC -> Mongo into a new Collection
- Mongo multi-Collection FAN_OUT job
- verify persisted definition JSON contains no Mongo URI/password
