### PR TITLE
style(ui): show four datasource cards per row

### DIFF
--- a/yak-ops-ui/src/pages/data-source/index.tsx
+++ b/yak-ops-ui/src/pages/data-source/index.tsx
@@ -179,7 +179,7 @@ const DataSourcePage = () => {
                   className={
                     viewMode === 'list'
                       ? 'grid grid-cols-1 gap-[14px]'
-                      : 'grid grid-cols-1 gap-[14px] md:grid-cols-2 2xl:grid-cols-3'
+                      : 'grid grid-cols-1 gap-[14px] md:grid-cols-2 xl:grid-cols-3 2xl:grid-cols-4'
                   }
                 >
                   {records.map((record, index) => (


### PR DESCRIPTION
## Summary

- increase the datasource card grid density from three to four columns on wide desktop screens
- keep the layout responsive: 1 column by default, 2 on medium screens, 3 on extra-large screens, and 4 on 2XL screens
- leave list view and datasource card content unchanged

## Why

The datasource page has enough horizontal space on desktop, and three cards per row leaves the list feeling unnecessarily sparse. A four-column wide-screen layout improves scanability and makes better use of the available canvas without changing the card interaction model.

## Scope

- frontend datasource list layout only
- no pagination, datasource API, or card behavior changes

## Validation

- branch is based on current `main`
- diff is limited to the responsive grid class in the datasource page
- CI checks pending on this draft PR
