### PR TITLE
feat(ui): use WebP artwork for running status

### DIFF
--- a/yak-ops-ui/src/components/YakStatusIcon/index.less
+++ b/yak-ops-ui/src/components/YakStatusIcon/index.less
@@ -62,6 +62,14 @@
   .yak-status-icon__dot {
     opacity: 0.5;
   }
+
+  .yak-status-icon__running-image {
+    pointer-events: none;
+  }
+
+  .yak-status-icon__running-reduced-motion {
+    display: none;
+  }
 }
 
 .yak-status-icon--success {
@@ -138,6 +146,14 @@
 
 @media (prefers-reduced-motion: reduce) {
   .yak-status-icon--animated {
+    .yak-status-icon__running-image {
+      display: none;
+    }
+
+    .yak-status-icon__running-reduced-motion {
+      display: inline;
+    }
+
     .yak-status-icon__orbit,
     .yak-status-icon__dot {
       animation: none;

--- a/yak-ops-ui/src/components/YakStatusIcon/index.test.tsx
+++ b/yak-ops-ui/src/components/YakStatusIcon/index.test.tsx
@@ -18,6 +18,18 @@ describe('YakStatusIcon', () => {
     expect(icon).toHaveAttribute('aria-hidden', 'true');
   });
 
+  it('renders the WebP artwork for the animated running status', () => {
+    const { container } = render(<YakStatusIcon status="running" />);
+    const artwork = container.querySelector(
+      'image.yak-status-icon__running-image',
+    );
+
+    expect(artwork).toBeInTheDocument();
+    expect(artwork).toHaveAttribute('width', '24');
+    expect(artwork).toHaveAttribute('height', '24');
+    expect(artwork).toHaveAttribute('preserveAspectRatio', 'xMidYMid meet');
+  });
+
   it('supports size, className and disabling motion', () => {
     const { container } = render(
       <YakStatusIcon
@@ -34,6 +46,10 @@ describe('YakStatusIcon', () => {
     expect(icon).toHaveAttribute('data-animated', 'false');
     expect(icon).toHaveAttribute('width', '24');
     expect(icon).toHaveAttribute('height', '24');
+    expect(
+      container.querySelector('image.yak-status-icon__running-image'),
+    ).not.toBeInTheDocument();
+    expect(container.querySelector('.yak-status-icon__orbit')).toBeInTheDocument();
   });
 
   it('exposes an accessible name when title is provided', () => {

--- a/yak-ops-ui/src/components/YakStatusIcon/index.tsx
+++ b/yak-ops-ui/src/components/YakStatusIcon/index.tsx
@@ -1,5 +1,6 @@
 import type { SVGProps } from 'react';
 
+import runningWebp from '../../assets/gif/running.webp';
 import './index.less';
 
 export const YAK_STATUS_VALUES = [
@@ -36,7 +37,47 @@ function StaticSurface() {
   return <path className="yak-status-icon__surface" d={BLOB_PATH} />;
 }
 
-function StatusGlyph({ status }: { status: YakStatus }) {
+function StaticRunningGlyph() {
+  return (
+    <>
+      <path
+        className="yak-status-icon__surface yak-status-icon__surface--soft"
+        d={BLOB_PATH}
+      />
+      <g className="yak-status-icon__orbit">
+        <path
+          className="yak-status-icon__orbit-line"
+          d="M4.55 10.55c.6-3.23 3.19-5.72 6.45-6.1"
+        />
+        <path
+          className="yak-status-icon__orbit-line"
+          d="M19.45 13.45c-.6 3.23-3.19 5.72-6.45 6.1"
+        />
+        <circle
+          className="yak-status-icon__orbit-node"
+          cx="17.45"
+          cy="7.15"
+          r="1.05"
+        />
+        <circle
+          className="yak-status-icon__orbit-node yak-status-icon__orbit-node--minor"
+          cx="6.35"
+          cy="16.9"
+          r="0.72"
+        />
+      </g>
+      <circle className="yak-status-icon__core" cx="12" cy="12" r="3.15" />
+    </>
+  );
+}
+
+function StatusGlyph({
+  status,
+  animated,
+}: {
+  status: YakStatus;
+  animated: boolean;
+}) {
   switch (status) {
     case 'success':
       return (
@@ -59,22 +100,27 @@ function StatusGlyph({ status }: { status: YakStatus }) {
         </>
       );
     case 'running':
+      if (!animated) {
+        return <StaticRunningGlyph />;
+      }
       return (
         <>
-          <path className="yak-status-icon__surface yak-status-icon__surface--soft" d={BLOB_PATH} />
-          <g className="yak-status-icon__orbit">
-            <path
-              className="yak-status-icon__orbit-line"
-              d="M4.55 10.55c.6-3.23 3.19-5.72 6.45-6.1"
-            />
-            <path
-              className="yak-status-icon__orbit-line"
-              d="M19.45 13.45c-.6 3.23-3.19 5.72-6.45 6.1"
-            />
-            <circle className="yak-status-icon__orbit-node" cx="17.45" cy="7.15" r="1.05" />
-            <circle className="yak-status-icon__orbit-node yak-status-icon__orbit-node--minor" cx="6.35" cy="16.9" r="0.72" />
+          <image
+            className="yak-status-icon__running-image"
+            href={runningWebp}
+            x="0"
+            y="0"
+            width="24"
+            height="24"
+            preserveAspectRatio="xMidYMid meet"
+            aria-hidden="true"
+          />
+          <g
+            className="yak-status-icon__running-reduced-motion"
+            aria-hidden="true"
+          >
+            <StaticRunningGlyph />
           </g>
-          <circle className="yak-status-icon__core" cx="12" cy="12" r="3.15" />
         </>
       );
     case 'pending':
@@ -82,9 +128,24 @@ function StatusGlyph({ status }: { status: YakStatus }) {
         <>
           <StaticSurface />
           <g className="yak-status-icon__dots">
-            <circle className="yak-status-icon__dot yak-status-icon__dot--1" cx="8.7" cy="12" r="1" />
-            <circle className="yak-status-icon__dot yak-status-icon__dot--2" cx="12" cy="12" r="1" />
-            <circle className="yak-status-icon__dot yak-status-icon__dot--3" cx="15.3" cy="12" r="1" />
+            <circle
+              className="yak-status-icon__dot yak-status-icon__dot--1"
+              cx="8.7"
+              cy="12"
+              r="1"
+            />
+            <circle
+              className="yak-status-icon__dot yak-status-icon__dot--2"
+              cx="12"
+              cy="12"
+              r="1"
+            />
+            <circle
+              className="yak-status-icon__dot yak-status-icon__dot--3"
+              cx="15.3"
+              cy="12"
+              r="1"
+            />
           </g>
         </>
       );
@@ -93,14 +154,22 @@ function StatusGlyph({ status }: { status: YakStatus }) {
         <>
           <StaticSurface />
           <path className="yak-status-icon__symbol" d="M12 8.35v4.75" />
-          <circle className="yak-status-icon__symbol-dot" cx="12" cy="15.75" r="1" />
+          <circle
+            className="yak-status-icon__symbol-dot"
+            cx="12"
+            cy="15.75"
+            r="1"
+          />
         </>
       );
     case 'paused':
       return (
         <>
           <StaticSurface />
-          <path className="yak-status-icon__symbol" d="M10 9.05v5.9m4-5.9v5.9" />
+          <path
+            className="yak-status-icon__symbol"
+            d="M10 9.05v5.9m4-5.9v5.9"
+          />
         </>
       );
     case 'canceled':
@@ -118,7 +187,12 @@ function StatusGlyph({ status }: { status: YakStatus }) {
             className="yak-status-icon__symbol"
             d="M9.65 9.7a2.55 2.55 0 0 1 4.91.95c0 1.85-2.56 1.94-2.56 3.18"
           />
-          <circle className="yak-status-icon__symbol-dot" cx="12" cy="16.15" r="0.9" />
+          <circle
+            className="yak-status-icon__symbol-dot"
+            cx="12"
+            cy="16.15"
+            r="0.9"
+          />
         </>
       );
   }
@@ -161,7 +235,7 @@ export default function YakStatusIcon({
       aria-hidden={isAccessible ? undefined : true}
     >
       {title ? <title>{title}</title> : null}
-      <StatusGlyph status={status} />
+      <StatusGlyph status={status} animated={animated} />
     </svg>
   );
 }

--- a/yak-ops-ui/src/typings.d.ts
+++ b/yak-ops-ui/src/typings.d.ts
@@ -8,6 +8,7 @@ declare module '*.png';
 declare module '*.jpg';
 declare module '*.jpeg';
 declare module '*.gif';
+declare module '*.webp';
 declare module '*.bmp';
 declare module '*.tiff';
 declare module 'omit.js';


### PR DESCRIPTION
## 目标

将 `YakStatusIcon` 的 `running` 状态从现有 SVG 轨道动画替换为已经提交到 `src/assets/gif/running.webp` 的动画素材，同时保持组件现有 API 和无障碍行为不变。

## 改动

- `running` + `animated=true` 时在现有 SVG 容器内渲染 `running.webp`。
- 保留 `size`、`className`、`title`、ARIA 和 `data-*` 等现有能力，调用方无需修改。
- `animated=false` 时继续使用原静态 running SVG，避免关闭动画后 WebP 仍播放。
- `prefers-reduced-motion: reduce` 时隐藏 WebP 并回退静态 SVG。
- 补充 `*.webp` TypeScript 资源声明。
- 补充 `YakStatusIcon` 测试，覆盖 WebP running 状态和禁用动画的 fallback。

## 范围

仅调整公共状态图标组件和 WebP 类型声明；其他 status 图标保持原实现不变。

## 验证结果

- ✅ release metadata
- ✅ `yarn install --frozen-lockfile`
- ✅ `yarn build`
- ✅ release version normalize
- ✅ `Package Yak Ops`
- ✅ distribution artifact upload
- ✅ `CI / Validate and build release distribution`

WebP 资源导入和前端生产构建均已通过。