### PR TITLE
fix(elasticsearch): correct required form rule type

### DIFF
--- a/yak-ops-plugins/yak-ops-plugin-datasource/yak-ops-plugin-datasource-elasticsearch/src/main/java/io/yak/ops/plugin/database/elasticsearch/AbstractElasticsearchDataSourcePlugin.java
+++ b/yak-ops-plugins/yak-ops-plugin-datasource/yak-ops-plugin-datasource-elasticsearch/src/main/java/io/yak/ops/plugin/database/elasticsearch/AbstractElasticsearchDataSourcePlugin.java
@@ -325,8 +325,8 @@ abstract class AbstractElasticsearchDataSourcePlugin implements DataSourcePlugin
     return List.copyOf(result);
   }
 
-  private FormRule required(String message) {
-    return new FormRule(true, null, null, null, message);
+  private List<FormRule> required(String message) {
+    return List.of(new FormRule(true, null, null, null, message));
   }
 
   private FormField field(


### PR DESCRIPTION
## What changed

Fix the Elasticsearch datasource plugin form descriptor compilation error caused by returning a single `FormRule` where `field(...)` expects `List<FormRule>`.

### Change
- Update `required(String message)` to return `List<FormRule>`.
- Keep the existing `scheme` and `host` descriptor calls unchanged.
- Align the Elasticsearch helper with the existing JDBC datasource plugin pattern.

## Why

Compilation failed with:

```text
java: 不兼容的类型: io.yak.ops.spi.datasource.DataSourcePluginDescriptor.FormRule无法转换为java.util.List<io.yak.ops.spi.datasource.DataSourcePluginDescriptor.FormRule>
```

`field(...)` explicitly accepts `List<FormRule>`, while Elasticsearch's `required(...)` helper returned a single `FormRule`.

## Scope

Minimal compile fix only. No runtime Elasticsearch connection or catalog behavior is changed.