### PR TITLE
fix(boot): stop eager MongoDB localhost connection on startup

### DIFF
--- a/yak-ops-boot/src/main/java/io/yak/ops/boot/YakOpsApplication.java
+++ b/yak-ops-boot/src/main/java/io/yak/ops/boot/YakOpsApplication.java
@@ -4,15 +4,23 @@ import org.apache.ibatis.annotations.Mapper;
 import org.mybatis.spring.annotation.MapperScan;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.boot.autoconfigure.mongo.MongoAutoConfiguration;
 
 /**
  * Yak Ops application entry point.
  *
  * <p>Yak Ops modules are scanned from their shared root package. Yak Framework integrations are
  * loaded through their Spring Boot auto-configuration metadata.</p>
+ *
+ * <p>MongoDB is managed by the datasource plugin and creates clients only for explicit datasource
+ * operations. Spring Boot's generic Mongo auto-configuration is disabled so merely having the
+ * MongoDB driver on the assembled application classpath does not create a default localhost
+ * client during startup.</p>
  */
 @MapperScan(basePackages = "io.yak.ops", annotationClass = Mapper.class)
-@SpringBootApplication(scanBasePackages = "io.yak.ops")
+@SpringBootApplication(
+    scanBasePackages = "io.yak.ops",
+    exclude = MongoAutoConfiguration.class)
 public class YakOpsApplication {
 
   public static void main(String[] args) {

--- a/yak-ops-boot/src/test/java/io/yak/ops/boot/YakOpsApplicationTests.java
+++ b/yak-ops-boot/src/test/java/io/yak/ops/boot/YakOpsApplicationTests.java
@@ -2,14 +2,17 @@ package io.yak.ops.boot;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
+import com.mongodb.client.MongoClient;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.context.ApplicationContext;
 import org.springframework.core.env.Environment;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.web.servlet.MockMvc;
@@ -24,6 +27,9 @@ class YakOpsApplicationTests {
 
   @Autowired
   private Environment environment;
+
+  @Autowired
+  private ApplicationContext applicationContext;
 
   @Test
   void testControllerShouldReturnFrameworkResult() throws Exception {
@@ -51,5 +57,10 @@ class YakOpsApplicationTests {
         environment.getProperty("yak.security.authentication.storage"));
     assertNull(environment.getProperty("yak.security.authentication.mode"));
     assertNull(environment.getProperty("yak.security.session.timeout"));
+  }
+
+  @Test
+  void shouldNotCreateDefaultMongoClientAtStartup() {
+    assertTrue(applicationContext.getBeansOfType(MongoClient.class).isEmpty());
   }
 }


### PR DESCRIPTION
## 问题

Yak Ops 聚合 `yak-ops-plugin-datasource-mongodb` 后，MongoDB Java Driver 会进入 Boot 应用 classpath。Spring Boot 的 `MongoAutoConfiguration` 因此自动创建默认 `MongoClient`，在没有显式 Mongo 配置时尝试连接 `localhost:27017`。

这不是 MongoDB datasource plugin 的业务连接；插件本身已经按需创建和关闭客户端。默认客户端会在应用启动阶段产生无意义的 monitor thread 和 `Connection refused` 堆栈。

## 修复

- 在 `YakOpsApplication` 显式排除 `MongoAutoConfiguration`。
- 保持 MongoDB datasource plugin 的连接测试、catalog 和客户端生命周期不变。
- 增加 Boot 启动回归测试，确保 Spring Context 中不会自动创建默认 `MongoClient`。

## 预期效果

- 未配置/未使用 MongoDB 数据源时，Yak Ops 启动不再探测 `localhost:27017`。
- 创建或测试 MongoDB 数据源时，仍由 `MongoDataSourcePlugin` 根据用户配置按需连接。
- 不通过修改日志级别或吞异常来掩盖真实连接错误。

## 验证结果

- ✅ Backend Compile / Java 21
- ✅ frontend production build
- ✅ Maven `clean package -DskipTests`（包含 test source compilation）
- ✅ release distribution package
- ✅ distribution artifact upload

说明：当前仓库 CI 使用 `-DskipTests`，因此新增的回归测试已通过编译，但 CI 本身不会执行测试方法。