### PR TITLE
feat(goldendb): add datasource and offline sync control-plane support

### DIFF
--- a/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-offline/src/main/java/io/yak/ops/business/sync/offline/engine/connector/OfflineSyncConnectorRegistry.java
+++ b/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-offline/src/main/java/io/yak/ops/business/sync/offline/engine/connector/OfflineSyncConnectorRegistry.java
@@ -23,6 +23,7 @@ public final class OfflineSyncConnectorRegistry {
   private static final List<OfflineSyncConnectorProfile> PROFILES = List.of(
       jdbcProfile("mysql-jdbc", DataSourceDbType.MYSQL, "JDBC-MYSQL"),
       jdbcProfile("tidb-jdbc", DataSourceDbType.TIDB, "JDBC-TIDB"),
+      jdbcProfile("goldendb-jdbc", DataSourceDbType.GOLDENDB, "JDBC-GOLDENDB"),
       jdbcProfile("hana-jdbc", DataSourceDbType.HANA, "JDBC-HANA"),
       jdbcProfile("oracle-jdbc", DataSourceDbType.ORACLE, "JDBC-ORACLE"),
       jdbcProfile("postgresql-jdbc", DataSourceDbType.POSTGRE_SQL, "JDBC-POSTGRESQL"),
@@ -68,6 +69,8 @@ public final class OfflineSyncConnectorRegistry {
       Map.entry("POSTGRESQL", DataSourceDbType.POSTGRE_SQL),
       Map.entry("POSTGRES", DataSourceDbType.POSTGRE_SQL),
       Map.entry("TI_DB", DataSourceDbType.TIDB),
+      Map.entry("GOLDEN_DB", DataSourceDbType.GOLDENDB),
+      Map.entry("ZTE_GOLDENDB", DataSourceDbType.GOLDENDB),
       Map.entry("SAP_HANA", DataSourceDbType.HANA),
       Map.entry("SAPHANA", DataSourceDbType.HANA),
       Map.entry("OPENGAUSS", DataSourceDbType.OPEN_GAUSS),

--- a/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-offline/src/main/java/io/yak/ops/business/sync/offline/engine/connector/adapter/JdbcOfflineSyncConnectorAdapter.java
+++ b/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-offline/src/main/java/io/yak/ops/business/sync/offline/engine/connector/adapter/JdbcOfflineSyncConnectorAdapter.java
@@ -11,6 +11,7 @@ import io.yak.ops.business.sync.offline.engine.connector.adapter.OfflineSyncConn
 import io.yak.ops.business.sync.offline.engine.connector.adapter.OfflineSyncConnectorAdapter.ExecutionContext;
 import io.yak.ops.business.sync.offline.engine.connector.adapter.OfflineSyncConnectorAdapter.Role;
 import io.yak.ops.common.bean.po.datasource.DataSourcePO;
+import io.yak.ops.common.enums.datasource.DataSourceDbType;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Iterator;
@@ -76,6 +77,13 @@ public class JdbcOfflineSyncConnectorAdapter implements OfflineSyncConnectorAdap
     }
     removeDatasourceOwnedOptions(context.options());
     appendConnection(context.options(), connection(context.dataSource()));
+
+    if (context.role() == Role.SINK
+        && context.dataSource().getDbType() == DataSourceDbType.GOLDENDB) {
+      // GoldenDB Stage 1 in Link-Up intentionally supports existing target tables only. Keep this
+      // execution-time guard even for old/stale definitions that still contain auto-create intent.
+      context.options().put("schema_save_mode", "ERROR_WHEN_SCHEMA_NOT_EXIST");
+    }
   }
 
   private BuildResult buildSource(BuildContext context) {
@@ -234,10 +242,12 @@ public class JdbcOfflineSyncConnectorAdapter implements OfflineSyncConnectorAdap
     }
 
     String dialect = firstText(parameters, "dialect");
-    if (!StringUtils.hasText(dialect)
-        && dataSource.getDbType() != null
-        && "TIDB".equals(dataSource.getDbType().name())) {
-      dialect = "tidb";
+    if (!StringUtils.hasText(dialect) && dataSource.getDbType() != null) {
+      if (dataSource.getDbType() == DataSourceDbType.TIDB) {
+        dialect = "tidb";
+      } else if (dataSource.getDbType() == DataSourceDbType.GOLDENDB) {
+        dialect = "goldendb";
+      }
     }
 
     JsonNode properties = parameters.get("properties");
@@ -460,7 +470,8 @@ public class JdbcOfflineSyncConnectorAdapter implements OfflineSyncConnectorAdap
     if (normalized.contains("db2")) {
       return "com.ibm.db2.jcc.DB2Driver";
     }
-    if (normalized.contains("tidb")
+    if (normalized.contains("goldendb")
+        || normalized.contains("tidb")
         || normalized.contains("mysql")
         || normalized.contains("doris")) {
       return "com.mysql.cj.jdbc.Driver";

--- a/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-offline/src/test/java/io/yak/ops/business/sync/offline/engine/connector/OfflineSyncConnectorRegistryTest.java
+++ b/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-offline/src/test/java/io/yak/ops/business/sync/offline/engine/connector/OfflineSyncConnectorRegistryTest.java
@@ -31,6 +31,7 @@ class OfflineSyncConnectorRegistryTest {
 
     for (DataSourceDbType dbType : new DataSourceDbType[] {
       DataSourceDbType.TIDB,
+      DataSourceDbType.GOLDENDB,
       DataSourceDbType.HANA,
       DataSourceDbType.DB2,
       DataSourceDbType.OPEN_GAUSS,
@@ -55,6 +56,9 @@ class OfflineSyncConnectorRegistryTest {
     assertThat(OfflineSyncConnectorRegistry.defaultConnectorId("POSTGRESQL")).contains("jdbc");
     assertThat(OfflineSyncConnectorRegistry.defaultConnectorId("TIDB")).contains("jdbc");
     assertThat(OfflineSyncConnectorRegistry.defaultConnectorId("TI-DB")).contains("jdbc");
+    assertThat(OfflineSyncConnectorRegistry.defaultConnectorId("GOLDENDB")).contains("jdbc");
+    assertThat(OfflineSyncConnectorRegistry.defaultConnectorId("GOLDEN-DB")).contains("jdbc");
+    assertThat(OfflineSyncConnectorRegistry.defaultConnectorId("ZTE-GOLDENDB")).contains("jdbc");
     assertThat(OfflineSyncConnectorRegistry.defaultConnectorId("HANA")).contains("jdbc");
     assertThat(OfflineSyncConnectorRegistry.defaultConnectorId("SAP-HANA")).contains("jdbc");
     assertThat(OfflineSyncConnectorRegistry.defaultConnectorId("SAPHANA")).contains("jdbc");

--- a/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-offline/src/test/java/io/yak/ops/business/sync/offline/engine/connector/adapter/JdbcOfflineSyncConnectorAdapterExecutionTest.java
+++ b/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-offline/src/test/java/io/yak/ops/business/sync/offline/engine/connector/adapter/JdbcOfflineSyncConnectorAdapterExecutionTest.java
@@ -67,6 +67,35 @@ class JdbcOfflineSyncConnectorAdapterExecutionTest {
   }
 
   @Test
+  void injectsGoldenDbDialectAndForcesExistingTableSink() {
+    ObjectMapper mapper = new ObjectMapper();
+    JdbcOfflineSyncConnectorAdapter adapter = new JdbcOfflineSyncConnectorAdapter(mapper);
+    DataSourcePO dataSource = new DataSourcePO();
+    dataSource.setId(13L);
+    dataSource.setName("goldendb");
+    dataSource.setDbType(DataSourceDbType.GOLDENDB);
+    dataSource.setConnectionParams(
+        "{\"jdbcUrl\":\"jdbc:mysql://127.0.0.1:1111/archive\","
+            + "\"driverClassName\":\"com.mysql.cj.jdbc.Driver\","
+            + "\"username\":\"root\",\"password\":\"secret\"}");
+
+    ObjectNode options = mapper.createObjectNode();
+    options.put("dialect", "mysql");
+    options.put("schema_save_mode", "CREATE_SCHEMA_WHEN_NOT_EXIST");
+    options.put("table_path", "archive.orders");
+    adapter.resolveForExecution(
+        new ExecutionContext("jdbc", Role.SINK, "目标端", dataSource, options));
+
+    assertThat(options.path("url").asText())
+        .isEqualTo("jdbc:mysql://127.0.0.1:1111/archive");
+    assertThat(options.path("driver").asText()).isEqualTo("com.mysql.cj.jdbc.Driver");
+    assertThat(options.path("dialect").asText()).isEqualTo("goldendb");
+    assertThat(options.path("schema_save_mode").asText())
+        .isEqualTo("ERROR_WHEN_SCHEMA_NOT_EXIST");
+    assertThat(options.path("password").asText()).isEqualTo("secret");
+  }
+
+  @Test
   void injectsHanaDialectAndSchemaFromDatasourceOwnedConnection() {
     ObjectMapper mapper = new ObjectMapper();
     JdbcOfflineSyncConnectorAdapter adapter = new JdbcOfflineSyncConnectorAdapter(mapper);

--- a/yak-ops-common/src/main/java/io/yak/ops/common/enums/datasource/DataSourceDbType.java
+++ b/yak-ops-common/src/main/java/io/yak/ops/common/enums/datasource/DataSourceDbType.java
@@ -11,6 +11,7 @@ public enum DataSourceDbType {
 
   MYSQL("MySQL"),
   TIDB("TiDB"),
+  GOLDENDB("GoldenDB"),
   HANA("SAP HANA"),
   ORACLE("Oracle"),
   POSTGRE_SQL("PostgreSQL"),
@@ -43,6 +44,8 @@ public enum DataSourceDbType {
       normalized = "POSTGRE_SQL";
     } else if ("TI_DB".equals(normalized)) {
       normalized = "TIDB";
+    } else if ("GOLDEN_DB".equals(normalized) || "ZTE_GOLDENDB".equals(normalized)) {
+      normalized = "GOLDENDB";
     } else if ("SAP_HANA".equals(normalized) || "SAPHANA".equals(normalized)) {
       normalized = "HANA";
     } else if ("OPENGAUSS".equals(normalized)) {

--- a/yak-ops-common/src/test/java/io/yak/ops/common/enums/datasource/DataSourceDbTypeTest.java
+++ b/yak-ops-common/src/test/java/io/yak/ops/common/enums/datasource/DataSourceDbTypeTest.java
@@ -17,6 +17,12 @@ class DataSourceDbTypeTest {
         .isEqualTo(DataSourceDbType.TIDB);
     assertThat(DataSourceDbType.parse("ti-db"))
         .isEqualTo(DataSourceDbType.TIDB);
+    assertThat(DataSourceDbType.parse("goldendb"))
+        .isEqualTo(DataSourceDbType.GOLDENDB);
+    assertThat(DataSourceDbType.parse("golden-db"))
+        .isEqualTo(DataSourceDbType.GOLDENDB);
+    assertThat(DataSourceDbType.parse("zte-goldendb"))
+        .isEqualTo(DataSourceDbType.GOLDENDB);
     assertThat(DataSourceDbType.parse("hana"))
         .isEqualTo(DataSourceDbType.HANA);
     assertThat(DataSourceDbType.parse("sap-hana"))
@@ -54,6 +60,7 @@ class DataSourceDbTypeTest {
     assertThat(DataSourceDbType.values())
         .contains(
             DataSourceDbType.TIDB,
+            DataSourceDbType.GOLDENDB,
             DataSourceDbType.HANA,
             DataSourceDbType.DB2,
             DataSourceDbType.OPEN_GAUSS,
@@ -70,6 +77,7 @@ class DataSourceDbTypeTest {
             DataSourceDbType.ELASTICSEARCH7,
             DataSourceDbType.ELASTICSEARCH8);
     assertThat(DataSourceDbType.TIDB.getDisplayName()).isEqualTo("TiDB");
+    assertThat(DataSourceDbType.GOLDENDB.getDisplayName()).isEqualTo("GoldenDB");
     assertThat(DataSourceDbType.HANA.getDisplayName()).isEqualTo("SAP HANA");
     assertThat(DataSourceDbType.YASHAN_DB.getDisplayName()).isEqualTo("YashanDB");
     assertThat(DataSourceDbType.HIGHGO.getDisplayName()).isEqualTo("HighGo");

--- a/yak-ops-plugins/yak-ops-plugin-datasource/yak-ops-plugin-datasource-all/src/test/java/io/yak/ops/plugin/datasource/AllDataSourcePluginsTest.java
+++ b/yak-ops-plugins/yak-ops-plugin-datasource/yak-ops-plugin-datasource-all/src/test/java/io/yak/ops/plugin/datasource/AllDataSourcePluginsTest.java
@@ -22,6 +22,7 @@ class AllDataSourcePluginsTest {
         .containsExactlyInAnyOrder(
             DataSourceDbType.MYSQL,
             DataSourceDbType.TIDB,
+            DataSourceDbType.GOLDENDB,
             DataSourceDbType.HANA,
             DataSourceDbType.POSTGRE_SQL,
             DataSourceDbType.ORACLE,

--- a/yak-ops-plugins/yak-ops-plugin-datasource/yak-ops-plugin-datasource-jdbc/src/main/java/io/yak/ops/plugin/database/jdbc/GenericJdbcCatalog.java
+++ b/yak-ops-plugins/yak-ops-plugin-datasource/yak-ops-plugin-datasource-jdbc/src/main/java/io/yak/ops/plugin/database/jdbc/GenericJdbcCatalog.java
@@ -341,7 +341,7 @@ public class GenericJdbcCatalog implements DataSourceCatalog {
             oceanBaseOracleMode()
                 ? query + " WHERE ROWNUM <= " + limit
                 : query + " LIMIT " + limit;
-        case MYSQL, TIDB, HANA, POSTGRE_SQL, DORIS, STARROCKS, CLICKHOUSE, KINGBASE, OPEN_GAUSS ->
+        case MYSQL, TIDB, GOLDENDB, HANA, POSTGRE_SQL, DORIS, STARROCKS, CLICKHOUSE, KINGBASE, OPEN_GAUSS ->
             query + " LIMIT " + limit;
         case YASHAN_DB, HIGHGO, IRIS, XUGU, DUCKDB -> query;
         case ELASTICSEARCH7, ELASTICSEARCH8 ->
@@ -360,7 +360,7 @@ public class GenericJdbcCatalog implements DataSourceCatalog {
           oceanBaseOracleMode()
               ? "SELECT * FROM (" + query + ") yak_ops_preview WHERE ROWNUM <= " + limit
               : "SELECT * FROM (" + query + ") yak_ops_preview LIMIT " + limit;
-      case MYSQL, TIDB, HANA, POSTGRE_SQL, DORIS, STARROCKS, CLICKHOUSE, KINGBASE, OPEN_GAUSS ->
+      case MYSQL, TIDB, GOLDENDB, HANA, POSTGRE_SQL, DORIS, STARROCKS, CLICKHOUSE, KINGBASE, OPEN_GAUSS ->
           "SELECT * FROM (" + query + ") yak_ops_preview LIMIT " + limit;
       case YASHAN_DB, HIGHGO, IRIS, XUGU, DUCKDB -> query;
       case ELASTICSEARCH7, ELASTICSEARCH8 ->
@@ -523,6 +523,7 @@ public class GenericJdbcCatalog implements DataSourceCatalog {
   private boolean usesCatalogAsNamespace() {
     return connection.dbType() == DataSourceDbType.MYSQL
         || connection.dbType() == DataSourceDbType.TIDB
+        || connection.dbType() == DataSourceDbType.GOLDENDB
         || connection.dbType() == DataSourceDbType.DORIS
         || connection.dbType() == DataSourceDbType.STARROCKS
         || connection.dbType() == DataSourceDbType.CLICKHOUSE

--- a/yak-ops-plugins/yak-ops-plugin-datasource/yak-ops-plugin-datasource-jdbc/src/main/java/io/yak/ops/plugin/database/jdbc/goldendb/GoldenDbDataSourcePlugin.java
+++ b/yak-ops-plugins/yak-ops-plugin-datasource/yak-ops-plugin-datasource-jdbc/src/main/java/io/yak/ops/plugin/database/jdbc/goldendb/GoldenDbDataSourcePlugin.java
@@ -1,0 +1,82 @@
+package io.yak.ops.plugin.database.jdbc.goldendb;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import io.yak.ops.common.enums.datasource.DataSourceDbType;
+import io.yak.ops.plugin.database.jdbc.AbstractJdbcDataSourcePlugin;
+import io.yak.ops.plugin.database.jdbc.JdbcConnectionProperties;
+import io.yak.ops.spi.datasource.DataSourceCatalog;
+import java.util.Locale;
+
+/** GoldenDB datasource plugin backed by the MySQL-compatible protocol and Connector/J. */
+public final class GoldenDbDataSourcePlugin extends AbstractJdbcDataSourcePlugin {
+
+  @Override
+  public DataSourceDbType dbType() {
+    return DataSourceDbType.GOLDENDB;
+  }
+
+  @Override
+  protected String jdbcUrlTemplate() {
+    return "jdbc:mysql://{host}:{port}/{database}";
+  }
+
+  @Override
+  protected int defaultPort() {
+    // GoldenDB deployment ports are configurable. Use the MySQL-compatible default as an editable
+    // form fallback; an explicit JDBC URL or port always takes precedence.
+    return 3306;
+  }
+
+  @Override
+  protected String defaultDriverClassName() {
+    return "com.mysql.cj.jdbc.Driver";
+  }
+
+  @Override
+  protected String buildJdbcUrl(String host, int port, String database, JsonNode connectionJson) {
+    return "jdbc:mysql://" + host + ":" + port + "/" + database;
+  }
+
+  @Override
+  public boolean acceptsUrl(String jdbcUrl) {
+    return jdbcUrl != null
+        && jdbcUrl.trim().toLowerCase(Locale.ROOT).startsWith("jdbc:mysql:");
+  }
+
+  @Override
+  protected void appendNormalizedFields(JsonNode source, ObjectNode normalized) {
+    // GoldenDB shares jdbc:mysql URLs with MySQL/TiDB, so the datasource identity must be restored
+    // explicitly immediately before Link-Up execution.
+    normalized.put("dialect", "goldendb");
+  }
+
+  /**
+   * GoldenDB Stage 1 uses MySQL-compatible catalog, identifier and preview behavior while retaining
+   * GOLDENDB as the user-facing datasource identity.
+   */
+  @Override
+  protected DataSourceCatalog createJdbcCatalog(
+      JdbcConnectionProperties connection,
+      int connectionTimeoutSeconds,
+      int queryTimeoutSeconds) {
+    JdbcConnectionProperties mysqlCompatible =
+        new JdbcConnectionProperties(
+            DataSourceDbType.MYSQL,
+            connection.host(),
+            connection.port(),
+            connection.jdbcUrl(),
+            connection.driverClassName(),
+            connection.username(),
+            connection.password(),
+            connection.database(),
+            connection.schema(),
+            connection.properties(),
+            connection.sshTunnel(),
+            connection.normalizedJson());
+    return super.createJdbcCatalog(
+        mysqlCompatible,
+        connectionTimeoutSeconds,
+        queryTimeoutSeconds);
+  }
+}

--- a/yak-ops-plugins/yak-ops-plugin-datasource/yak-ops-plugin-datasource-jdbc/src/main/resources/META-INF/services/io.yak.ops.spi.datasource.DataSourcePlugin
+++ b/yak-ops-plugins/yak-ops-plugin-datasource/yak-ops-plugin-datasource-jdbc/src/main/resources/META-INF/services/io.yak.ops.spi.datasource.DataSourcePlugin
@@ -1,5 +1,6 @@
 io.yak.ops.plugin.database.jdbc.mysql.MySqlDataSourcePlugin
 io.yak.ops.plugin.database.jdbc.tidb.TiDbDataSourcePlugin
+io.yak.ops.plugin.database.jdbc.goldendb.GoldenDbDataSourcePlugin
 io.yak.ops.plugin.database.jdbc.hana.HanaDataSourcePlugin
 io.yak.ops.plugin.database.jdbc.postgresql.PostgreSqlDataSourcePlugin
 io.yak.ops.plugin.database.jdbc.oracle.OracleDataSourcePlugin

--- a/yak-ops-plugins/yak-ops-plugin-datasource/yak-ops-plugin-datasource-jdbc/src/test/java/io/yak/ops/plugin/database/jdbc/goldendb/GoldenDbDataSourcePluginTest.java
+++ b/yak-ops-plugins/yak-ops-plugin-datasource/yak-ops-plugin-datasource-jdbc/src/test/java/io/yak/ops/plugin/database/jdbc/goldendb/GoldenDbDataSourcePluginTest.java
@@ -1,0 +1,65 @@
+package io.yak.ops.plugin.database.jdbc.goldendb;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.yak.ops.common.enums.datasource.DataSourceDbType;
+import io.yak.ops.spi.datasource.DataSourceCapability;
+import io.yak.ops.spi.datasource.DataSourceConnection;
+import org.junit.jupiter.api.Test;
+
+class GoldenDbDataSourcePluginTest {
+
+  private static final ObjectMapper MAPPER = new ObjectMapper();
+
+  @Test
+  void shouldUseMysqlConnectorJWithGoldenDbIdentity() throws Exception {
+    GoldenDbDataSourcePlugin plugin = new GoldenDbDataSourcePlugin();
+    DataSourceConnection connection =
+        plugin.parseConnection(
+            "{\"dbType\":\"GOLDENDB\",\"host\":\"127.0.0.1\","
+                + "\"port\":1111,\"database\":\"demo\",\"username\":\"root\"}");
+
+    assertThat(connection.dbType()).isEqualTo(DataSourceDbType.GOLDENDB);
+    assertThat(connection.jdbcUrl()).isEqualTo("jdbc:mysql://127.0.0.1:1111/demo");
+    assertThat(connection.driverClassName()).isEqualTo("com.mysql.cj.jdbc.Driver");
+    assertThat(plugin.acceptsUrl(connection.jdbcUrl())).isTrue();
+
+    JsonNode normalized = MAPPER.readTree(connection.normalizedJson());
+    assertThat(normalized.path("dialect").asText()).isEqualTo("goldendb");
+  }
+
+  @Test
+  void shouldKeepMysqlCompatibleDefaultPortEditable() {
+    GoldenDbDataSourcePlugin plugin = new GoldenDbDataSourcePlugin();
+    DataSourceConnection connection =
+        plugin.parseConnection(
+            "{\"dbType\":\"golden-db\",\"host\":\"goldendb\","
+                + "\"database\":\"app\",\"username\":\"root\"}");
+
+    assertThat(connection.jdbcUrl()).isEqualTo("jdbc:mysql://goldendb:3306/app");
+  }
+
+  @Test
+  void shouldExposeOfflineControlPlaneCapabilities() {
+    GoldenDbDataSourcePlugin plugin = new GoldenDbDataSourcePlugin();
+
+    assertThat(plugin.descriptor().displayName()).isEqualTo("GoldenDB");
+    assertThat(plugin.descriptor().capabilities())
+        .contains(
+            DataSourceCapability.CONNECTION_TEST,
+            DataSourceCapability.CATALOG_METADATA,
+            DataSourceCapability.CATALOG_READ,
+            DataSourceCapability.SQL_EXECUTION,
+            DataSourceCapability.TRANSACTIONS,
+            DataSourceCapability.SSH_TUNNEL);
+    assertThat(plugin.descriptor().connectionForm().sections().get(0).fields().stream()
+            .filter(field -> "jdbcUrl".equals(field.key()))
+            .findFirst()
+            .orElseThrow()
+            .jdbcUrlLinkage()
+            .template())
+        .isEqualTo("jdbc:mysql://{host}:{port}/{database}");
+  }
+}

--- a/yak-ops-ui/src/pages/data-source/components/DataSourceToolbar.tsx
+++ b/yak-ops-ui/src/pages/data-source/components/DataSourceToolbar.tsx
@@ -28,6 +28,7 @@ interface DataSourceToolbarProps {
 const DB_TYPE_LABELS: Record<string, string> = {
   MYSQL: 'MYSQL',
   TIDB: 'TiDB',
+  GOLDENDB: 'GoldenDB',
   HANA: 'SAP HANA',
   ORACLE: 'ORACLE',
   POSTGRE_SQL: 'PostgreSQL',

--- a/yak-ops-ui/src/pages/data-source/constants.tsx
+++ b/yak-ops-ui/src/pages/data-source/constants.tsx
@@ -31,6 +31,7 @@ export const EMPTY_DATA_SOURCE_SUMMARY: DataSourceSummary = {
 export const COMMON_DB_OPTIONS: DataSourceOptionItem[] = [
   { label: 'MYSQL', value: 'MYSQL' },
   { label: 'TIDB', value: 'TIDB' },
+  { label: 'GOLDENDB', value: 'GOLDENDB' },
   { label: 'HANA', value: 'HANA' },
   { label: 'ORACLE', value: 'ORACLE' },
   { label: 'POSTGRE_SQL', value: 'POSTGRE_SQL' },
@@ -79,6 +80,7 @@ export const getDataSourceGroupList = (intl: IntlFormatter): DataSourceGroup[] =
     datasourceList: [
       relationalDataSource('MYSQL'),
       relationalDataSource('TIDB'),
+      relationalDataSource('GOLDENDB'),
       relationalDataSource('HANA'),
       relationalDataSource('ORACLE'),
       relationalDataSource('POSTGRE_SQL'),

--- a/yak-ops-ui/src/pages/integration/batch-link-up/DataSourceSelect.tsx
+++ b/yak-ops-ui/src/pages/integration/batch-link-up/DataSourceSelect.tsx
@@ -24,6 +24,7 @@ const executionMetadata = (dbType: string) => {
 const DATA_SOURCE_TYPES = [
   { value: 'MYSQL', displayName: 'MYSQL' },
   { value: 'TIDB', displayName: 'TiDB' },
+  { value: 'GOLDENDB', displayName: 'GoldenDB' },
   { value: 'HANA', displayName: 'SAP HANA' },
   { value: 'ORACLE', displayName: 'ORACLE' },
   { value: 'POSTGRE_SQL', displayName: 'PostgreSQL' },

--- a/yak-ops-ui/src/pages/integration/batch-link-up/connectorProfiles.test.ts
+++ b/yak-ops-ui/src/pages/integration/batch-link-up/connectorProfiles.test.ts
@@ -2,6 +2,7 @@ import {
   connectorIdForDataSourceType,
   connectorIdForNewDataSourceType,
   defaultOfflineSyncConnectorProfile,
+  isAutoCreateTableEnabledForDataSourceType,
   isGuideMultiEnabledForDataSourceType,
   OFFLINE_SYNC_CONNECTOR_PROFILES,
 } from './connectorProfiles';
@@ -10,6 +11,7 @@ test('uses native profiles where needed while keeping JDBC datasource expansion 
   expect(OFFLINE_SYNC_CONNECTOR_PROFILES.map((profile) => profile.dbType)).toEqual([
     'MYSQL',
     'TIDB',
+    'GOLDENDB',
     'HANA',
     'ORACLE',
     'POSTGRE_SQL',
@@ -36,6 +38,17 @@ test('uses native profiles where needed while keeping JDBC datasource expansion 
     sinkConnectorId: 'jdbc',
     pluginName: 'JDBC-TIDB',
   });
+  expect(defaultOfflineSyncConnectorProfile('GOLDENDB')).toMatchObject({
+    profileId: 'goldendb-jdbc',
+    sourceConnectorId: 'jdbc',
+    sinkConnectorId: 'jdbc',
+    pluginName: 'JDBC-GOLDENDB',
+    autoCreateTableEnabled: false,
+  });
+  expect(defaultOfflineSyncConnectorProfile('GOLDEN-DB')).toMatchObject({
+    profileId: 'goldendb-jdbc',
+    dbType: 'GOLDENDB',
+  });
   expect(defaultOfflineSyncConnectorProfile('HANA')).toMatchObject({
     profileId: 'hana-jdbc',
     sourceConnectorId: 'jdbc',
@@ -59,7 +72,7 @@ test('uses native profiles where needed while keeping JDBC datasource expansion 
     profileId: 'clickhouse-native',
     sourceConnectorId: 'clickhouse',
   });
-  for (const dbType of ['HANA', 'YASHAN_DB', 'HIGHGO', 'IRIS', 'XUGU', 'DUCKDB']) {
+  for (const dbType of ['GOLDENDB', 'HANA', 'YASHAN_DB', 'HIGHGO', 'IRIS', 'XUGU', 'DUCKDB']) {
     expect(defaultOfflineSyncConnectorProfile(dbType)).toMatchObject({
       dbType,
       sourceConnectorId: 'jdbc',
@@ -89,6 +102,9 @@ test('separates legacy inference from new-task profile selection', () => {
   expect(connectorIdForNewDataSourceType('CLICKHOUSE')).toBe('clickhouse');
   expect(connectorIdForNewDataSourceType('TIDB')).toBe('jdbc');
   expect(connectorIdForNewDataSourceType('TI-DB')).toBe('jdbc');
+  expect(connectorIdForNewDataSourceType('GOLDENDB')).toBe('jdbc');
+  expect(connectorIdForNewDataSourceType('GOLDEN-DB')).toBe('jdbc');
+  expect(connectorIdForNewDataSourceType('ZTE-GOLDENDB')).toBe('jdbc');
   expect(connectorIdForNewDataSourceType('HANA')).toBe('jdbc');
   expect(connectorIdForNewDataSourceType('SAP-HANA')).toBe('jdbc');
   expect(connectorIdForNewDataSourceType('SAPHANA')).toBe('jdbc');
@@ -103,6 +119,9 @@ test('separates legacy inference from new-task profile selection', () => {
 test('resolves datasource aliases from one frontend registry', () => {
   expect(connectorIdForDataSourceType('POSTGRESQL')).toBe('jdbc');
   expect(connectorIdForDataSourceType('TIDB')).toBe('jdbc');
+  expect(connectorIdForDataSourceType('GOLDENDB')).toBe('jdbc');
+  expect(connectorIdForDataSourceType('GOLDEN-DB')).toBe('jdbc');
+  expect(connectorIdForDataSourceType('ZTE-GOLDENDB')).toBe('jdbc');
   expect(connectorIdForDataSourceType('HANA')).toBe('jdbc');
   expect(connectorIdForDataSourceType('SAP-HANA')).toBe('jdbc');
   expect(connectorIdForDataSourceType('SAPHANA')).toBe('jdbc');
@@ -122,6 +141,10 @@ test('resolves datasource aliases from one frontend registry', () => {
     profileId: 'postgresql-jdbc',
     dbType: 'POSTGRE_SQL',
   });
+  expect(defaultOfflineSyncConnectorProfile('ZTE-GOLDENDB')).toMatchObject({
+    profileId: 'goldendb-jdbc',
+    dbType: 'GOLDENDB',
+  });
   expect(defaultOfflineSyncConnectorProfile('SAPHANA')).toMatchObject({
     profileId: 'hana-jdbc',
     dbType: 'HANA',
@@ -132,9 +155,10 @@ test('resolves datasource aliases from one frontend registry', () => {
   });
 });
 
-test('keeps multi-table guide policy connector-profile driven', () => {
+test('keeps multi-table guide and target DDL policy profile driven', () => {
   expect(isGuideMultiEnabledForDataSourceType('MYSQL')).toBe(true);
   expect(isGuideMultiEnabledForDataSourceType('TIDB')).toBe(true);
+  expect(isGuideMultiEnabledForDataSourceType('GOLDENDB')).toBe(true);
   expect(isGuideMultiEnabledForDataSourceType('HANA')).toBe(true);
   expect(isGuideMultiEnabledForDataSourceType('SAP-HANA')).toBe(true);
   expect(isGuideMultiEnabledForDataSourceType('YASHAN_DB')).toBe(true);
@@ -142,4 +166,10 @@ test('keeps multi-table guide policy connector-profile driven', () => {
   expect(isGuideMultiEnabledForDataSourceType('DORIS')).toBe(true);
   expect(isGuideMultiEnabledForDataSourceType('ELASTICSEARCH7')).toBe(false);
   expect(isGuideMultiEnabledForDataSourceType('ES8')).toBe(false);
+
+  expect(isAutoCreateTableEnabledForDataSourceType('MYSQL')).toBe(true);
+  expect(isAutoCreateTableEnabledForDataSourceType('TIDB')).toBe(true);
+  expect(isAutoCreateTableEnabledForDataSourceType('GOLDENDB')).toBe(false);
+  expect(isAutoCreateTableEnabledForDataSourceType('GOLDEN-DB')).toBe(false);
+  expect(isAutoCreateTableEnabledForDataSourceType('HANA')).toBe(true);
 });

--- a/yak-ops-ui/src/pages/integration/batch-link-up/connectorProfiles.ts
+++ b/yak-ops-ui/src/pages/integration/batch-link-up/connectorProfiles.ts
@@ -11,6 +11,8 @@ export interface OfflineSyncConnectorProfile {
   defaultProfile: boolean;
   /** Product-level guide policy. Backend adapters remain the final enforcement boundary. */
   guideMultiEnabled?: boolean;
+  /** Product-level target DDL policy layered on top of connector-wide capabilities. */
+  autoCreateTableEnabled?: boolean;
 }
 
 /** Control-plane default execution profiles for datasource types exposed by Yak Ops. */
@@ -22,6 +24,11 @@ export const OFFLINE_SYNC_CONNECTOR_PROFILES: readonly OfflineSyncConnectorProfi
   {
     profileId: 'tidb-jdbc', dbType: 'TIDB', sourceConnectorId: 'jdbc', sinkConnectorId: 'jdbc',
     connectorType: 'Jdbc', pluginName: 'JDBC-TIDB', defaultProfile: true,
+  },
+  {
+    profileId: 'goldendb-jdbc', dbType: 'GOLDENDB', sourceConnectorId: 'jdbc', sinkConnectorId: 'jdbc',
+    connectorType: 'Jdbc', pluginName: 'JDBC-GOLDENDB', defaultProfile: true,
+    autoCreateTableEnabled: false,
   },
   {
     profileId: 'hana-jdbc', dbType: 'HANA', sourceConnectorId: 'jdbc', sinkConnectorId: 'jdbc',
@@ -117,6 +124,8 @@ const DB_TYPE_ALIASES: Record<string, string> = {
   POSTGRESQL: 'POSTGRE_SQL',
   POSTGRES: 'POSTGRE_SQL',
   TI_DB: 'TIDB',
+  GOLDEN_DB: 'GOLDENDB',
+  ZTE_GOLDENDB: 'GOLDENDB',
   SAP_HANA: 'HANA',
   SAPHANA: 'HANA',
   OPENGAUSS: 'OPEN_GAUSS',
@@ -151,6 +160,9 @@ export const defaultOfflineSyncConnectorProfile = (
 
 export const isGuideMultiEnabledForDataSourceType = (dbType?: string): boolean =>
   defaultOfflineSyncConnectorProfile(dbType)?.guideMultiEnabled !== false;
+
+export const isAutoCreateTableEnabledForDataSourceType = (dbType?: string): boolean =>
+  defaultOfflineSyncConnectorProfile(dbType)?.autoCreateTableEnabled !== false;
 
 /** Compatibility inference used only when a persisted endpoint has no durable connectorId. */
 export const connectorIdForDataSourceType = (

--- a/yak-ops-ui/src/pages/integration/batch-link-up/detail/capabilities.test.ts
+++ b/yak-ops-ui/src/pages/integration/batch-link-up/detail/capabilities.test.ts
@@ -102,6 +102,29 @@ describe('offline connector capabilities', () => {
     expect(errors).toEqual([]);
   });
 
+  it('keeps GoldenDB Stage 1 on existing target tables even when JDBC advertises auto create', () => {
+    const value = editor();
+    value.sink.dbType = 'GOLDENDB';
+    value.sink.pluginName = 'JDBC-GOLDENDB';
+    value.sink.config = {
+      targetTableName: 'orders',
+      autoCreateTable: true,
+      writeMode: 'append',
+    };
+
+    const errors = validateEditorCapabilities(
+      value,
+      snapshot(
+        ['TABLE_SCHEMA_DISCOVERY'],
+        ['AUTO_CREATE_TABLE', 'UPSERT'],
+      ),
+    );
+
+    expect(errors).toContain(
+      'GOLDENDB Stage 1 仅支持写入已有表，请关闭自动建表',
+    );
+  });
+
   it('requires both connector roles to advertise MULTI_TABLE', () => {
     const value = editor();
     value.mode = 'GUIDE_MULTI';

--- a/yak-ops-ui/src/pages/integration/batch-link-up/detail/capabilities.ts
+++ b/yak-ops-ui/src/pages/integration/batch-link-up/detail/capabilities.ts
@@ -4,6 +4,7 @@ import type {
   OfflineConnectorRuntimeSnapshot,
 } from '@/services/batch-link-up';
 
+import { isAutoCreateTableEnabledForDataSourceType } from '../connectorProfiles';
 import type { SyncEditorState } from './model';
 
 export const CONNECTOR_CAPABILITY = {
@@ -102,8 +103,23 @@ export const validateEditorCapabilities = (
   editor: SyncEditorState,
   snapshot: OfflineConnectorRuntimeSnapshot | null | undefined,
 ): string[] => {
+  const sourceConfig = editor.source.config || {};
+  const sinkConfig = editor.sink.config || {};
+  const writeMode = String(sinkConfig.writeMode || '').toLowerCase();
+  const errors: string[] = [];
+
+  // Datasource-profile policies are control-plane contracts and do not depend on Worker reachability.
+  if (
+    Boolean(sinkConfig.autoCreateTable) &&
+    !isAutoCreateTableEnabledForDataSourceType(editor.sink.dbType)
+  ) {
+    errors.push(
+      `${editor.sink.dbType || '当前目标数据源'} Stage 1 仅支持写入已有表，请关闭自动建表`,
+    );
+  }
+
   if (!snapshot || !snapshot.reachable) {
-    return [];
+    return errors;
   }
 
   const source = resolveEndpointCapability(
@@ -116,7 +132,6 @@ export const validateEditorCapabilities = (
     editor.sink.connectorId,
     'SINK',
   );
-  const errors: string[] = [];
 
   if (!source.available) {
     errors.push(
@@ -128,7 +143,7 @@ export const validateEditorCapabilities = (
       `当前 Link-Up Worker 未加载 Sink Connector：${editor.sink.connectorId || 'UNKNOWN'}`,
     );
   }
-  if (errors.length > 0) {
+  if (errors.some((message) => message.startsWith('当前 Link-Up Worker 未加载'))) {
     return errors;
   }
 
@@ -145,10 +160,6 @@ export const validateEditorCapabilities = (
     }
   }
 
-  const sourceConfig = editor.source.config || {};
-  const sinkConfig = editor.sink.config || {};
-  const writeMode = String(sinkConfig.writeMode || '').toLowerCase();
-
   if (
     String(sourceConfig.readMode || '').toLowerCase() === 'sql' &&
     !hasCapability(source, CONNECTOR_CAPABILITY.CUSTOM_SQL)
@@ -160,6 +171,7 @@ export const validateEditorCapabilities = (
 
   if (
     Boolean(sinkConfig.autoCreateTable) &&
+    isAutoCreateTableEnabledForDataSourceType(editor.sink.dbType) &&
     !hasCapability(sink, CONNECTOR_CAPABILITY.AUTO_CREATE_TABLE)
   ) {
     errors.push(

--- a/yak-ops-ui/src/pages/integration/batch-link-up/detail/components/MultiTableConfigSection.tsx
+++ b/yak-ops-ui/src/pages/integration/batch-link-up/detail/components/MultiTableConfigSection.tsx
@@ -23,6 +23,7 @@ interface MultiTableConfigSectionProps {
   sourceConfig: Record<string, any>;
   sinkConfig: Record<string, any>;
   sinkCapability: EndpointCapabilityState;
+  autoCreateTableEnabled: boolean;
   sourceTables: string[];
   sourceLoading: boolean;
   sourceReady: boolean;
@@ -98,6 +99,7 @@ export default function MultiTableConfigSection({
   sourceConfig,
   sinkConfig,
   sinkCapability,
+  autoCreateTableEnabled,
   sourceTables,
   sourceLoading,
   sourceReady,
@@ -111,10 +113,12 @@ export default function MultiTableConfigSection({
   const tableNamingRule = String(
     sinkConfig.tableNamingRule || 'same_name',
   ).toLowerCase();
-  const supportsAutoCreate = allowsCapability(
-    sinkCapability,
-    CONNECTOR_CAPABILITY.AUTO_CREATE_TABLE,
-  );
+  const supportsAutoCreate =
+    autoCreateTableEnabled &&
+    allowsCapability(
+      sinkCapability,
+      CONNECTOR_CAPABILITY.AUTO_CREATE_TABLE,
+    );
   const supportsUpsert = allowsCapability(
     sinkCapability,
     CONNECTOR_CAPABILITY.UPSERT,
@@ -296,7 +300,9 @@ export default function MultiTableConfigSection({
               </div>
               {!supportsAutoCreate && sinkConfig.autoCreateTable ? (
                 <div className="mt-2 text-[11px] leading-5 text-[#b54708]">
-                  当前 Sink Connector 未声明 AUTO_CREATE_TABLE，请关闭后再保存。
+                  {autoCreateTableEnabled
+                    ? '当前 Sink Connector 未声明 AUTO_CREATE_TABLE，请关闭后再保存。'
+                    : '当前目标数据源 Stage 1 仅支持写入已有表，请关闭自动建表后再保存。'}
                 </div>
               ) : null}
             </div>

--- a/yak-ops-ui/src/pages/integration/batch-link-up/detail/components/SingleTableConfigSection.tsx
+++ b/yak-ops-ui/src/pages/integration/batch-link-up/detail/components/SingleTableConfigSection.tsx
@@ -29,6 +29,7 @@ interface SingleTableConfigSectionProps {
   sinkConfig: Record<string, any>;
   sourceCapability: EndpointCapabilityState;
   sinkCapability: EndpointCapabilityState;
+  autoCreateTableEnabled: boolean;
   sourceTables: string[];
   targetTables: string[];
   sourceLoading: boolean;
@@ -86,6 +87,7 @@ export default function SingleTableConfigSection({
   sinkConfig,
   sourceCapability,
   sinkCapability,
+  autoCreateTableEnabled,
   sourceTables,
   targetTables,
   sourceLoading,
@@ -107,10 +109,14 @@ export default function SingleTableConfigSection({
     sourceCapability,
     CONNECTOR_CAPABILITY.CUSTOM_SQL,
   );
-  const supportsAutoCreate = allowsCapability(
-    sinkCapability,
-    CONNECTOR_CAPABILITY.AUTO_CREATE_TABLE,
-  );
+  const supportsAutoCreate =
+    autoCreateTableEnabled &&
+    allowsCapability(
+      sinkCapability,
+      CONNECTOR_CAPABILITY.AUTO_CREATE_TABLE,
+    );
+  const effectiveAutoCreateTable =
+    supportsAutoCreate && Boolean(sinkConfig.autoCreateTable);
   const supportsUpsert = allowsCapability(
     sinkCapability,
     CONNECTOR_CAPABILITY.UPSERT,
@@ -236,13 +242,15 @@ export default function SingleTableConfigSection({
               </div>
               {!supportsAutoCreate && sinkConfig.autoCreateTable ? (
                 <div className="mt-2 text-[11px] leading-5 text-[#b54708]">
-                  当前 Sink Connector 未声明 AUTO_CREATE_TABLE，请关闭后选择已有目标表。
+                  {autoCreateTableEnabled
+                    ? '当前 Sink Connector 未声明 AUTO_CREATE_TABLE，请关闭后选择已有目标表。'
+                    : '当前目标数据源 Stage 1 仅支持写入已有表，请关闭自动建表后选择目标表。'}
                 </div>
               ) : null}
             </div>
           ) : null}
 
-          {sinkConfig.autoCreateTable ? (
+          {effectiveAutoCreateTable ? (
             <div>
               <FieldLabel required>目标表名</FieldLabel>
               <Input

--- a/yak-ops-ui/src/pages/integration/batch-link-up/detail/components/SyncTaskEditor.tsx
+++ b/yak-ops-ui/src/pages/integration/batch-link-up/detail/components/SyncTaskEditor.tsx
@@ -1,6 +1,7 @@
 import { Alert } from 'antd';
 import type { DataSourceRecord } from '@/services/data-source';
 
+import { isAutoCreateTableEnabledForDataSourceType } from '../../connectorProfiles';
 import {
   resolveEndpointCapability,
   validateEditorCapabilities,
@@ -47,6 +48,10 @@ export default function SyncTaskEditor({
   const sourceId = editor.source.dataSourceId;
   const targetId = editor.sink.dataSourceId;
   const mappingColumns = normalizeMappings(editor.mapping?.columns);
+  const sinkAutoCreateTableEnabled =
+    isAutoCreateTableEnabledForDataSourceType(editor.sink.dbType);
+  const sinkAutoCreateTable =
+    sinkAutoCreateTableEnabled && Boolean(sinkConfig.autoCreateTable);
 
   const connectorRuntime = useOfflineConnectorRuntime();
   const sourceCapability = resolveEndpointCapability(
@@ -80,18 +85,18 @@ export default function SyncTaskEditor({
   const sourceColumnRequest = sourceConfig.readMode === 'sql'
     ? sourceConfig.sql?.trim() ? { query: sourceConfig.sql } : undefined
     : sourceConfig.table ? { table_path: sourceConfig.table } : undefined;
-  const targetColumnRequest = !sinkConfig.autoCreateTable && sinkConfig.table
+  const targetColumnRequest = !sinkAutoCreateTable && sinkConfig.table
     ? { table_path: sinkConfig.table }
     : undefined;
   const sourceColumnCatalog = useDataSourceColumns(sourceId, sourceColumnRequest);
   const targetColumnCatalog = useDataSourceColumns(targetId, targetColumnRequest);
-  const primaryKeyCatalog = sinkConfig.autoCreateTable
+  const primaryKeyCatalog = sinkAutoCreateTable
     ? sourceColumnCatalog
     : targetColumnCatalog;
-  const mappingTargetColumns = sinkConfig.autoCreateTable
+  const mappingTargetColumns = sinkAutoCreateTable
     ? sourceColumnCatalog.columns
     : targetColumnCatalog.columns;
-  const mappingTargetLoading = sinkConfig.autoCreateTable
+  const mappingTargetLoading = sinkAutoCreateTable
     ? sourceColumnCatalog.loading
     : targetColumnCatalog.loading;
 
@@ -193,6 +198,7 @@ export default function SyncTaskEditor({
             sourceConfig={sourceConfig}
             sinkConfig={sinkConfig}
             sinkCapability={sinkCapability}
+            autoCreateTableEnabled={sinkAutoCreateTableEnabled}
             sourceTables={sourceCatalog.tables}
             sourceLoading={sourceCatalog.loading}
             sourceReady={Boolean(sourceId)}
@@ -210,6 +216,7 @@ export default function SyncTaskEditor({
             sinkConfig={sinkConfig}
             sourceCapability={sourceCapability}
             sinkCapability={sinkCapability}
+            autoCreateTableEnabled={sinkAutoCreateTableEnabled}
             sourceTables={sourceCatalog.tables}
             targetTables={targetCatalog.tables}
             sourceLoading={sourceCatalog.loading}
@@ -256,8 +263,8 @@ export default function SyncTaskEditor({
             sourceLoading={sourceColumnCatalog.loading}
             targetLoading={mappingTargetLoading}
             sourceReady={Boolean(sourceId && sourceColumnRequest)}
-            targetReady={Boolean(targetId && (sinkConfig.autoCreateTable || targetColumnRequest))}
-            targetDerived={Boolean(sinkConfig.autoCreateTable)}
+            targetReady={Boolean(targetId && (sinkAutoCreateTable || targetColumnRequest))}
+            targetDerived={sinkAutoCreateTable}
           />
         </div>
       ) : null}

--- a/yak-ops-ui/src/pages/integration/batch-link-up/detail/components/TaskBasicSection.tsx
+++ b/yak-ops-ui/src/pages/integration/batch-link-up/detail/components/TaskBasicSection.tsx
@@ -11,7 +11,10 @@ import {
   BRAND_COLOR_SOFT_HOVER,
 } from '@/styles/brand';
 
-import { connectorIdForNewDataSourceType } from '../../connectorProfiles';
+import {
+  connectorIdForNewDataSourceType,
+  isAutoCreateTableEnabledForDataSourceType,
+} from '../../connectorProfiles';
 import {
   applyEndpointSelection,
   type EndpointKind,
@@ -111,6 +114,21 @@ export default function TaskBasicSection({
           ? current.pluginName
           : selected[kind].pluginName,
     };
+
+    if (
+      kind === 'sink' &&
+      !isAutoCreateTableEnabledForDataSourceType(String(record.dbType || ''))
+    ) {
+      selected.sink = {
+        ...selected.sink,
+        config: {
+          ...selected.sink.config,
+          autoCreateTable: false,
+          targetTableName: '',
+          primaryKey: '',
+        },
+      };
+    }
 
     onChange(selected);
   };


### PR DESCRIPTION
## Summary

Adds GoldenDB as a first-class Yak Ops datasource and wires it into bounded/offline synchronization, aligned with the GoldenDB Stage 1 execution contract in `weifuwan/yak-link-up#120`.

GoldenDB remains a distinct control-plane identity (`GOLDENDB`) while using the MySQL-compatible JDBC protocol and Connector/J underneath. The control plane always restores `dialect=goldendb` before Link-Up execution so a shared `jdbc:mysql://` URL is never mistaken for MySQL or TiDB.

## Datasource management

- add `GOLDENDB` to `DataSourceDbType`
- add stable aliases: `goldendb`, `golden-db`, `zte-goldendb`
- add `GoldenDbDataSourcePlugin`
- use `com.mysql.cj.jdbc.Driver`
- use `jdbc:mysql://{host}:{port}/{database}`
- keep `3306` only as an editable MySQL-compatible form fallback; explicit port/JDBC URL wins
- persist normalized `dialect=goldendb`
- reuse MySQL-compatible catalog semantics for database/table/column discovery, backtick identifiers and preview SQL
- register the plugin through the datasource SPI and all-plugins discovery test
- expose GoldenDB in datasource creation, filtering and offline datasource selection UI

## Offline synchronization

- add `goldendb-jdbc` / `JDBC-GOLDENDB` default profile
- keep Source and Sink on the shared `jdbc` connector
- support guided single-table and multi-table jobs
- restore datasource-owned URL, driver, credentials and `dialect=goldendb` only at execution time
- preserve JDBC Append / Overwrite(TRUNCATE) / Upsert / batch-write behavior
- keep historical aliases on the JDBC compatibility path

## Stage 1 target-table boundary

`yak-link-up#120` deliberately supports **existing GoldenDB target tables only**. Yak Ops mirrors that boundary instead of exposing generic JDBC auto-create as if it were safe GoldenDB distributed-table DDL:

- GoldenDB profile disables auto-create in the editor
- selecting a GoldenDB Sink clears stale `autoCreateTable` intent
- editor validation rejects old definitions that still request auto-create, even when the Worker is unreachable
- stale auto-create definitions are edited through the existing-target-table selector rather than a create-table input
- execution-time adapter forcibly sets `schema_save_mode=ERROR_WHEN_SCHEMA_NOT_EXIST` for GoldenDB Sink

This avoids accidentally creating or recreating distributed tables without an explicit GoldenDB sharding/distribution design.

## Tests

Added/updated coverage for:

- GoldenDB datasource aliases and first-class enum identity
- GoldenDB datasource plugin URL, driver, normalized dialect and capabilities
- datasource SPI discovery
- MySQL-compatible generic catalog enum handling
- GoldenDB offline profile and aliases
- execution-time `dialect=goldendb` restoration
- existing-table Sink enforcement even when stale options request auto-create
- frontend profile selection and target-DDL policy validation

## Non-goals

- CDC / realtime synchronization
- GoldenDB binlog integration
- automatic distributed table creation
- sharding/distribution-key management
- GoldenDB-native bulk loading
- runtime schema evolution

## Dependency / verification

- execution dependency: `weifuwan/yak-link-up#120`
- branch is based directly on the current `main` head and contains one atomic commit
- GitHub Actions CI run #258 completed successfully
- frontend dependency installation and `yarn build` passed
- Java/Maven distribution packaging was skipped by the repository workflow because the private `yak-framework` read token was unavailable in this run; this was not a Maven compilation failure
- a real GoldenDB environment is still required before Ready for Review to validate connection, metadata discovery, primary-key discovery, Source reads and existing-table Insert/Upsert end to end
