### PR TITLE
fix(ci): restore workflow test compilation

### DIFF
--- a/yak-ops-business/yak-ops-business-workflow/src/test/java/io/yak/ops/business/workflow/backfill/WorkflowBackfillAuditCoordinatorTest.java
+++ b/yak-ops-business/yak-ops-business-workflow/src/test/java/io/yak/ops/business/workflow/backfill/WorkflowBackfillAuditCoordinatorTest.java
@@ -46,10 +46,9 @@ class WorkflowBackfillAuditCoordinatorTest {
     assertThat(audit.request.resourceType()).isEqualTo("WORKFLOW_BACKFILL");
     assertThat(audit.request.metadata().toString()).doesNotContain("backfill-secret");
     Map<String, ?> payload = audit.handle.events.get(0).payload();
-    assertThat(payload)
-        .containsEntry("changeType", "BACKFILL_CREATED")
-        .containsEntry("totalCount", 3)
-        .containsEntry("inputConfigured", true);
+    assertThat(payload.get("changeType")).isEqualTo("BACKFILL_CREATED");
+    assertThat(payload.get("totalCount")).isEqualTo(3);
+    assertThat(payload.get("inputConfigured")).isEqualTo(true);
     assertThat(payload.toString()).doesNotContain("backfill-secret");
   }
 
@@ -72,10 +71,10 @@ class WorkflowBackfillAuditCoordinatorTest {
     coordinator.createBusinessDateRerun("execution-source", source, request);
 
     assertThat(audit.request.operationType()).isEqualTo("WORKFLOW_BUSINESS_DATE_RERUN");
-    assertThat(audit.request.metadata()).containsEntry("sourceExecutionId", "execution-source");
+    assertThat(audit.request.metadata().get("sourceExecutionId")).isEqualTo("execution-source");
     assertThat(audit.request.metadata().toString()).doesNotContain("rerun-secret");
-    assertThat(audit.handle.events.get(0).payload())
-        .containsEntry("changeType", "BUSINESS_DATE_RERUN_CREATED");
+    assertThat(audit.handle.events.get(0).payload().get("changeType"))
+        .isEqualTo("BUSINESS_DATE_RERUN_CREATED");
     assertThat(audit.handle.events.get(0).payload().toString()).doesNotContain("rerun-secret");
   }
 

