### PR TITLE
ci: resolve yak-framework from Maven snapshot repository

### DIFF
--- a/.github/maven-settings.xml
+++ b/.github/maven-settings.xml
@@ -1,0 +1,47 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<settings xmlns="http://maven.apache.org/SETTINGS/1.0.0"
+          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+          xsi:schemaLocation="http://maven.apache.org/SETTINGS/1.0.0 https://maven.apache.org/xsd/settings-1.0.0.xsd">
+
+    <servers>
+        <server>
+            <id>yak-snapshot</id>
+            <username>${env.YAK_MAVEN_USERNAME}</username>
+            <password>${env.YAK_MAVEN_PASSWORD}</password>
+        </server>
+    </servers>
+
+    <mirrors>
+        <mirror>
+            <id>aliyunmaven</id>
+            <mirrorOf>*,!yak-snapshot</mirrorOf>
+            <name>Aliyun Public Maven Repository</name>
+            <url>https://maven.aliyun.com/repository/public</url>
+        </mirror>
+    </mirrors>
+
+    <profiles>
+        <profile>
+            <id>rdc</id>
+            <repositories>
+                <repository>
+                    <id>yak-snapshot</id>
+                    <name>Yak Framework Snapshot Repository</name>
+                    <url>https://yak-cn-hangzhou.devops.aliyuncs.com/packages/api/protocol/maven/4885-snapshot-jhbojn</url>
+                    <releases>
+                        <enabled>false</enabled>
+                    </releases>
+                    <snapshots>
+                        <enabled>true</enabled>
+                        <updatePolicy>always</updatePolicy>
+                    </snapshots>
+                </repository>
+            </repositories>
+        </profile>
+    </profiles>
+
+    <activeProfiles>
+        <activeProfile>rdc</activeProfile>
+    </activeProfiles>
+
+</settings>

--- a/.github/workflows/backend-compile.yml
+++ b/.github/workflows/backend-compile.yml
@@ -12,7 +12,7 @@ on:
       - 'yak-ops-business/**'
       - 'yak-ops-plugins/**'
       - 'yak-ops-boot/**'
-      - 'release.env'
+      - '.github/maven-settings.xml'
       - '.github/workflows/backend-compile.yml'
   push:
     branches:
@@ -27,7 +27,7 @@ on:
       - 'yak-ops-business/**'
       - 'yak-ops-plugins/**'
       - 'yak-ops-boot/**'
-      - 'release.env'
+      - '.github/maven-settings.xml'
       - '.github/workflows/backend-compile.yml'
   workflow_dispatch:
 
@@ -44,27 +44,13 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 20
 
+    env:
+      YAK_MAVEN_USERNAME: ${{ secrets.YAK_MAVEN_USERNAME }}
+      YAK_MAVEN_PASSWORD: ${{ secrets.YAK_MAVEN_PASSWORD }}
+
     steps:
       - name: Checkout Yak Ops
         uses: actions/checkout@v7
-
-      - name: Load Yak Framework ref
-        shell: bash
-        run: |
-          set -a
-          source release.env
-          set +a
-          echo "YAK_FRAMEWORK_REF=$YAK_FRAMEWORK_REF" >> "$GITHUB_ENV"
-
-      - name: Require Yak Framework read token
-        shell: bash
-        env:
-          YAK_FRAMEWORK_READ_TOKEN: ${{ secrets.YAK_FRAMEWORK_READ_TOKEN }}
-        run: |
-          if [[ -z "$YAK_FRAMEWORK_READ_TOKEN" ]]; then
-            echo "::error::YAK_FRAMEWORK_READ_TOKEN is required to compile the backend because yak-framework is private."
-            exit 1
-          fi
 
       - name: Set up Java 21
         uses: actions/setup-java@v6
@@ -73,18 +59,13 @@ jobs:
           java-version: '21'
           cache: maven
 
-      - name: Checkout pinned Yak Framework
-        uses: actions/checkout@v7
-        with:
-          repository: weifuwan/yak-framework
-          ref: ${{ env.YAK_FRAMEWORK_REF }}
-          path: .deps/yak-framework
-          token: ${{ secrets.YAK_FRAMEWORK_READ_TOKEN }}
-          persist-credentials: false
-
-      - name: Install Yak Framework
-        working-directory: .deps/yak-framework
-        run: mvn -B -ntp -DskipTests install
+      - name: Require Yak Maven credentials
+        shell: bash
+        run: |
+          if [[ -z "$YAK_MAVEN_USERNAME" || -z "$YAK_MAVEN_PASSWORD" ]]; then
+            echo "::error::YAK_MAVEN_USERNAME and YAK_MAVEN_PASSWORD are required to resolve yak-framework snapshots."
+            exit 1
+          fi
 
       - name: Compile Yak Ops backend
-        run: ./mvnw -B -ntp -DskipTests -pl yak-ops-boot -am compile
+        run: ./mvnw -s .github/maven-settings.xml -B -ntp -DskipTests -pl yak-ops-boot -am compile


### PR DESCRIPTION
## What changed

- remove `YAK_FRAMEWORK_READ_TOKEN` from `Backend Compile`
- stop checking out and installing the private `weifuwan/yak-framework` repository
- add `.github/maven-settings.xml` based on the existing Yak Aliyun Maven configuration
- resolve `yak-framework:1.0.0-SNAPSHOT` directly from the `yak-snapshot` repository
- keep third-party dependencies on the Aliyun public Maven mirror
- compile the backend with:
  - `./mvnw -s .github/maven-settings.xml -B -ntp -DskipTests -pl yak-ops-boot -am compile`

## Required Actions Secrets

The workflow now expects Maven repository credentials rather than a GitHub repository token:

- `YAK_MAVEN_USERNAME`
- `YAK_MAVEN_PASSWORD`

No Maven credentials are committed to the repository. The checked-in settings file references environment variables only.