--- a/yak-ops-business/yak-ops-business-workflow/src/test/java/io/yak/ops/business/workflow/backfill/WorkflowBackfillTriggerCoordinatorTest.java
+++ b/yak-ops-business/yak-ops-business-workflow/src/test/java/io/yak/ops/business/workflow/backfill/WorkflowBackfillTriggerCoordinatorTest.java
@@ -74,7 +74,7 @@ class WorkflowBackfillTriggerCoordinatorTest {
         .thenReturn(launched);
     when(launched.id()).thenReturn("execution-v5-20260810");
     when(admission.bindLaunch(any(WorkflowScheduleTriggerPO.class), eq("execution-v5-20260810")))
-        .thenReturn(AdmissionResult.none());
+        .thenReturn(new AdmissionResult(null, false, false));
 
     var result = coordinator.submitBackfill(
         backfill.getId(), occurrence.businessDate(), occurrence.scheduleInstant());

--- a/yak-ops-business/yak-ops-business-workflow/src/test/java/io/yak/ops/business/workflow/definition/WorkflowDefinitionAuditCoordinatorTest.java
+++ b/yak-ops-business/yak-ops-business-workflow/src/test/java/io/yak/ops/business/workflow/definition/WorkflowDefinitionAuditCoordinatorTest.java
@@ -91,10 +91,9 @@ class WorkflowDefinitionAuditCoordinatorTest {
     assertThat(audit.request.operationType()).isEqualTo("WORKFLOW_UPDATE");
     assertThat(audit.handle.events).hasSize(1);
     Map<String, ?> payload = audit.handle.events.get(0).payload();
-    assertThat(payload)
-        .containsEntry("descriptionChanged", true)
-        .containsEntry("inputChanged", true)
-        .containsEntry("editorMetaChanged", true);
+    assertThat(payload.get("descriptionChanged")).isEqualTo(true);
+    assertThat(payload.get("inputChanged")).isEqualTo(true);
+    assertThat(payload.get("editorMetaChanged")).isEqualTo(true);
     assertThat(payload.toString())
         .doesNotContain("secret-before", "secret-after", "private-before", "private-after");
     assertThat(audit.handle.successSummary).isEqualTo("Workflow updated");
@@ -116,7 +115,7 @@ class WorkflowDefinitionAuditCoordinatorTest {
     assertThat(audit.request.operationType()).isEqualTo("WORKFLOW_PUBLISH");
     assertThat(audit.handle.events).hasSize(2);
     assertThat(audit.handle.events)
-        .extracting(event -> event.payload().get("changeType"))
+        .extracting(event -> String.valueOf(event.payload().get("changeType")))
         .containsExactly("VERSION_PUBLISHED", "RESOURCE_ENABLED");
     assertThat(audit.handle.successSummary).isEqualTo("Workflow published");
   }
@@ -156,10 +155,9 @@ class WorkflowDefinitionAuditCoordinatorTest {
     assertThat(audit.request.resourceType()).isEqualTo("WORKFLOW_EXECUTION");
     assertThat(audit.request.resourceId()).isEqualTo("execution-1");
     assertThat(audit.handle.events).singleElement().satisfies(event -> {
-      assertThat(event.payload())
-          .containsEntry("changeType", "EXECUTION_PAUSED")
-          .containsEntry("executionId", "execution-1")
-          .containsEntry("status", "PAUSED");
+      assertThat(event.payload().get("changeType")).isEqualTo("EXECUTION_PAUSED");
+      assertThat(event.payload().get("executionId")).isEqualTo("execution-1");
+      assertThat(event.payload().get("status")).isEqualTo("PAUSED");
     });
   }
 

--- a/yak-ops-business/yak-ops-business-workflow/src/test/java/io/yak/ops/business/workflow/execution/WorkflowExecutionAuditBridgeTest.java
+++ b/yak-ops-business/yak-ops-business-workflow/src/test/java/io/yak/ops/business/workflow/execution/WorkflowExecutionAuditBridgeTest.java
@@ -84,9 +84,10 @@ class WorkflowExecutionAuditBridgeTest {
         correlation.findCarrierJson("execution-2").orElseThrow(), AuditCarrier.class);
     assertThat(stored.operationId()).isEqualTo("AUD-1");
     assertThat(stored.actorName()).isEqualTo("alice");
-    assertThat(auditService.requests.getFirst().metadata())
-        .containsEntry("launchMode", "RETRY_FAILED_NODE")
-        .containsEntry("nodeId", "node-1");
+    assertThat(auditService.requests.getFirst().metadata().get("launchMode"))
+        .isEqualTo("RETRY_FAILED_NODE");
+    assertThat(auditService.requests.getFirst().metadata().get("nodeId"))
+        .isEqualTo("node-1");
 
     bridge.observeTerminal(new WorkflowExecutionTerminalEvent(
         "execution-2", "SUCCESS", Instant.parse("2026-09-02T07:31:00Z")));
@@ -190,7 +191,8 @@ class WorkflowExecutionAuditBridgeTest {
 
     @Override
     public AuditOperationHandle resume(AuditCarrier carrier) {
-      return handles.getOrDefault(carrier.operationId(), AuditOperationHandle.noop(carrier));
+      RecordingHandle handle = handles.get(carrier.operationId());
+      return handle == null ? AuditOperationHandle.noop(carrier) : handle;
     }
 
     RecordingHandle handle(String operationId) {

--- a/yak-ops-business/yak-ops-business-workflow/src/test/java/io/yak/ops/business/workflow/runtime/WorkflowPersistenceWiringTest.java
+++ b/yak-ops-business/yak-ops-business-workflow/src/test/java/io/yak/ops/business/workflow/runtime/WorkflowPersistenceWiringTest.java
@@ -6,11 +6,15 @@ import io.yak.ops.business.workflow.observability.WorkflowEventStream;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.Mockito.mock;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
 import io.yak.framework.workflow.engine.spi.ExecutionRepository;
 import io.yak.framework.workflow.engine.spi.WorkflowDefinitionRepository;
 import io.yak.ops.business.job.task.TaskExecutionGateway;
 import io.yak.ops.business.job.task.TaskRegistry;
+import io.yak.ops.business.taskcatalog.service.TaskCatalogService;
+import io.yak.ops.business.workflow.dao.WorkflowExecutionDao;
 import io.yak.ops.business.workflow.repository.WorkflowRuntimeRepository;
+import io.yak.ops.core.project.CurrentProject;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.ObjectProvider;
 import org.springframework.beans.factory.support.DefaultListableBeanFactory;
@@ -34,15 +38,19 @@ class WorkflowPersistenceWiringTest {
   }
 
   @Test
-  void definitionServiceShouldFailFastWhenDatabaseIsEnabledButCatalogIsMissing() {
+  void definitionServiceShouldFailFastWhenDatabaseIsEnabledButRepositoriesAreMissing() {
     DefaultListableBeanFactory beans = new DefaultListableBeanFactory();
 
     assertThatThrownBy(() -> new WorkflowDefinitionManager(
         mock(WorkflowRuntime.class),
         mock(TaskRegistry.class),
+        provider(beans, TaskCatalogService.class),
+        new ObjectMapper(),
         provider(
             beans,
             io.yak.ops.business.workflow.repository.WorkflowDefinitionRepository.class),
+        provider(beans, WorkflowExecutionDao.class),
+        mock(CurrentProject.class),
         true))
         .isInstanceOf(IllegalStateException.class)
         .hasMessageContaining("WorkflowDefinitionRepository");

--- a/yak-ops-business/yak-ops-business-workflow/src/test/java/io/yak/ops/business/workflow/schedule/WorkflowPauseSchedulingTest.java
+++ b/yak-ops-business/yak-ops-business-workflow/src/test/java/io/yak/ops/business/workflow/schedule/WorkflowPauseSchedulingTest.java
@@ -33,9 +33,11 @@ class WorkflowPauseSchedulingTest {
   private WorkflowRuntime service;
 
   @AfterEach
-  void tearDown() {
+  void tearDown() throws ReflectiveOperationException {
     if (service != null) {
-      service.shutdown();
+      var shutdown = WorkflowRuntime.class.getDeclaredMethod("shutdown");
+      shutdown.setAccessible(true);
+      shutdown.invoke(service);
     }
   }
 

--- a/yak-ops-business/yak-ops-business-workflow/src/test/java/io/yak/ops/business/workflow/schedule/WorkflowScheduleAuditCoordinatorTest.java
+++ b/yak-ops-business/yak-ops-business-workflow/src/test/java/io/yak/ops/business/workflow/schedule/WorkflowScheduleAuditCoordinatorTest.java
@@ -49,9 +49,8 @@ class WorkflowScheduleAuditCoordinatorTest {
     assertThat(audit.request.metadata().toString()).doesNotContain("schedule-secret");
     assertThat(audit.handle.events).hasSize(1);
     Map<String, ?> payload = audit.handle.events.get(0).payload();
-    assertThat(payload)
-        .containsEntry("changeType", "SCHEDULE_CREATED")
-        .containsEntry("inputConfigured", true);
+    assertThat(payload.get("changeType")).isEqualTo("SCHEDULE_CREATED");
+    assertThat(payload.get("inputConfigured")).isEqualTo(true);
     assertThat(payload.toString()).doesNotContain("schedule-secret");
   }
 
@@ -102,10 +101,11 @@ class WorkflowScheduleAuditCoordinatorTest {
 
     assertThat(audit.request.operationType()).isEqualTo("WORKFLOW_SCHEDULE_DISABLE");
     assertThat(audit.request.source()).isEqualTo("SCHEDULE");
-    assertThat(audit.request.metadata()).containsEntry("cause", "WORKFLOW_NOT_ONLINE");
-    assertThat(audit.handle.events.get(0).payload())
-        .containsEntry("changeType", "SCHEDULE_DISABLED")
-        .containsEntry("cause", "WORKFLOW_NOT_ONLINE");
+    assertThat(audit.request.metadata().get("cause")).isEqualTo("WORKFLOW_NOT_ONLINE");
+    assertThat(audit.handle.events.get(0).payload().get("changeType"))
+        .isEqualTo("SCHEDULE_DISABLED");
+    assertThat(audit.handle.events.get(0).payload().get("cause"))
+        .isEqualTo("WORKFLOW_NOT_ONLINE");
   }
 
   @Test
@@ -127,9 +127,9 @@ class WorkflowScheduleAuditCoordinatorTest {
 
     assertThat(audit.request.operationType()).isEqualTo("WORKFLOW_SCHEDULE_EXPIRE");
     assertThat(audit.request.source()).isEqualTo("SCHEDULE");
-    assertThat(audit.handle.events.get(0).payload())
-        .containsEntry("changeType", "SCHEDULE_EXPIRED")
-        .containsEntry("fireTime", fireTime);
+    assertThat(audit.handle.events.get(0).payload().get("changeType"))
+        .isEqualTo("SCHEDULE_EXPIRED");
+    assertThat(audit.handle.events.get(0).payload().get("fireTime")).isEqualTo(fireTime);
   }
 
   private static WorkflowScheduleVO schedule(String status, Map<String, Object> input) {

--- a/yak-ops-business/yak-ops-business-workflow/src/test/java/io/yak/ops/business/workflow/schedule/trigger/WorkflowScheduleTriggerHandlerTest.java
+++ b/yak-ops-business/yak-ops-business-workflow/src/test/java/io/yak/ops/business/workflow/schedule/trigger/WorkflowScheduleTriggerHandlerTest.java
@@ -17,6 +17,7 @@ import io.yak.ops.business.workflow.schedule.WorkflowScheduleRuntimeState;
 import io.yak.ops.business.workflow.schedule.engine.WorkflowScheduleEngineBridge;
 import io.yak.ops.common.bean.po.workflow.WorkflowSchedulePO;
 import io.yak.ops.common.bean.vo.workflow.WorkflowDefinitionVO;
+import io.yak.ops.common.schedule.YakScheduleNamespaces;
 import io.yak.ops.core.project.ProjectContext;
 import io.yak.ops.core.project.ProjectContextScope;
 import java.time.Instant;
@@ -115,7 +116,7 @@ class WorkflowScheduleTriggerHandlerTest {
   private ScheduleExecutionContext context(Instant planned, long projectId) {
     return new ScheduleExecutionContext(
         "trigger-1",
-        new ScheduleKey(WorkflowScheduleEngineBridge.NAMESPACE, "schedule-1"),
+        new ScheduleKey(YakScheduleNamespaces.WORKFLOW, "schedule-1"),
         "quartz",
         WorkflowScheduleEngineBridge.HANDLER,
         Map.of(


### PR DESCRIPTION
## 目标

修复当前 `CI / Validate and build release distribution` 在 `yak-ops-business-workflow:testCompile` 阶段暴露的测试源码兼容性问题，不通过关闭测试编译来绕过 CI。

## 修复内容

- 修复 `Map<String, ?>` 与 AssertJ `containsEntry` 组合导致的 capture 泛型编译错误，改为按 key 读取后断言。
- 更新 `WorkflowDefinitionManager` 持久化 wiring 测试，匹配当前构造器依赖。
- 测试不再直接访问 package-private 的 `AdmissionResult.none()` 与 `WorkflowScheduleEngineBridge.NAMESPACE`。
- 修复 `WorkflowExecutionAuditBridgeTest` 中 `AuditOperationHandle` / `RecordingHandle` 的类型推断问题。
- `WorkflowPauseSchedulingTest` 保持生产 `WorkflowRuntime.shutdown()` 可见性不变，仅在测试清理阶段反射调用。

## 范围

本 PR 只修改 8 个 workflow 测试文件，不改业务实现，不弱化 Maven CI：仍保留 `clean package -DskipTests` 对测试源码的 `testCompile` 校验。

## 验证结果

- ✅ `Backend Compile / Compile backend with Java 21`
- ✅ 前端 `yarn install --frozen-lockfile`
- ✅ 前端 `yarn build`
- ✅ `Normalize release version`
- ✅ `Package Yak Ops`（完整 Maven reactor，包含 testCompile）
- ✅ `Upload distribution`
- ✅ `CI / Validate and build release distribution`

完整 CI 已越过原先失败的 `yak-ops-business-workflow:testCompile` 并成功完成 distribution 打包。