### PR TITLE
refactor(ui): simplify home workbench hierarchy

### DIFF
--- a/yak-ops-ui/src/pages/home/HomePage.tsx
+++ b/yak-ops-ui/src/pages/home/HomePage.tsx
@@ -23,15 +23,16 @@ export default function HomePage() {
           </div>
 
           <div className="mt-4 grid grid-cols-1 items-start gap-4 xl:grid-cols-[minmax(0,1fr)_380px] 2xl:grid-cols-[minmax(0,1fr)_410px]">
-            <div className="min-w-0 space-y-4">
-              <DataCenter />
-              <HomeWorkbenchMain />
-            </div>
+            <DataCenter />
 
             <aside className="min-w-0 space-y-4">
               <NotificationCenter />
               <ScheduleCenter />
             </aside>
+          </div>
+
+          <div className="mt-4">
+            <HomeWorkbenchMain />
           </div>
         </main>
       </div>

--- a/yak-ops-ui/src/pages/home/HomePage.tsx
+++ b/yak-ops-ui/src/pages/home/HomePage.tsx
@@ -1,10 +1,7 @@
 import DataCenter from './components/DataCenter';
 import { HomeBackground } from './components/HomeBackground';
 import { HomeHeader } from './components/HomeHeader';
-import {
-  HomeWorkbenchMain,
-  HomeWorkbenchSidebar,
-} from './components/HomeWorkbench';
+import { HomeWorkbenchMain } from './components/HomeWorkbench';
 import NotificationCenter from './components/NotificationCenter';
 import { QuickCreatePanel } from './components/QuickCreatePanel';
 import ScheduleCenter from './components/ScheduleCenter';
@@ -34,7 +31,6 @@ export default function HomePage() {
             <aside className="min-w-0 space-y-4">
               <NotificationCenter />
               <ScheduleCenter />
-              <HomeWorkbenchSidebar />
             </aside>
           </div>
         </main>

--- a/yak-ops-ui/src/pages/home/components/DataCenter/index.tsx
+++ b/yak-ops-ui/src/pages/home/components/DataCenter/index.tsx
@@ -98,7 +98,7 @@ export default function DataCenter() {
             }
           />
 
-          <div className="h-[263px] overflow-y-auto overflow-x-hidden pr-1">
+          <div className="h-[263px] overflow-auto pr-1">
             {activeTab === 'overview' && (
               <OverviewPanel
                 overview={overview}

--- a/yak-ops-ui/src/pages/home/components/DataCenter/index.tsx
+++ b/yak-ops-ui/src/pages/home/components/DataCenter/index.tsx
@@ -46,8 +46,8 @@ export default function DataCenter() {
     : formatDate(fallbackPeriod.end);
 
   return (
-    <section className="min-w-0 rounded-[22px] border border-[#f0f1f3] bg-white px-6 pb-5 pt-5">
-      <header className="flex flex-wrap items-center justify-between gap-x-4 gap-y-2">
+    <section className="flex min-w-0 flex-col rounded-[22px] border border-[#f0f1f3] bg-white px-6 pb-5 pt-5 lg:h-[400px] lg:overflow-hidden">
+      <header className="flex shrink-0 flex-wrap items-center justify-between gap-x-4 gap-y-2">
         <div className="flex min-w-0 items-center gap-1.5">
           <h2 className="shrink-0 text-xl font-semibold tracking-[-0.35px] text-[#252832]">
             {intl.formatMessage({ id: 'pages.home.dataCenter.title' })}
@@ -74,14 +74,14 @@ export default function DataCenter() {
         </button>
       </header>
 
-      <div className="mt-4 flex flex-col gap-5 lg:flex-row lg:gap-6">
+      <div className="mt-4 flex flex-col gap-5 lg:min-h-0 lg:flex-1 lg:flex-row lg:gap-6 lg:overflow-hidden">
         <LatestTaskCard
           task={overview?.latestTask}
           loading={overviewLoading}
           failed={overviewFailed}
         />
 
-        <div className="min-w-0 flex-1">
+        <div className="min-w-0 flex-1 lg:min-h-0 lg:overflow-hidden">
           <YakTab
             activeKey={activeTab}
             onChange={(key) => setActiveTab(key as HomeDataCenterTabKey)}
@@ -98,32 +98,34 @@ export default function DataCenter() {
             }
           />
 
-          {activeTab === 'overview' && (
-            <OverviewPanel
-              overview={overview}
-              periodKey={periodKey}
-              periodLabel={periodLabel}
-              loading={overviewLoading}
-              failed={overviewFailed}
-            />
-          )}
+          <div className="h-[263px] overflow-y-auto overflow-x-hidden pr-1">
+            {activeTab === 'overview' && (
+              <OverviewPanel
+                overview={overview}
+                periodKey={periodKey}
+                periodLabel={periodLabel}
+                loading={overviewLoading}
+                failed={overviewFailed}
+              />
+            )}
 
-          {activeTab === 'recent' && (
-            <RecentTasksPanel
-              items={recentTasks}
-              loading={recentLoading}
-              failed={recentFailed}
-            />
-          )}
+            {activeTab === 'recent' && (
+              <RecentTasksPanel
+                items={recentTasks}
+                loading={recentLoading}
+                failed={recentFailed}
+              />
+            )}
 
-          {activeTab === 'schedule' && (
-            <SchedulePanel
-              items={scheduleItems}
-              periodLabel={periodLabel}
-              loading={scheduleLoading}
-              failed={scheduleFailed}
-            />
-          )}
+            {activeTab === 'schedule' && (
+              <SchedulePanel
+                items={scheduleItems}
+                periodLabel={periodLabel}
+                loading={scheduleLoading}
+                failed={scheduleFailed}
+              />
+            )}
+          </div>
         </div>
       </div>
     </section>

--- a/yak-ops-ui/src/pages/home/components/HomeDataServiceOverview.tsx
+++ b/yak-ops-ui/src/pages/home/components/HomeDataServiceOverview.tsx
@@ -59,6 +59,7 @@ export default function HomeDataServiceOverview() {
   return (
     <section className="flex h-[188px] min-w-0 flex-col rounded-[18px] border border-[#f0f1f3] bg-white px-5 pb-4 pt-4">
       <SectionHeader
+        compact
         title={intl.formatMessage({ id: 'pages.home.dataService.title' })}
         onMore={() => history.push('/data-service/overview')}
       />
@@ -77,20 +78,20 @@ export default function HomeDataServiceOverview() {
                 {intl.formatMessage({ id: 'pages.home.dataService.metric.apiTotal' })}
               </span>
             </div>
-            <div className="mt-1 flex items-center gap-3 text-[10px] text-[#8f949d]">
-              <span>
+            <div className="mt-1 grid grid-cols-3 gap-3 text-[9px] text-[#8f949d]">
+              <span className="min-w-0 truncate">
                 {intl.formatMessage({ id: 'pages.home.dataService.metric.running' })}{' '}
                 <strong className="font-semibold text-[#555a64]">
                   {formatMetric(data?.runningApis, intl.locale)}
                 </strong>
               </span>
-              <span>
+              <span className="min-w-0 truncate">
                 {intl.formatMessage({ id: 'pages.home.dataService.metric.successRate' })}{' '}
                 <strong className="font-semibold text-[#555a64]">
                   {formatRate(data)}
                 </strong>
               </span>
-              <span>
+              <span className="min-w-0 truncate">
                 {intl.formatMessage({ id: 'pages.home.dataService.metric.calls7d' })}{' '}
                 <strong className="font-semibold text-[#555a64]">
                   {formatMetric(data?.totalCalls, intl.locale)}

--- a/yak-ops-ui/src/pages/home/components/HomeDataServiceOverview.tsx
+++ b/yak-ops-ui/src/pages/home/components/HomeDataServiceOverview.tsx
@@ -3,12 +3,9 @@ import {
   type DataServiceOverview,
 } from '@/services/data-service';
 import { history, useIntl } from '@umijs/max';
-import type { EChartsOption } from 'echarts';
-import ReactECharts from 'echarts-for-react';
-import { Activity } from 'lucide-react';
-import { useEffect, useMemo, useState } from 'react';
+import { Activity, ChevronRight, Server } from 'lucide-react';
+import { useEffect, useState } from 'react';
 
-import { HomeEmptyState } from './HomeEmptyState';
 import { SectionHeader } from './homeAssetOverviewShared';
 
 interface DataServiceOverviewState {
@@ -31,6 +28,7 @@ function useDataServiceOverview(): DataServiceOverviewState {
 
   useEffect(() => {
     let active = true;
+
     getDataServiceOverview('7d')
       .then((data) => {
         if (!active) return;
@@ -52,209 +50,85 @@ function useDataServiceOverview(): DataServiceOverviewState {
   return state;
 }
 
-function buildTrendOption(
-  data: DataServiceOverview | undefined,
-  seriesName: string,
-): EChartsOption {
-  const trend = data?.trend || [];
-  return {
-    animation: true,
-    animationDuration: 520,
-    tooltip: {
-      trigger: 'axis',
-      backgroundColor: '#fff',
-      borderColor: '#e8ebef',
-      textStyle: { color: '#4b5059', fontSize: 10 },
-    },
-    grid: { top: 10, left: 8, right: 8, bottom: 22, containLabel: false },
-    xAxis: {
-      type: 'category',
-      boundaryGap: false,
-      data: trend.map((item) => item.time),
-      axisLine: { show: false },
-      axisTick: { show: false },
-      axisLabel: {
-        interval: 3,
-        color: '#a0a4ac',
-        fontSize: 9,
-        formatter: (value: string) => value.slice(0, 5),
-      },
-    },
-    yAxis: {
-      type: 'value',
-      minInterval: 1,
-      axisLine: { show: false },
-      axisTick: { show: false },
-      axisLabel: { show: false },
-      splitLine: { lineStyle: { color: '#f1f3f6' } },
-    },
-    series: [
-      {
-        name: seriesName,
-        type: 'line',
-        smooth: 0.38,
-        symbol: 'none',
-        data: trend.map((item) => item.calls),
-        lineStyle: { width: 2, color: '#6490ee' },
-        areaStyle: {
-          color: {
-            type: 'linear',
-            x: 0,
-            y: 0,
-            x2: 0,
-            y2: 1,
-            colorStops: [
-              { offset: 0, color: 'rgba(100,144,238,0.18)' },
-              { offset: 1, color: 'rgba(100,144,238,0.01)' },
-            ],
-          },
-        },
-      },
-    ],
-  };
-}
-
-function OverviewMetric({ label, value }: { label: string; value: string }) {
-  return (
-    <div className="min-w-0 px-4 first:pl-0 last:pr-0">
-      <div className="truncate text-[11px] text-[#92969f]">{label}</div>
-      <strong className="mt-1 block truncate text-[24px] font-semibold tracking-[-0.6px] text-[#30343d]">
-        {value}
-      </strong>
-    </div>
-  );
-}
-
-function TrendEmpty({ state }: { state: DataServiceOverviewState }) {
-  const intl = useIntl();
-  if (state.loading || state.failed) {
-    return (
-      <div className="flex h-[126px] items-center justify-center text-[11px] text-[#a0a4ac]">
-        {intl.formatMessage({
-          id: state.loading
-            ? 'pages.home.dataService.loading'
-            : 'pages.home.dataService.failed',
-        })}
-      </div>
-    );
-  }
-
-  return (
-    <HomeEmptyState
-      icon={Activity}
-      title={intl.formatMessage({ id: 'pages.home.dataService.empty' })}
-      size="small"
-      className="h-[126px]"
-    />
-  );
-}
-
 export default function HomeDataServiceOverview() {
   const intl = useIntl();
   const state = useDataServiceOverview();
   const data = state.data;
-  const seriesName = intl.formatMessage({ id: 'pages.home.dataService.series.calls' });
-  const trendOption = useMemo(
-    () => buildTrendOption(data, seriesName),
-    [data, seriesName],
-  );
-  const hasCalls = (data?.totalCalls || 0) > 0;
   const topApi = data?.hotApis?.[0];
 
   return (
-    <section className="rounded-[22px] border border-[#f0f1f3] bg-white px-6 pb-5 pt-5">
+    <section className="flex h-[188px] min-w-0 flex-col rounded-[18px] border border-[#f0f1f3] bg-white px-5 pb-4 pt-4">
       <SectionHeader
         title={intl.formatMessage({ id: 'pages.home.dataService.title' })}
-        description=""
         onMore={() => history.push('/data-service/overview')}
       />
 
-      <div className="mt-5">
-        <div className="grid grid-cols-2 divide-x divide-[#eef0f3] lg:grid-cols-4">
-          <OverviewMetric
-            label={intl.formatMessage({ id: 'pages.home.dataService.metric.apiTotal' })}
-            value={formatMetric(data?.apiTotal, intl.locale)}
-          />
-          <OverviewMetric
-            label={intl.formatMessage({ id: 'pages.home.dataService.metric.running' })}
-            value={formatMetric(data?.runningApis, intl.locale)}
-          />
-          <OverviewMetric
-            label={intl.formatMessage({ id: 'pages.home.dataService.metric.calls7d' })}
-            value={formatMetric(data?.totalCalls, intl.locale)}
-          />
-          <OverviewMetric
-            label={intl.formatMessage({ id: 'pages.home.dataService.metric.successRate' })}
-            value={formatRate(data)}
-          />
-        </div>
-
-        <div className="mt-5 flex items-center justify-between gap-3 text-[10px] text-[#9da1a9]">
-          <span>{intl.formatMessage({ id: 'pages.home.dataService.trend' })}</span>
-          {data ? (
-            <span className="truncate text-right">
-              {intl.formatMessage(
-                { id: 'pages.home.dataService.summary' },
-                {
-                  duration: formatMetric(data.averageDurationMs, intl.locale),
-                  failures: formatMetric(data.failureCalls, intl.locale),
-                },
-              )}
-            </span>
-          ) : (
-            <span>
-              {state.failed
-                ? intl.formatMessage({ id: 'pages.home.dataService.unavailable' })
-                : '--'}
-            </span>
-          )}
-        </div>
-
-        <div className="mt-1 h-[126px]">
-          {hasCalls ? (
-            <ReactECharts
-              option={trendOption}
-              style={{ width: '100%', height: '126px' }}
-              notMerge
-              lazyUpdate
-            />
-          ) : (
-            <TrendEmpty state={state} />
-          )}
-        </div>
-
-        <div className="mt-2 flex min-h-[30px] items-center justify-between gap-3 border-t border-[#f0f1f3] pt-3 text-[10px]">
-          <span className="shrink-0 text-[#9da1a9]">
-            {intl.formatMessage({ id: 'pages.home.dataService.mostCalled' })}
+      <div className="mt-3 flex min-h-0 flex-1 flex-col justify-between">
+        <div className="flex items-center gap-3">
+          <span className="flex h-10 w-10 shrink-0 items-center justify-center rounded-[11px] bg-[#eef5ff] text-[#6490ee]">
+            <Server size={18} strokeWidth={1.8} />
           </span>
-          {topApi ? (
-            <button
-              type="button"
-              onClick={() => history.push('/data-service/overview')}
-              className="min-w-0 border-0 bg-transparent p-0 text-right text-[#646a74] transition-colors hover:text-[#343842]"
-            >
-              <span className="block truncate">
-                {topApi.name || topApi.path || `API #${topApi.apiId}`}
-                <strong className="ml-1 font-semibold text-[#454a54]">
-                  {intl.formatMessage(
-                    { id: 'pages.home.dataService.calls' },
-                    { count: formatMetric(topApi.calls, intl.locale) },
-                  )}
+          <div className="min-w-0 flex-1">
+            <div className="flex items-baseline gap-2">
+              <strong className="text-[25px] font-semibold leading-7 tracking-[-0.6px] text-[#30343d]">
+                {formatMetric(data?.apiTotal, intl.locale)}
+              </strong>
+              <span className="text-[10px] text-[#969aa3]">
+                {intl.formatMessage({ id: 'pages.home.dataService.metric.apiTotal' })}
+              </span>
+            </div>
+            <div className="mt-1 flex items-center gap-3 text-[10px] text-[#8f949d]">
+              <span>
+                {intl.formatMessage({ id: 'pages.home.dataService.metric.running' })}{' '}
+                <strong className="font-semibold text-[#555a64]">
+                  {formatMetric(data?.runningApis, intl.locale)}
                 </strong>
               </span>
-            </button>
-          ) : (
-            <span className="truncate text-right text-[#a0a4ac]">
-              {intl.formatMessage({
-                id: state.loading
-                  ? 'pages.home.dataCenter.latest.loading'
-                  : state.failed
-                    ? 'pages.home.dataService.unavailable'
-                    : 'pages.home.dataService.noCalls',
-              })}
-            </span>
-          )}
+              <span>
+                {intl.formatMessage({ id: 'pages.home.dataService.metric.successRate' })}{' '}
+                <strong className="font-semibold text-[#555a64]">
+                  {formatRate(data)}
+                </strong>
+              </span>
+              <span>
+                {intl.formatMessage({ id: 'pages.home.dataService.metric.calls7d' })}{' '}
+                <strong className="font-semibold text-[#555a64]">
+                  {formatMetric(data?.totalCalls, intl.locale)}
+                </strong>
+              </span>
+            </div>
+          </div>
         </div>
+
+        <button
+          type="button"
+          onClick={() => history.push('/data-service/overview')}
+          className="group flex h-9 w-full items-center gap-2 rounded-[9px] border-0 bg-[#f8f9fb] px-3 text-left"
+        >
+          <Activity size={13} strokeWidth={1.8} className="shrink-0 text-[#7192d9]" />
+          <span className="shrink-0 text-[10px] text-[#92969f]">
+            {intl.formatMessage({ id: 'pages.home.dataService.mostCalled' })}
+          </span>
+          <span className="min-w-0 flex-1 truncate text-[10px] text-[#5f6570]">
+            {topApi
+              ? topApi.name || topApi.path || `API #${topApi.apiId}`
+              : state.loading
+                ? intl.formatMessage({ id: 'pages.home.dataService.loading' })
+                : state.failed
+                  ? intl.formatMessage({ id: 'pages.home.dataService.failed' })
+                  : intl.formatMessage({ id: 'pages.home.dataService.noCalls' })}
+          </span>
+          {topApi ? (
+            <strong className="shrink-0 text-[10px] font-semibold text-[#454a54]">
+              {formatMetric(topApi.calls, intl.locale)}
+            </strong>
+          ) : null}
+          <ChevronRight
+            size={12}
+            strokeWidth={1.8}
+            className="shrink-0 text-[#b5b9c0] transition-transform group-hover:translate-x-0.5"
+          />
+        </button>
       </div>
     </section>
   );

--- a/yak-ops-ui/src/pages/home/components/HomeDatasetOverview.tsx
+++ b/yak-ops-ui/src/pages/home/components/HomeDatasetOverview.tsx
@@ -1,5 +1,5 @@
 import { history, useIntl } from '@umijs/max';
-import { Boxes, ChevronRight, Database, Table2 } from 'lucide-react';
+import { Boxes, ChevronRight, Table2 } from 'lucide-react';
 
 import {
   formatMetric,
@@ -85,6 +85,10 @@ export function DatasetOverview({ state }: { state: HomeAssetOverviewState }) {
   const intl = useIntl();
   const dataset = state.data?.dataset;
   const items = dataset?.recentDatasets?.slice(0, 4) ?? [];
+  const todayCreated =
+    dataset?.todayCreatedCount == null
+      ? '--'
+      : `+${formatMetric(dataset.todayCreatedCount, intl.locale)}`;
 
   return (
     <section className="rounded-[20px] border border-[#f0f1f3] bg-white px-5 pb-5 pt-5">
@@ -114,7 +118,7 @@ export function DatasetOverview({ state }: { state: HomeAssetOverviewState }) {
                 {intl.formatMessage({ id: 'pages.home.dataset.todayCreated' })}
               </span>
               <strong className="mt-1 block text-[17px] font-semibold text-[#343842]">
-                +{formatMetric(dataset?.todayCreatedCount, intl.locale)}
+                {todayCreated}
               </strong>
             </div>
           </div>

--- a/yak-ops-ui/src/pages/home/components/HomeDatasetOverview.tsx
+++ b/yak-ops-ui/src/pages/home/components/HomeDatasetOverview.tsx
@@ -2,7 +2,6 @@ import { history, useIntl } from '@umijs/max';
 import { Boxes, ChevronRight, Database, Table2 } from 'lucide-react';
 
 import {
-  EmptyList,
   formatMetric,
   type HomeAssetOverviewState,
   relativeTime,
@@ -10,104 +9,28 @@ import {
 } from './homeAssetOverviewShared';
 import type { HomeAssetDatasetItem } from './service';
 
-function datasetStatusLabel(status: string | undefined, formatMessage: (id: string) => string) {
+function datasetStatusLabel(
+  status: string | undefined,
+  formatMessage: (id: string) => string,
+) {
   const normalized = status?.toUpperCase();
-  if (normalized === 'ONLINE') return formatMessage('pages.home.dataset.status.online');
-  if (normalized === 'OFFLINE') return formatMessage('pages.home.dataset.status.offline');
+  if (normalized === 'ONLINE') {
+    return formatMessage('pages.home.dataset.status.online');
+  }
+  if (normalized === 'OFFLINE') {
+    return formatMessage('pages.home.dataset.status.offline');
+  }
   return status || formatMessage('pages.home.dataset.status.unknown');
-}
-
-function AssetOverviewColumn({ state }: { state: HomeAssetOverviewState }) {
-  const intl = useIntl();
-  const dataset = state.data?.dataset;
-  const metrics = [
-    {
-      label: intl.formatMessage({ id: 'pages.home.dataset.metric.dataset' }),
-      value: dataset?.datasetCount,
-      icon: <Database size={17} strokeWidth={1.8} />,
-    },
-    {
-      label: intl.formatMessage({ id: 'pages.home.dataset.metric.lineageTable' }),
-      value: dataset?.tableAssetCount,
-      icon: <Table2 size={17} strokeWidth={1.8} />,
-    },
-    {
-      label: intl.formatMessage({ id: 'pages.home.dataset.metric.lineageColumn' }),
-      value: dataset?.columnAssetCount,
-      icon: <Boxes size={17} strokeWidth={1.8} />,
-    },
-  ];
-
-  return (
-    <div className="min-w-0 lg:pr-6">
-      <div className="flex items-center gap-3 border-b border-[#eef0f3] pb-3">
-        <strong className="text-[13px] font-semibold text-[#343842]">
-          {intl.formatMessage({ id: 'pages.home.dataset.overview' })}
-        </strong>
-        <span className="text-[11px] text-[#9da1a9]">
-          {intl.formatMessage({ id: 'pages.home.dataset.inLineage' })}
-        </span>
-      </div>
-
-      <div className="mt-4 space-y-4">
-        {metrics.map((item) => (
-          <button
-            key={item.label}
-            type="button"
-            onClick={() => history.push('/data-analysis/data-catalog')}
-            className="group flex w-full items-center gap-3 border-0 bg-transparent p-0 text-left"
-          >
-            <span className="flex h-10 w-10 shrink-0 items-center justify-center rounded-[10px] bg-[#f2f5ff] text-[#637be7] transition-colors group-hover:bg-[#eaf0ff]">
-              {item.icon}
-            </span>
-            <span className="min-w-0 flex-1">
-              <span className="block text-[11px] leading-5 text-[#92969f]">
-                {item.label}
-              </span>
-              <strong className="mt-0.5 block text-[22px] font-semibold leading-7 tracking-[-0.6px] text-[#2f333c]">
-                {formatMetric(item.value, intl.locale)}
-              </strong>
-            </span>
-            <ChevronRight
-              size={14}
-              strokeWidth={1.8}
-              className="text-[#c1c4ca] opacity-0 transition-all group-hover:translate-x-0.5 group-hover:opacity-100"
-            />
-          </button>
-        ))}
-      </div>
-
-      <div className="mt-5 rounded-[10px] bg-[#f7f8fa] px-3 py-3">
-        <div className="flex items-center justify-between">
-          <span className="text-[11px] text-[#8e939c]">
-            {intl.formatMessage({ id: 'pages.home.dataset.todayCreated' })}
-          </span>
-          <span className="text-[10px] text-[#a0a4ac]">
-            {state.failed
-              ? intl.formatMessage({ id: 'pages.home.common.loadFailed' })
-              : intl.formatMessage({ id: 'pages.home.dataset.realtimeStats' })}
-          </span>
-        </div>
-        <div className="mt-1 flex items-baseline gap-2">
-          <strong className="text-[18px] font-semibold text-[#343842]">
-            {formatMetric(dataset?.todayCreatedCount, intl.locale)}
-          </strong>
-          <span className="text-[10px] text-[#a0a4ac]">
-            {intl.formatMessage({ id: 'pages.home.dataset.unit' })}
-          </span>
-        </div>
-      </div>
-    </div>
-  );
 }
 
 function DatasetRow({ item }: { item: HomeAssetDatasetItem }) {
   const intl = useIntl();
+
   return (
     <button
       type="button"
       onClick={() => history.push('/data-analysis/data-catalog')}
-      className="group flex w-full items-center gap-3 rounded-[8px] border-0 bg-transparent px-1 py-[11px] text-left transition-colors hover:bg-[#f7f8fa]"
+      className="group flex w-full items-center gap-3 rounded-[8px] border-0 bg-transparent px-2 py-2 text-left transition-colors hover:bg-[#f7f8fa]"
     >
       <span className="flex h-8 w-8 shrink-0 items-center justify-center rounded-[8px] bg-[#f1f4f8] text-[#69717e]">
         <Table2 size={15} strokeWidth={1.8} />
@@ -117,131 +40,129 @@ function DatasetRow({ item }: { item: HomeAssetDatasetItem }) {
           {item.name}
         </strong>
         <span className="mt-0.5 block truncate text-[10px] leading-4 text-[#9ca0a8]">
-          {datasetStatusLabel(item.status, (id) => intl.formatMessage({ id }))} · #{item.id}
+          {datasetStatusLabel(item.status, (id) => intl.formatMessage({ id }))}
         </span>
       </span>
       <span className="shrink-0 text-[10px] text-[#a0a4ac]">
         {relativeTime(item.updatedAt, intl.locale)}
       </span>
+      <ChevronRight
+        size={13}
+        strokeWidth={1.8}
+        className="shrink-0 text-[#c0c4cb] transition-transform group-hover:translate-x-0.5"
+      />
     </button>
   );
 }
 
-function RecentDatasetColumn({ state }: { state: HomeAssetOverviewState }) {
+function Metric({
+  icon,
+  label,
+  value,
+}: {
+  icon: React.ReactNode;
+  label: string;
+  value?: number | null;
+}) {
   const intl = useIntl();
-  const items = state.data?.dataset?.recentDatasets || [];
+
   return (
-    <div className="min-w-0 border-t border-[#eef0f3] py-5 lg:border-l lg:border-t-0 lg:px-6 lg:py-0">
-      <div className="flex items-center gap-3 border-b border-[#eef0f3] pb-3">
-        <strong className="text-[13px] font-semibold text-[#343842]">
-          {intl.formatMessage({ id: 'pages.home.dataset.recentUpdated' })}
+    <div className="flex min-w-0 items-center gap-3">
+      <span className="flex h-9 w-9 shrink-0 items-center justify-center rounded-[10px] bg-[#f3f5fb] text-[#6c7fd3]">
+        {icon}
+      </span>
+      <span className="min-w-0">
+        <span className="block truncate text-[10px] text-[#969aa3]">{label}</span>
+        <strong className="mt-0.5 block text-[18px] font-semibold leading-6 text-[#343842]">
+          {formatMetric(value, intl.locale)}
         </strong>
-        <span className="text-[11px] text-[#9da1a9]">
-          {intl.formatMessage({ id: 'pages.home.dataset.byUpdatedAt' })}
-        </span>
-      </div>
-
-      {items.length > 0 ? (
-        <div className="mt-1">
-          {items.map((item) => (
-            <DatasetRow key={item.id} item={item} />
-          ))}
-        </div>
-      ) : (
-        <EmptyList
-          loading={state.loading}
-          failed={state.failed}
-          unavailable={state.data?.dataset?.datasetCount == null}
-          text={intl.formatMessage({ id: 'pages.home.dataset.empty' })}
-          icon={Table2}
-        />
-      )}
-    </div>
-  );
-}
-
-function OnlineDatasetColumn({ state }: { state: HomeAssetOverviewState }) {
-  const intl = useIntl();
-  const items = state.data?.dataset?.onlineDatasets || [];
-  return (
-    <div className="min-w-0 border-t border-[#eef0f3] pt-5 lg:border-l lg:border-t-0 lg:pl-6 lg:pt-0">
-      <div className="flex items-center gap-3 border-b border-[#eef0f3] pb-3">
-        <strong className="text-[13px] font-semibold text-[#343842]">
-          {intl.formatMessage({ id: 'pages.home.dataset.onlineTitle' })}
-        </strong>
-        <span className="text-[11px] text-[#9da1a9]">
-          {intl.formatMessage({ id: 'pages.home.dataset.byUpdatedAt' })}
-        </span>
-      </div>
-
-      {items.length > 0 ? (
-        <div className="mt-1">
-          {items.map((item, index) => {
-            const rankClassName =
-              index === 0
-                ? 'bg-[#ff4d68]'
-                : index === 1
-                  ? 'bg-[#ff8c31]'
-                  : index === 2
-                    ? 'bg-[#e9b919]'
-                    : 'bg-[#999da5]';
-            return (
-              <button
-                key={item.id}
-                type="button"
-                onClick={() => history.push('/data-analysis/data-catalog')}
-                className="group flex w-full items-center gap-3 rounded-[8px] border-0 bg-transparent px-1 py-[11px] text-left transition-colors hover:bg-[#f7f8fa]"
-              >
-                <span
-                  className={`flex h-[18px] w-[18px] shrink-0 items-center justify-center rounded-[4px] text-[10px] font-semibold text-white ${rankClassName}`}
-                >
-                  {index + 1}
-                </span>
-                <span className="min-w-0 flex-1 truncate text-[12px] text-[#454952]">
-                  {item.name}
-                </span>
-                <span className="shrink-0 text-[10px] text-[#999da5]">
-                  {relativeTime(item.updatedAt, intl.locale)}
-                </span>
-              </button>
-            );
-          })}
-        </div>
-      ) : (
-        <EmptyList
-          loading={state.loading}
-          failed={state.failed}
-          unavailable={state.data?.dataset?.datasetCount == null}
-          text={intl.formatMessage({ id: 'pages.home.dataset.emptyOnline' })}
-          icon={Database}
-        />
-      )}
-
-      <button
-        type="button"
-        onClick={() => history.push('/data-analysis/data-catalog')}
-        className="mx-auto mt-3 flex items-center gap-0.5 border-0 bg-transparent px-3 py-1 text-[11px] text-[#868b94] transition-colors hover:text-[#343842]"
-      >
-        {intl.formatMessage({ id: 'pages.home.common.viewAll' })}
-        <ChevronRight size={12} strokeWidth={1.8} />
-      </button>
+      </span>
     </div>
   );
 }
 
 export function DatasetOverview({ state }: { state: HomeAssetOverviewState }) {
   const intl = useIntl();
+  const dataset = state.data?.dataset;
+  const items = dataset?.recentDatasets?.slice(0, 4) ?? [];
+
   return (
-    <section className="rounded-[22px] border border-[#f0f1f3] bg-white px-6 pb-6 pt-5">
+    <section className="rounded-[20px] border border-[#f0f1f3] bg-white px-5 pb-5 pt-5">
       <SectionHeader
         title={intl.formatMessage({ id: 'pages.home.dataset.title' })}
-        description=""
         onMore={() => history.push('/data-analysis/data-catalog')}
       />
-      <div className="mt-5 grid grid-cols-1 lg:grid-cols-[0.76fr_1.15fr_1fr]">
-        <AssetOverviewColumn state={state} />
-        <RecentDatasetColumn state={state} />
-        <OnlineDatasetColumn state={state} />
+
+      <div className="mt-4 grid grid-cols-1 gap-5 lg:grid-cols-[290px_minmax(0,1fr)] lg:gap-6">
+        <div className="rounded-[14px] bg-[#f8f9fb] px-4 py-4">
+          <div className="flex items-end justify-between gap-4 border-b border-[#eceef2] pb-3">
+            <div>
+              <span className="text-[10px] text-[#92969f]">
+                {intl.formatMessage({ id: 'pages.home.dataset.metric.dataset' })}
+              </span>
+              <div className="mt-1 flex items-baseline gap-2">
+                <strong className="text-[30px] font-semibold leading-8 tracking-[-0.8px] text-[#2f333c]">
+                  {formatMetric(dataset?.datasetCount, intl.locale)}
+                </strong>
+                <span className="text-[10px] text-[#9da1a9]">
+                  {intl.formatMessage({ id: 'pages.home.dataset.unit' })}
+                </span>
+              </div>
+            </div>
+            <div className="text-right">
+              <span className="text-[10px] text-[#92969f]">
+                {intl.formatMessage({ id: 'pages.home.dataset.todayCreated' })}
+              </span>
+              <strong className="mt-1 block text-[17px] font-semibold text-[#343842]">
+                +{formatMetric(dataset?.todayCreatedCount, intl.locale)}
+              </strong>
+            </div>
+          </div>
+
+          <div className="mt-4 grid grid-cols-2 gap-4">
+            <Metric
+              icon={<Table2 size={16} strokeWidth={1.8} />}
+              label={intl.formatMessage({ id: 'pages.home.dataset.metric.lineageTable' })}
+              value={dataset?.tableAssetCount}
+            />
+            <Metric
+              icon={<Boxes size={16} strokeWidth={1.8} />}
+              label={intl.formatMessage({ id: 'pages.home.dataset.metric.lineageColumn' })}
+              value={dataset?.columnAssetCount}
+            />
+          </div>
+        </div>
+
+        <div className="min-w-0">
+          <div className="flex items-center justify-between gap-3 pb-2">
+            <strong className="text-[12px] font-semibold text-[#454a53]">
+              {intl.formatMessage({ id: 'pages.home.dataset.recentUpdated' })}
+            </strong>
+            <span className="text-[10px] text-[#9da1a9]">
+              {intl.formatMessage({ id: 'pages.home.dataset.byUpdatedAt' })}
+            </span>
+          </div>
+
+          {items.length > 0 ? (
+            <div className="grid grid-cols-1 gap-x-3 sm:grid-cols-2">
+              {items.map((item) => (
+                <DatasetRow key={item.id} item={item} />
+              ))}
+            </div>
+          ) : (
+            <button
+              type="button"
+              onClick={() => history.push('/data-analysis/data-catalog')}
+              className="flex h-[108px] w-full items-center justify-center rounded-[12px] border border-dashed border-[#e3e6eb] bg-[#fafbfc] text-[11px] text-[#9da1a8]"
+            >
+              {state.loading
+                ? intl.formatMessage({ id: 'pages.home.common.loading' })
+                : state.failed
+                  ? intl.formatMessage({ id: 'pages.home.common.loadFailed' })
+                  : intl.formatMessage({ id: 'pages.home.dataset.empty' })}
+            </button>
+          )}
+        </div>
       </div>
     </section>
   );

--- a/yak-ops-ui/src/pages/home/components/HomeDatasetOverview.tsx
+++ b/yak-ops-ui/src/pages/home/components/HomeDatasetOverview.tsx
@@ -148,7 +148,7 @@ export function DatasetOverview({ state }: { state: HomeAssetOverviewState }) {
           </div>
 
           {items.length > 0 ? (
-            <div className="grid grid-cols-1 gap-x-3 sm:grid-cols-2">
+            <div className="grid grid-cols-1 gap-x-3 sm:grid-cols-2 xl:grid-cols-4">
               {items.map((item) => (
                 <DatasetRow key={item.id} item={item} />
               ))}
@@ -157,7 +157,7 @@ export function DatasetOverview({ state }: { state: HomeAssetOverviewState }) {
             <button
               type="button"
               onClick={() => history.push('/data-analysis/data-catalog')}
-              className="flex h-[108px] w-full items-center justify-center rounded-[12px] border border-dashed border-[#e3e6eb] bg-[#fafbfc] text-[11px] text-[#9da1a8]"
+              className="flex h-[84px] w-full items-center justify-center rounded-[12px] border border-dashed border-[#e3e6eb] bg-[#fafbfc] text-[11px] text-[#9da1a8]"
             >
               {state.loading
                 ? intl.formatMessage({ id: 'pages.home.common.loading' })

--- a/yak-ops-ui/src/pages/home/components/HomeLineageOverview.tsx
+++ b/yak-ops-ui/src/pages/home/components/HomeLineageOverview.tsx
@@ -1,172 +1,14 @@
-import YakOpsEmpty from '@/components/YakOpsEmpty';
 import { history, useIntl } from '@umijs/max';
-import type { EChartsOption } from 'echarts';
-import ReactECharts from 'echarts-for-react';
-import { Activity } from 'lucide-react';
-import { useMemo } from 'react';
+import { Activity, ChevronRight, GitBranch } from 'lucide-react';
 
-import { HomeEmptyState } from './HomeEmptyState';
 import {
-  assetTypeColor,
-  compactName,
   formatMetric,
   type HomeAssetOverviewState,
-  type HomeLineageRelationKey,
   relativeTime,
   relationTypeLabel,
   SectionHeader,
+  type HomeLineageRelationKey,
 } from './homeAssetOverviewShared';
-import type { HomeLineageActivity } from './service';
-
-function buildLineageGraphOption(
-  state: HomeAssetOverviewState,
-  resolveRelation: (key: HomeLineageRelationKey) => string,
-): EChartsOption {
-  const nodes = state.data?.lineage?.nodes || [];
-  const edges = state.data?.lineage?.edges || [];
-  return {
-    animationDuration: 520,
-    animationDurationUpdate: 420,
-    tooltip: { trigger: 'item' },
-    series: [
-      {
-        type: 'graph',
-        layout: 'force',
-        roam: false,
-        draggable: false,
-        data: nodes.map((node) => ({
-          id: node.id,
-          name: compactName(node.name),
-          value: node.assetType,
-          symbolSize: node.assetType === 'COLUMN' ? 28 : 36,
-          itemStyle: {
-            color: assetTypeColor(node.assetType),
-            borderColor: '#ffffff',
-            borderWidth: 2,
-            shadowBlur: 8,
-            shadowColor: 'rgba(31,35,41,0.10)',
-          },
-          label: {
-            show: true,
-            position: 'bottom',
-            color: '#5f646e',
-            fontSize: 9,
-            distance: 5,
-          },
-        })),
-        links: edges.map((edge) => ({
-          id: edge.id,
-          source: edge.sourceAssetId,
-          target: edge.targetAssetId,
-          value: relationTypeLabel(edge.relationType, resolveRelation),
-        })),
-        force: {
-          repulsion: 150,
-          edgeLength: [70, 120],
-          gravity: 0.08,
-        },
-        edgeSymbol: ['none', 'arrow'],
-        edgeSymbolSize: 6,
-        lineStyle: {
-          color: '#cbd2dc',
-          width: 1.4,
-          curveness: 0.08,
-        },
-        emphasis: { focus: 'adjacency' },
-      },
-    ],
-  };
-}
-
-function LineagePreview({ state }: { state: HomeAssetOverviewState }) {
-  const intl = useIntl();
-  const resolveRelation = (key: HomeLineageRelationKey) =>
-    intl.formatMessage({ id: `pages.home.lineage.relation.${key}` });
-  const graphOption = useMemo(
-    () => buildLineageGraphOption(state, resolveRelation),
-    [intl.locale, state],
-  );
-  const hasGraph = (state.data?.lineage?.nodes.length || 0) > 0;
-  const unavailable = state.data?.lineage?.assetCount == null;
-
-  return (
-    <div className="relative h-[276px] overflow-hidden rounded-[14px] border border-[#eef0f3] bg-[#fafbfc]">
-      <div className="absolute inset-0 opacity-[0.5] [background-image:radial-gradient(circle,#dfe2e7_0.7px,transparent_0.8px)] [background-size:12px_12px]" />
-      {hasGraph ? (
-        <ReactECharts
-          option={graphOption}
-          style={{ width: '100%', height: '276px' }}
-        />
-      ) : state.loading || state.failed || unavailable ? (
-        <div className="relative flex h-full items-center justify-center text-[11px] text-[#a0a4ac]">
-          {intl.formatMessage({
-            id: state.loading
-              ? 'pages.home.lineage.loading'
-              : state.failed
-                ? 'pages.home.lineage.failed'
-                : 'pages.home.lineage.unavailable',
-          })}
-        </div>
-      ) : (
-        <div className="relative flex h-full items-center justify-center">
-          <YakOpsEmpty
-            width={160}
-            height={108}
-            title={intl.formatMessage({ id: 'pages.home.lineage.empty' })}
-            showCaption
-          />
-        </div>
-      )}
-      <div className="absolute bottom-3 left-3 rounded-full border border-[#e6e8ec] bg-white/90 px-2.5 py-1 text-[9px] text-[#999da5] shadow-sm backdrop-blur">
-        {intl.formatMessage({ id: 'pages.home.lineage.recentBadge' })}
-      </div>
-    </div>
-  );
-}
-
-function LineageMetric({
-  label,
-  value,
-}: {
-  label: string;
-  value?: number | null;
-}) {
-  const intl = useIntl();
-  return (
-    <div>
-      <div className="text-[10px] text-[#989ca4]">{label}</div>
-      <strong className="mt-1 block text-[20px] font-semibold text-[#3c4049]">
-        {formatMetric(value, intl.locale)}
-      </strong>
-    </div>
-  );
-}
-
-function LineageUpdate({ item }: { item: HomeLineageActivity }) {
-  const intl = useIntl();
-  const resolveRelation = (key: HomeLineageRelationKey) =>
-    intl.formatMessage({ id: `pages.home.lineage.relation.${key}` });
-  return (
-    <button
-      type="button"
-      onClick={() => history.push('/data-analysis/lineage')}
-      className="group flex w-full items-center gap-2 border-0 bg-transparent p-0 text-left"
-    >
-      <span className="h-1.5 w-1.5 shrink-0 rounded-full bg-[#8394e8]" />
-      <span className="min-w-0 flex-1">
-        <strong className="block truncate text-[11px] font-medium text-[#555a64]">
-          {item.sourceName} → {item.targetName}
-        </strong>
-        <span className="mt-0.5 block text-[9px] text-[#a1a5ad]">
-          {relationTypeLabel(item.relationType, resolveRelation)}
-        </span>
-      </span>
-      <span className="shrink-0 text-[9px] text-[#a1a5ad]">
-        {relativeTime(item.occurredAt, intl.locale)}
-      </span>
-    </button>
-  );
-}
 
 export function DataLineageOverview({
   state,
@@ -175,68 +17,77 @@ export function DataLineageOverview({
 }) {
   const intl = useIntl();
   const lineage = state.data?.lineage;
-  const activities = lineage?.recentActivities || [];
+  const latest = lineage?.recentActivities?.[0];
+  const resolveRelation = (key: HomeLineageRelationKey) =>
+    intl.formatMessage({ id: `pages.home.lineage.relation.${key}` });
+
   return (
-    <section className="rounded-[22px] border border-[#f0f1f3] bg-white px-6 pb-5 pt-5">
+    <section className="flex h-[188px] min-w-0 flex-col rounded-[18px] border border-[#f0f1f3] bg-white px-5 pb-4 pt-4">
       <SectionHeader
         title={intl.formatMessage({ id: 'pages.home.lineage.title' })}
-        description=""
         onMore={() => history.push('/data-analysis/lineage')}
       />
 
-      <div className="mt-5 grid grid-cols-1 gap-5 lg:grid-cols-[minmax(0,1fr)_220px]">
-        <LineagePreview state={state} />
-        <div className="flex flex-col">
-          <div className="grid grid-cols-2 gap-x-5 gap-y-5">
-            <LineageMetric
-              label={intl.formatMessage({ id: 'pages.home.lineage.metric.nodes' })}
-              value={lineage?.assetCount}
-            />
-            <LineageMetric
-              label={intl.formatMessage({ id: 'pages.home.lineage.metric.relations' })}
-              value={lineage?.relationCount}
-            />
-            <LineageMetric
-              label={intl.formatMessage({ id: 'pages.home.lineage.metric.todayUpdated' })}
-              value={lineage?.todayUpdatedCount}
-            />
-            <LineageMetric
-              label={intl.formatMessage({ id: 'pages.home.lineage.metric.datasetNodes' })}
-              value={lineage?.datasetAssetCount}
-            />
-          </div>
-
-          <div className="mt-6 border-t border-[#eef0f3] pt-4">
-            <div className="flex items-center gap-1.5 text-[11px] font-medium text-[#525761]">
-              <Activity size={13} strokeWidth={1.8} />
-              {intl.formatMessage({ id: 'pages.home.lineage.recentRelations' })}
+      <div className="mt-3 flex min-h-0 flex-1 flex-col justify-between">
+        <div className="flex items-center gap-3">
+          <span className="flex h-10 w-10 shrink-0 items-center justify-center rounded-[11px] bg-[#f2f4fb] text-[#7082d7]">
+            <GitBranch size={18} strokeWidth={1.8} />
+          </span>
+          <div className="min-w-0">
+            <div className="flex items-baseline gap-2">
+              <strong className="text-[25px] font-semibold leading-7 tracking-[-0.6px] text-[#30343d]">
+                {formatMetric(lineage?.relationCount, intl.locale)}
+              </strong>
+              <span className="text-[10px] text-[#969aa3]">
+                {intl.formatMessage({ id: 'pages.home.lineage.metric.relations' })}
+              </span>
             </div>
-            {activities.length > 0 ? (
-              <div className="mt-3 space-y-3">
-                {activities.map((item) => (
-                  <LineageUpdate key={item.id} item={item} />
-                ))}
-              </div>
-            ) : state.loading || state.failed || lineage?.assetCount == null ? (
-              <div className="flex min-h-[118px] items-center justify-center text-[10px] text-[#a0a4ac]">
-                {intl.formatMessage({
-                  id: state.loading
-                    ? 'pages.home.common.loading'
-                    : state.failed
-                      ? 'pages.home.common.loadFailed'
-                      : 'pages.home.common.unavailable',
-                })}
-              </div>
-            ) : (
-              <HomeEmptyState
-                icon={Activity}
-                title={intl.formatMessage({ id: 'pages.home.lineage.emptyRecent' })}
-                size="small"
-                className="min-h-[118px]"
-              />
-            )}
+            <div className="mt-1 flex items-center gap-3 text-[10px] text-[#8f949d]">
+              <span>
+                {intl.formatMessage({ id: 'pages.home.lineage.metric.nodes' })}{' '}
+                <strong className="font-semibold text-[#555a64]">
+                  {formatMetric(lineage?.assetCount, intl.locale)}
+                </strong>
+              </span>
+              <span>
+                {intl.formatMessage({ id: 'pages.home.lineage.metric.todayUpdated' })}{' '}
+                <strong className="font-semibold text-[#555a64]">
+                  {formatMetric(lineage?.todayUpdatedCount, intl.locale)}
+                </strong>
+              </span>
+            </div>
           </div>
         </div>
+
+        <button
+          type="button"
+          onClick={() => history.push('/data-analysis/lineage')}
+          className="group flex h-9 w-full items-center gap-2 rounded-[9px] border-0 bg-[#f8f9fb] px-3 text-left"
+        >
+          <Activity size={13} strokeWidth={1.8} className="shrink-0 text-[#8995cd]" />
+          <span className="min-w-0 flex-1 truncate text-[10px] text-[#747a84]">
+            {latest
+              ? `${latest.sourceName} → ${latest.targetName} · ${relationTypeLabel(
+                  latest.relationType,
+                  resolveRelation,
+                )}`
+              : state.loading
+                ? intl.formatMessage({ id: 'pages.home.common.loading' })
+                : state.failed
+                  ? intl.formatMessage({ id: 'pages.home.common.loadFailed' })
+                  : intl.formatMessage({ id: 'pages.home.lineage.emptyRecent' })}
+          </span>
+          {latest ? (
+            <span className="shrink-0 text-[9px] text-[#a0a4ac]">
+              {relativeTime(latest.occurredAt, intl.locale)}
+            </span>
+          ) : null}
+          <ChevronRight
+            size={12}
+            strokeWidth={1.8}
+            className="shrink-0 text-[#b5b9c0] transition-transform group-hover:translate-x-0.5"
+          />
+        </button>
       </div>
     </section>
   );

--- a/yak-ops-ui/src/pages/home/components/HomeLineageOverview.tsx
+++ b/yak-ops-ui/src/pages/home/components/HomeLineageOverview.tsx
@@ -24,6 +24,7 @@ export function DataLineageOverview({
   return (
     <section className="flex h-[188px] min-w-0 flex-col rounded-[18px] border border-[#f0f1f3] bg-white px-5 pb-4 pt-4">
       <SectionHeader
+        compact
         title={intl.formatMessage({ id: 'pages.home.lineage.title' })}
         onMore={() => history.push('/data-analysis/lineage')}
       />

--- a/yak-ops-ui/src/pages/home/components/HomeQualitySidebarOverview.tsx
+++ b/yak-ops-ui/src/pages/home/components/HomeQualitySidebarOverview.tsx
@@ -1,24 +1,18 @@
-import { formatQualityDimension } from '@/features/data-quality/i18n';
 import {
   homeQualityOverviewApi,
-  type HomeQualityDimension,
   type HomeQualityIssue,
   type HomeQualityOverview,
 } from '@/services/home';
-import { BRAND_COLOR } from '@/styles/brand';
 import { history, useIntl } from '@umijs/max';
-import type { EChartsOption } from 'echarts';
-import ReactECharts from 'echarts-for-react';
 import {
   AlertTriangle,
   CheckCircle2,
   ChevronRight,
   ShieldCheck,
 } from 'lucide-react';
-import { useEffect, useMemo, useState } from 'react';
+import { useEffect, useState } from 'react';
 
-import { HomeEmptyState } from './HomeEmptyState';
-import { relativeTime, SectionHeader } from './homeAssetOverviewShared';
+import { SectionHeader } from './homeAssetOverviewShared';
 
 interface QualitySidebarState {
   data?: HomeQualityOverview;
@@ -26,80 +20,11 @@ interface QualitySidebarState {
   failed: boolean;
 }
 
-type RadarDimensionKey =
-  | 'completeness'
-  | 'uniqueness'
-  | 'validity'
-  | 'accuracy'
-  | 'timeliness';
-
-interface RadarDimensionDefinition {
-  key: RadarDimensionKey;
-  aliases: string[];
-}
-
-const RADAR_DIMENSIONS: RadarDimensionDefinition[] = [
-  { key: 'completeness', aliases: ['完整性'] },
-  { key: 'uniqueness', aliases: ['唯一性'] },
-  { key: 'validity', aliases: ['有效性'] },
-  { key: 'accuracy', aliases: ['准确性'] },
-  { key: 'timeliness', aliases: ['时效性', '及时性'] },
-];
-
 const formatMetric = (value: number | null | undefined, locale: string) =>
   value == null ? '--' : new Intl.NumberFormat(locale).format(value);
 
 const formatRate = (value?: number | null) =>
   value == null ? '--' : value.toFixed(1);
-
-const normalizeRadarDimensions = (
-  dimensions: HomeQualityDimension[],
-  resolveLabel: (key: RadarDimensionKey) => string,
-): HomeQualityDimension[] =>
-  RADAR_DIMENSIONS.map((definition) => {
-    const matched = dimensions.find((item) =>
-      definition.aliases.includes(item.dimension),
-    );
-
-    return {
-      dimension: resolveLabel(definition.key),
-      total: matched?.total ?? 0,
-      issues: matched?.issues ?? 0,
-      passRate: matched?.passRate ?? null,
-    };
-  });
-
-const healthState = (
-  passRate: number | null | undefined,
-  labels: {
-    noData: string;
-    healthy: string;
-    attention: string;
-    risky: string;
-  },
-) => {
-  if (passRate == null) {
-    return {
-      label: labels.noData,
-      className: 'text-[#858b94]',
-      icon: null,
-    };
-  }
-
-  if (passRate >= 95) {
-    return {
-      label: labels.healthy,
-      className: 'text-[#31865a]',
-      icon: <CheckCircle2 size={13} strokeWidth={2} />,
-    };
-  }
-
-  return {
-    label: passRate >= 80 ? labels.attention : labels.risky,
-    className: passRate >= 80 ? 'text-[#b87520]' : 'text-[#d94d59]',
-    icon: <AlertTriangle size={13} strokeWidth={1.9} />,
-  };
-};
 
 function useQualitySidebarOverview(): QualitySidebarState {
   const [state, setState] = useState<QualitySidebarState>({
@@ -132,269 +57,109 @@ function useQualitySidebarOverview(): QualitySidebarState {
   return state;
 }
 
-function buildRadarOption(dimensions: HomeQualityDimension[]): EChartsOption {
-  const hasCompleteRadar = dimensions.every((item) => item.passRate != null);
-
-  return {
-    animation: hasCompleteRadar,
-    animationDuration: 520,
-    tooltip: hasCompleteRadar
-      ? {
-          trigger: 'item',
-          formatter: () =>
-            dimensions
-              .map((item) => `${item.dimension}: ${formatRate(item.passRate)}%`)
-              .join('<br/>'),
-        }
-      : { show: false },
-    radar: {
-      center: ['50%', '51%'],
-      radius: '62%',
-      splitNumber: 4,
-      indicator: dimensions.map((item) => ({
-        name: item.dimension,
-        max: 100,
-      })),
-      axisName: {
-        color: '#666d78',
-        fontSize: 10,
-        fontWeight: 500,
-      },
-      axisLine: { lineStyle: { color: '#dde1e7' } },
-      splitLine: { lineStyle: { color: '#e2e5ea' } },
-      splitArea: { areaStyle: { color: ['#ffffff', '#f8f9fb'] } },
-    },
-    series: hasCompleteRadar
-      ? [
-          {
-            type: 'radar',
-            symbol: 'circle',
-            symbolSize: 4,
-            data: [
-              {
-                value: dimensions.map((item) => item.passRate ?? 0),
-                lineStyle: { width: 2, color: BRAND_COLOR },
-                itemStyle: { color: BRAND_COLOR },
-                areaStyle: { color: 'rgba(254,44,85,0.09)' },
-              },
-            ],
-          },
-        ]
-      : [],
-  };
-}
-
-function QualityMetric({
-  label,
-  value,
-  warning = false,
-}: {
-  label: string;
-  value?: number | null;
-  warning?: boolean;
-}) {
-  const intl = useIntl();
-  return (
-    <div className="min-w-0 text-center">
-      <div className="truncate text-[10px] leading-4 text-[#92969f]">
-        {label}
-      </div>
-      <strong
-        className={`mt-1 block text-[17px] font-semibold leading-6 ${
-          warning && (value ?? 0) > 0 ? 'text-[#d94d59]' : 'text-[#343943]'
-        }`}
-      >
-        {formatMetric(value, intl.locale)}
-      </strong>
-    </div>
-  );
-}
-
 const objectLabel = (issue: HomeQualityIssue) =>
   issue.objectName || issue.tableName || issue.monitorName;
-
-function RecentIssueRow({ issue }: { issue: HomeQualityIssue }) {
-  const intl = useIntl();
-  return (
-    <button
-      type="button"
-      onClick={() =>
-        history.push(
-          `/data-quality/execution/${encodeURIComponent(issue.executionNo)}`,
-        )
-      }
-      className="group flex w-full items-center gap-2.5 border-0 bg-transparent py-2.5 text-left"
-    >
-      <span className="flex h-7 w-7 shrink-0 items-center justify-center rounded-[8px] bg-[#fff2f3] text-[#e35d69]">
-        <AlertTriangle size={13} strokeWidth={1.9} />
-      </span>
-      <span className="min-w-0 flex-1">
-        <span className="flex min-w-0 items-center gap-1.5">
-          <strong className="truncate text-[11px] font-medium text-[#42464f]">
-            {issue.ruleName}
-          </strong>
-          <span className="shrink-0 rounded-full bg-[#f0f1f4] px-1.5 py-0.5 text-[9px] text-[#747a84]">
-            {formatQualityDimension(intl, issue.dimension)}
-          </span>
-        </span>
-        <span className="mt-0.5 block truncate text-[9px] text-[#999ea7]">
-          {objectLabel(issue)}
-          {issue.columnName ? ` · ${issue.columnName}` : ''}
-        </span>
-      </span>
-      <span className="shrink-0 text-[9px] text-[#a0a4ac]">
-        {relativeTime(issue.queuedAt, intl.locale)}
-      </span>
-      <ChevronRight
-        size={12}
-        strokeWidth={1.8}
-        className="shrink-0 text-[#b0b4bb] transition-transform group-hover:translate-x-0.5"
-      />
-    </button>
-  );
-}
 
 export default function HomeQualitySidebarOverview() {
   const intl = useIntl();
   const state = useQualitySidebarOverview();
   const data = state.data;
-  const health = healthState(data?.passRate, {
-    noData: intl.formatMessage({ id: 'pages.home.quality.health.noData' }),
-    healthy: intl.formatMessage({ id: 'pages.home.quality.health.healthy' }),
-    attention: intl.formatMessage({ id: 'pages.home.quality.health.attention' }),
-    risky: intl.formatMessage({ id: 'pages.home.quality.health.risky' }),
-  });
-  const dimensions = useMemo(
-    () =>
-      normalizeRadarDimensions(data?.dimensions ?? [], (key) =>
-        intl.formatMessage({ id: `pages.home.quality.dimension.${key}` }),
-      ),
-    [data?.dimensions, intl.locale],
-  );
-  const radarOption = useMemo(() => buildRadarOption(dimensions), [dimensions]);
-  const issues = data?.recentIssues?.slice(0, 3) ?? [];
-  const showRadar = !state.loading && !state.failed && data?.passRate != null;
+  const latestIssue = data?.recentIssues?.[0];
+  const risky = (data?.recentIssueCount ?? 0) > 0;
 
   return (
-    <section className="min-w-0 rounded-[22px] border border-[#f0f1f3] bg-white px-5 pb-5 pt-5">
+    <section className="flex h-[188px] min-w-0 flex-col rounded-[18px] border border-[#f0f1f3] bg-white px-5 pb-4 pt-4">
       <SectionHeader
         title={intl.formatMessage({ id: 'pages.home.quality.title' })}
-        description=""
         onMore={() => history.push('/data-quality/overview')}
       />
 
-      <div className="mt-4 rounded-[14px] border border-[#eef0f3] bg-[#fafbfc] px-4 pb-3.5 pt-3.5">
-        <div className="flex items-start justify-between gap-4">
-          <div>
-            <span className="text-[10px] text-[#92969f]">
-              {intl.formatMessage({ id: 'pages.home.quality.overallPassRate' })}
+      <div className="mt-3 flex min-h-0 flex-1 flex-col justify-between">
+        <div className="flex items-center justify-between gap-4">
+          <div className="flex min-w-0 items-center gap-3">
+            <span
+              className={`flex h-10 w-10 shrink-0 items-center justify-center rounded-[11px] ${
+                risky
+                  ? 'bg-[#fff2f3] text-[#df5c68]'
+                  : 'bg-[#eef8f2] text-[#43815f]'
+              }`}
+            >
+              {risky ? (
+                <AlertTriangle size={18} strokeWidth={1.8} />
+              ) : (
+                <ShieldCheck size={18} strokeWidth={1.8} />
+              )}
             </span>
-            <div className="mt-0.5 flex items-end gap-1">
-              <strong className="text-[28px] font-semibold leading-8 tracking-[-0.7px] text-[#2d313a]">
-                {formatRate(data?.passRate)}
+            <div className="min-w-0">
+              <div className="flex items-baseline gap-1">
+                <strong className="text-[25px] font-semibold leading-7 tracking-[-0.6px] text-[#30343d]">
+                  {formatRate(data?.passRate)}
+                </strong>
+                {data?.passRate != null ? (
+                  <span className="text-[10px] text-[#8f949d]">%</span>
+                ) : null}
+              </div>
+              <span className="mt-0.5 block text-[10px] text-[#969aa3]">
+                {intl.formatMessage({ id: 'pages.home.quality.overallPassRate' })}
+              </span>
+            </div>
+          </div>
+
+          <div className="grid grid-cols-2 gap-x-5 text-right">
+            <div>
+              <span className="block text-[9px] text-[#a0a4ac]">
+                {intl.formatMessage({ id: 'pages.home.quality.metric.todayChecks' })}
+              </span>
+              <strong className="mt-1 block text-[14px] font-semibold text-[#454a53]">
+                {formatMetric(data?.todayExecutionCount, intl.locale)}
               </strong>
-              {data?.passRate != null ? (
-                <span className="mb-0.5 text-[10px] text-[#7e848e]">%</span>
-              ) : null}
+            </div>
+            <div>
+              <span className="block text-[9px] text-[#a0a4ac]">
+                {intl.formatMessage({ id: 'pages.home.quality.recentIssues' })}
+              </span>
+              <strong
+                className={`mt-1 block text-[14px] font-semibold ${
+                  risky ? 'text-[#d94d59]' : 'text-[#454a53]'
+                }`}
+              >
+                {formatMetric(data?.recentIssueCount, intl.locale)}
+              </strong>
             </div>
           </div>
-
-          <span
-            className={`mt-1 flex items-center gap-1 text-[10px] font-medium ${health.className}`}
-          >
-            {health.icon}
-            {state.loading
-              ? intl.formatMessage({ id: 'pages.home.dataCenter.latest.loading' })
-              : state.failed
-                ? intl.formatMessage({ id: 'pages.home.common.loadFailed' })
-                : health.label}
-          </span>
         </div>
 
-        <div className="mt-1 h-[176px]">
-          {showRadar ? (
-            <ReactECharts
-              option={radarOption}
-              notMerge
-              style={{ width: '100%', height: '176px' }}
-            />
-          ) : state.loading || state.failed ? (
-            <div className="flex h-full items-center justify-center text-[10px] text-[#9da1a8]">
-              {intl.formatMessage({
-                id: state.loading
-                  ? 'pages.home.quality.loading'
-                  : 'pages.home.quality.failed',
-              })}
-            </div>
+        <button
+          type="button"
+          onClick={() =>
+            latestIssue
+              ? history.push(
+                  `/data-quality/execution/${encodeURIComponent(latestIssue.executionNo)}`,
+                )
+              : history.push('/data-quality/overview')
+          }
+          className="group flex h-9 w-full items-center gap-2 rounded-[9px] border-0 bg-[#f8f9fb] px-3 text-left"
+        >
+          {latestIssue ? (
+            <AlertTriangle size={13} strokeWidth={1.8} className="shrink-0 text-[#df5c68]" />
           ) : (
-            <HomeEmptyState
-              icon={ShieldCheck}
-              title={intl.formatMessage({ id: 'pages.home.quality.health.noData' })}
-              size="medium"
-              className="h-full"
-            />
+            <CheckCircle2 size={13} strokeWidth={1.8} className="shrink-0 text-[#4f936d]" />
           )}
-        </div>
-
-        <div className="grid grid-cols-4 gap-2 border-t border-[#e6e9ee] pt-3">
-          <QualityMetric
-            label={intl.formatMessage({ id: 'pages.home.quality.metric.monitoredTables' })}
-            value={data?.monitoredTableCount}
-          />
-          <QualityMetric
-            label={intl.formatMessage({ id: 'pages.home.quality.metric.todayChecks' })}
-            value={data?.todayExecutionCount}
-          />
-          <QualityMetric
-            label={intl.formatMessage({ id: 'pages.home.quality.metric.issueTables' })}
-            value={data?.todayIssueTableCount}
-            warning
-          />
-          <QualityMetric
-            label={intl.formatMessage({ id: 'pages.home.quality.metric.enabledRules' })}
-            value={data?.enabledRuleCount}
-          />
-        </div>
-      </div>
-
-      <div className="mt-4 border-t border-[#eef0f3] pt-3.5">
-        <div className="flex items-center justify-between gap-3">
-          <strong className="text-[12px] font-semibold text-[#454a53]">
-            {intl.formatMessage({ id: 'pages.home.quality.recentIssues' })}
-          </strong>
-          <span className="flex items-center gap-1 text-[10px] text-[#8f949d]">
-            <AlertTriangle size={11} strokeWidth={1.8} className="text-[#e35d69]" />
-            {intl.formatMessage(
-              { id: 'pages.home.quality.issueCount' },
-              { count: formatMetric(data?.recentIssueCount, intl.locale) },
-            )}
-          </span>
-        </div>
-
-        {issues.length > 0 ? (
-          <div className="mt-1 divide-y divide-[#f0f1f3]">
-            {issues.map((issue) => (
-              <RecentIssueRow key={issue.id} issue={issue} />
-            ))}
-          </div>
-        ) : state.loading || state.failed || data?.recentIssueCount == null ? (
-          <div className="flex min-h-[92px] items-center justify-center text-[10px] text-[#9da1a8]">
-            {intl.formatMessage({
-              id: state.loading
-                ? 'pages.home.quality.issueLoading'
+          <span className="min-w-0 flex-1 truncate text-[10px] text-[#747a84]">
+            {latestIssue
+              ? `${latestIssue.ruleName} · ${objectLabel(latestIssue)}`
+              : state.loading
+                ? intl.formatMessage({ id: 'pages.home.common.loading' })
                 : state.failed
-                  ? 'pages.home.quality.issueFailed'
-                  : 'pages.home.quality.issueUnavailable',
-            })}
-          </div>
-        ) : (
-          <HomeEmptyState
-            icon={CheckCircle2}
-            title={intl.formatMessage({ id: 'pages.home.quality.emptyIssues' })}
-            size="small"
-            className="min-h-[92px]"
+                  ? intl.formatMessage({ id: 'pages.home.common.loadFailed' })
+                  : intl.formatMessage({ id: 'pages.home.quality.emptyIssues' })}
+          </span>
+          <ChevronRight
+            size={12}
+            strokeWidth={1.8}
+            className="shrink-0 text-[#b5b9c0] transition-transform group-hover:translate-x-0.5"
           />
-        )}
+        </button>
       </div>
     </section>
   );

--- a/yak-ops-ui/src/pages/home/components/HomeQualitySidebarOverview.tsx
+++ b/yak-ops-ui/src/pages/home/components/HomeQualitySidebarOverview.tsx
@@ -70,6 +70,7 @@ export default function HomeQualitySidebarOverview() {
   return (
     <section className="flex h-[188px] min-w-0 flex-col rounded-[18px] border border-[#f0f1f3] bg-white px-5 pb-4 pt-4">
       <SectionHeader
+        compact
         title={intl.formatMessage({ id: 'pages.home.quality.title' })}
         onMore={() => history.push('/data-quality/overview')}
       />

--- a/yak-ops-ui/src/pages/home/components/HomeVisualizationOverview.tsx
+++ b/yak-ops-ui/src/pages/home/components/HomeVisualizationOverview.tsx
@@ -36,14 +36,21 @@ const timestamp = (value?: string) => {
   return Number.isFinite(parsed) ? parsed : 0;
 };
 
-const dashboardItem = (value: DashboardSummary): RecentVisualization => ({
-  id: `dashboard-${value.id}`,
-  name: value.name,
-  updatedAt: value.updateTime || value.publishedTime || value.createTime,
-  path: value.publishedVersionId
-    ? `/dashboard/${value.id}`
-    : `/dashboard/${value.id}/edit`,
-});
+const dashboardItem = (value: DashboardSummary): RecentVisualization => {
+  const published = Boolean(value.publishedVersionId);
+  const hasUnpublishedChanges =
+    published && value.currentVersionNo > value.publishedVersionNo;
+
+  return {
+    id: `dashboard-${value.id}`,
+    name: value.name,
+    updatedAt: value.updateTime || value.publishedTime || value.createTime,
+    path:
+      published && !hasUnpublishedChanges
+        ? `/dashboard/${value.id}`
+        : `/dashboard/${value.id}/edit`,
+  };
+};
 
 const screenItem = (value: DigitalScreenInstance): RecentVisualization => ({
   id: `screen-${value.id}`,
@@ -142,6 +149,7 @@ export default function HomeVisualizationOverview() {
   return (
     <section className="flex h-[188px] min-w-0 flex-col rounded-[18px] border border-[#f0f1f3] bg-white px-5 pb-4 pt-4">
       <SectionHeader
+        compact
         title={intl.formatMessage({ id: 'pages.home.visualization.title' })}
         onMore={() => history.push('/dashboard')}
       />

--- a/yak-ops-ui/src/pages/home/components/HomeVisualizationOverview.tsx
+++ b/yak-ops-ui/src/pages/home/components/HomeVisualizationOverview.tsx
@@ -5,10 +5,9 @@ import {
   type DashboardSummary,
 } from '@/services/dashboard';
 import { history, useIntl } from '@umijs/max';
-import { Clock3, LayoutDashboard, Monitor } from 'lucide-react';
+import { ChevronRight, Clock3, LayoutDashboard, Monitor } from 'lucide-react';
 import { useEffect, useMemo, useState } from 'react';
 
-import { HomeEmptyState } from './HomeEmptyState';
 import {
   formatMetric,
   relativeTime,
@@ -24,16 +23,10 @@ interface VisualizationState {
   screenFailed: boolean;
 }
 
-type VisualizationKind = 'dashboard' | 'screen';
-type VisualizationStatus = 'published' | 'draft' | 'changed';
-
-interface VisualizationItem {
+interface RecentVisualization {
   id: string;
-  kind: VisualizationKind;
   name: string;
-  description: string;
   updatedAt?: string;
-  status: VisualizationStatus;
   path: string;
 }
 
@@ -43,49 +36,24 @@ const timestamp = (value?: string) => {
   return Number.isFinite(parsed) ? parsed : 0;
 };
 
-const dashboardItem = (value: DashboardSummary): VisualizationItem => {
-  const published = Boolean(value.publishedVersionId);
-  const hasUnpublishedChanges =
-    published && value.currentVersionNo > value.publishedVersionNo;
-  return {
-    id: value.id,
-    kind: 'dashboard',
-    name: value.name,
-    description: value.description || `Dashboard · v${value.currentVersionNo}`,
-    updatedAt: value.updateTime || value.publishedTime || value.createTime,
-    status: hasUnpublishedChanges
-      ? 'changed'
-      : published
-        ? 'published'
-        : 'draft',
-    path:
-      published && !hasUnpublishedChanges
-        ? `/dashboard/${value.id}`
-        : `/dashboard/${value.id}/edit`,
-  };
-};
-
-const screenItem = (
-  value: DigitalScreenInstance,
-  fallbackDescription: string,
-): VisualizationItem => ({
-  id: value.id,
-  kind: 'screen',
+const dashboardItem = (value: DashboardSummary): RecentVisualization => ({
+  id: `dashboard-${value.id}`,
   name: value.name,
-  description: value.description || fallbackDescription,
+  updatedAt: value.updateTime || value.publishedTime || value.createTime,
+  path: value.publishedVersionId
+    ? `/dashboard/${value.id}`
+    : `/dashboard/${value.id}/edit`,
+});
+
+const screenItem = (value: DigitalScreenInstance): RecentVisualization => ({
+  id: `screen-${value.id}`,
+  name: value.name,
   updatedAt: value.updatedAt || value.publishedAt || value.createdAt,
-  status: value.status === 'published' ? 'published' : 'draft',
   path:
     value.status === 'published'
       ? `/digital-screen/${value.id}`
       : `/digital-screen/${value.id}/edit`,
 });
-
-const statusClassName = (status: VisualizationStatus) => {
-  if (status === 'published') return 'bg-[#eef8f2] text-[#43815f]';
-  if (status === 'changed') return 'bg-[#fff7e9] text-[#a46d25]';
-  return 'bg-[#f3f4f6] text-[#7d828b]';
-};
 
 function useVisualizationOverview(): VisualizationState {
   const [state, setState] = useState<VisualizationState>({
@@ -144,192 +112,102 @@ function useVisualizationOverview(): VisualizationState {
   return state;
 }
 
-function OverviewMetric({
-  label,
-  value,
-  route,
-}: {
-  label: string;
-  value?: number;
-  route: string;
-}) {
-  const intl = useIntl();
-  return (
-    <button
-      type="button"
-      onClick={() => history.push(route)}
-      className="group min-w-0 border-0 bg-transparent px-4 py-1 text-left first:pl-0 last:pr-0"
-    >
-      <div className="truncate text-[11px] text-[#92969f] transition-colors group-hover:text-[#6d737d]">
-        {label}
-      </div>
-      <strong className="mt-1 block truncate text-[24px] font-semibold tracking-[-0.6px] text-[#30343d]">
-        {formatMetric(value, intl.locale)}
-      </strong>
-    </button>
-  );
-}
-
-function VisualizationPreview({ kind }: { kind: VisualizationKind }) {
-  const Icon = kind === 'dashboard' ? LayoutDashboard : Monitor;
-  return (
-    <div className="relative flex h-[112px] items-center justify-center overflow-hidden bg-[linear-gradient(145deg,#f4f6fb_0%,#edf1f8_100%)]">
-      <div className="absolute inset-3 rounded-[10px] border border-white/90 bg-white/55 shadow-[0_5px_18px_rgba(31,35,41,0.04)]" />
-      <div className="relative z-10 flex flex-col items-center gap-2 text-[#7783ad]">
-        <span className="flex h-10 w-10 items-center justify-center rounded-[11px] bg-white/85 shadow-sm">
-          <Icon size={19} strokeWidth={1.7} />
-        </span>
-        <span className="text-[9px] font-medium tracking-[0.08em] text-[#9aa1b6]">
-          {kind === 'dashboard' ? 'DASHBOARD' : 'DIGITAL SCREEN'}
-        </span>
-      </div>
-    </div>
-  );
-}
-
-function VisualizationCard({ item }: { item: VisualizationItem }) {
-  const intl = useIntl();
-  return (
-    <button
-      type="button"
-      onClick={() => history.push(item.path)}
-      className="group overflow-hidden rounded-[14px] border border-[#eceef2] bg-white text-left transition-[box-shadow,transform,border-color] duration-200 hover:-translate-y-0.5 hover:border-[#dfe2e8] hover:shadow-[0_10px_28px_rgba(31,35,41,0.075)]"
-    >
-      <VisualizationPreview kind={item.kind} />
-      <div className="px-4 pb-4 pt-3.5">
-        <div className="flex items-start gap-2">
-          <div className="min-w-0 flex-1">
-            <strong className="block truncate text-[13px] font-semibold text-[#373b44]">
-              {item.name}
-            </strong>
-            <p className="mt-1 truncate text-[10px] text-[#92969f]">
-              {item.description}
-            </p>
-          </div>
-          <span
-            className={`shrink-0 rounded-full px-2 py-0.5 text-[9px] ${statusClassName(item.status)}`}
-          >
-            {intl.formatMessage({
-              id: `pages.home.visualization.status.${item.status}`,
-            })}
-          </span>
-        </div>
-        <div className="mt-3 flex items-center justify-between gap-2 text-[10px] text-[#a0a4ac]">
-          <span>
-            {intl.formatMessage({
-              id: `pages.home.visualization.kind.${item.kind}`,
-            })}
-          </span>
-          <span className="flex min-w-0 items-center gap-1">
-            <Clock3 size={11} strokeWidth={1.8} />
-            <span className="truncate">
-              {relativeTime(item.updatedAt, intl.locale)}
-            </span>
-          </span>
-        </div>
-      </div>
-    </button>
-  );
-}
-
 export default function HomeVisualizationOverview() {
   const intl = useIntl();
   const state = useVisualizationOverview();
-  const dashboard = state.dashboard;
-  const screens = state.screens;
-  const publishedScreens = screens?.filter((item) => item.status === 'published').length;
-
-  const recentItems = useMemo(() => {
+  const dashboardCount = state.dashboard?.dashboardCount;
+  const screenCount = state.screens?.length;
+  const publishedScreens = state.screens?.filter(
+    (item) => item.status === 'published',
+  ).length;
+  const latest = useMemo(() => {
     const items = [
-      ...(dashboard?.recentDashboards || []).map(dashboardItem),
-      ...(screens || []).map((item) =>
-        screenItem(
-          item,
-          intl.formatMessage(
-            { id: 'pages.home.visualization.screenFallback' },
-            { templateId: item.templateId },
-          ),
-        ),
-      ),
+      ...(state.dashboard?.recentDashboards || []).map(dashboardItem),
+      ...(state.screens || []).map(screenItem),
     ];
-    return items
-      .sort((left, right) => timestamp(right.updatedAt) - timestamp(left.updatedAt))
-      .slice(0, 4);
-  }, [dashboard, intl.locale, screens]);
+    return items.sort(
+      (left, right) => timestamp(right.updatedAt) - timestamp(left.updatedAt),
+    )[0];
+  }, [state.dashboard, state.screens]);
 
-  const loading = state.dashboardLoading || state.screenLoading;
-  const allFailed = state.dashboardFailed && state.screenFailed;
+  const total =
+    dashboardCount == null && screenCount == null
+      ? undefined
+      : (dashboardCount ?? 0) + (screenCount ?? 0);
+  const published =
+    state.dashboard?.publishedDashboardCount == null && publishedScreens == null
+      ? undefined
+      : (state.dashboard?.publishedDashboardCount ?? 0) + (publishedScreens ?? 0);
 
   return (
-    <section className="rounded-[22px] border border-[#f0f1f3] bg-white px-6 pb-6 pt-5">
+    <section className="flex h-[188px] min-w-0 flex-col rounded-[18px] border border-[#f0f1f3] bg-white px-5 pb-4 pt-4">
       <SectionHeader
         title={intl.formatMessage({ id: 'pages.home.visualization.title' })}
-        description=""
+        onMore={() => history.push('/dashboard')}
       />
 
-      <div className="mt-5 grid grid-cols-2 divide-x divide-[#eef0f3] lg:grid-cols-4">
-        <OverviewMetric
-          label={intl.formatMessage({ id: 'pages.home.visualization.metric.dashboard' })}
-          value={state.dashboardFailed ? undefined : dashboard?.dashboardCount}
-          route="/dashboard"
-        />
-        <OverviewMetric
-          label={intl.formatMessage({
-            id: 'pages.home.visualization.metric.publishedDashboard',
-          })}
-          value={state.dashboardFailed ? undefined : dashboard?.publishedDashboardCount}
-          route="/dashboard"
-        />
-        <OverviewMetric
-          label={intl.formatMessage({ id: 'pages.home.visualization.metric.screen' })}
-          value={state.screenFailed ? undefined : screens?.length}
-          route="/digital-screen"
-        />
-        <OverviewMetric
-          label={intl.formatMessage({
-            id: 'pages.home.visualization.metric.publishedScreen',
-          })}
-          value={state.screenFailed ? undefined : publishedScreens}
-          route="/digital-screen"
-        />
-      </div>
-
-      <div className="mt-6 flex items-center justify-between border-t border-[#f0f1f3] pt-4">
-        <strong className="text-[12px] font-semibold text-[#444851]">
-          {intl.formatMessage({ id: 'pages.home.visualization.recentUpdated' })}
-        </strong>
-        <span className="text-[10px] text-[#9ca0a8]">
-          {intl.formatMessage({
-            id:
-              state.dashboardFailed || state.screenFailed
-                ? 'pages.home.visualization.partialUnavailable'
-                : 'pages.home.visualization.sortedByUpdatedAt',
-          })}
-        </span>
-      </div>
-
-      {recentItems.length > 0 ? (
-        <div className="mt-3 grid grid-cols-1 gap-4 sm:grid-cols-2 xl:grid-cols-4">
-          {recentItems.map((item) => (
-            <VisualizationCard key={`${item.kind}-${item.id}`} item={item} />
-          ))}
+      <div className="mt-3 flex min-h-0 flex-1 flex-col justify-between">
+        <div className="flex items-center gap-3">
+          <span className="flex h-10 w-10 shrink-0 items-center justify-center rounded-[11px] bg-[#f2f4fb] text-[#7783ad]">
+            <LayoutDashboard size={18} strokeWidth={1.8} />
+          </span>
+          <div className="min-w-0 flex-1">
+            <div className="flex items-baseline gap-2">
+              <strong className="text-[25px] font-semibold leading-7 tracking-[-0.6px] text-[#30343d]">
+                {formatMetric(total, intl.locale)}
+              </strong>
+              <span className="text-[10px] text-[#969aa3]">
+                {intl.formatMessage({ id: 'pages.home.visualization.title' })}
+              </span>
+            </div>
+            <div className="mt-1 flex items-center gap-3 text-[10px] text-[#8f949d]">
+              <span className="flex items-center gap-1">
+                <LayoutDashboard size={11} strokeWidth={1.8} />
+                {formatMetric(dashboardCount, intl.locale)}
+              </span>
+              <span className="flex items-center gap-1">
+                <Monitor size={11} strokeWidth={1.8} />
+                {formatMetric(screenCount, intl.locale)}
+              </span>
+              <span>
+                {intl.formatMessage({ id: 'pages.home.visualization.status.published' })}{' '}
+                <strong className="font-semibold text-[#555a64]">
+                  {formatMetric(published, intl.locale)}
+                </strong>
+              </span>
+            </div>
+          </div>
         </div>
-      ) : loading || allFailed ? (
-        <div className="flex min-h-[176px] items-center justify-center text-[11px] text-[#a0a4ac]">
-          {intl.formatMessage({
-            id: loading
-              ? 'pages.home.visualization.loading'
-              : 'pages.home.visualization.failed',
-          })}
-        </div>
-      ) : (
-        <HomeEmptyState
-          icon={LayoutDashboard}
-          title={intl.formatMessage({ id: 'pages.home.visualization.empty' })}
-          size="medium"
-          className="min-h-[176px]"
-        />
-      )}
+
+        <button
+          type="button"
+          onClick={() => history.push(latest?.path || '/dashboard')}
+          className="group flex h-9 w-full items-center gap-2 rounded-[9px] border-0 bg-[#f8f9fb] px-3 text-left"
+        >
+          <Clock3 size={13} strokeWidth={1.8} className="shrink-0 text-[#8995ad]" />
+          <span className="min-w-0 flex-1 truncate text-[10px] text-[#747a84]">
+            {latest?.name ||
+              intl.formatMessage({
+                id:
+                  state.dashboardLoading || state.screenLoading
+                    ? 'pages.home.visualization.loading'
+                    : state.dashboardFailed && state.screenFailed
+                      ? 'pages.home.visualization.failed'
+                      : 'pages.home.visualization.empty',
+              })}
+          </span>
+          {latest ? (
+            <span className="shrink-0 text-[9px] text-[#a0a4ac]">
+              {relativeTime(latest.updatedAt, intl.locale)}
+            </span>
+          ) : null}
+          <ChevronRight
+            size={12}
+            strokeWidth={1.8}
+            className="shrink-0 text-[#b5b9c0] transition-transform group-hover:translate-x-0.5"
+          />
+        </button>
+      </div>
     </section>
   );
 }

--- a/yak-ops-ui/src/pages/home/components/HomeWorkbench.tsx
+++ b/yak-ops-ui/src/pages/home/components/HomeWorkbench.tsx
@@ -8,9 +8,9 @@ import HomeQualitySidebarOverview from './HomeQualitySidebarOverview';
 import HomeVisualizationOverview from './HomeVisualizationOverview';
 
 /**
- * 首页主内容流。
+ * 首页工作台。
  *
- * 宽内容保留在主列，避免数据集、血缘和可视化在窄侧栏中失去信息密度。
+ * 数据集保留中等信息密度，其余能力收敛为等高的轻量入口，避免首页变成多个详情页的拼接。
  */
 export function HomeWorkbenchMain() {
   const assetOverviewState = useHomeAssetOverview();
@@ -18,34 +18,17 @@ export function HomeWorkbenchMain() {
   return (
     <div className="min-w-0 space-y-4">
       <DatasetOverview state={assetOverviewState} />
-      <DataLineageOverview state={assetOverviewState} />
-      <HomeVisualizationOverview />
+
+      <div className="grid grid-cols-1 gap-4 md:grid-cols-2">
+        <HomeQualitySidebarOverview />
+        <DataLineageOverview state={assetOverviewState} />
+        <HomeVisualizationOverview />
+        <HomeDataServiceOverview />
+      </div>
     </div>
   );
 }
 
-/**
- * 首页辅助内容流。
- *
- * 数据质量使用侧栏专用紧凑视图，数据服务本身即适配约 400px 宽度。
- */
-export function HomeWorkbenchSidebar() {
-  return (
-    <div className="min-w-0 space-y-4">
-      <HomeQualitySidebarOverview />
-      <HomeDataServiceOverview />
-    </div>
-  );
-}
-
-/**
- * 保留独立使用 HomeWorkbench 时的兼容入口。
- */
 export default function HomeWorkbench() {
-  return (
-    <div className="mt-4 grid grid-cols-1 items-start gap-4 xl:grid-cols-[minmax(0,1fr)_380px] 2xl:grid-cols-[minmax(0,1fr)_410px]">
-      <HomeWorkbenchMain />
-      <HomeWorkbenchSidebar />
-    </div>
-  );
+  return <HomeWorkbenchMain />;
 }

--- a/yak-ops-ui/src/pages/home/components/HomeWorkbench.tsx
+++ b/yak-ops-ui/src/pages/home/components/HomeWorkbench.tsx
@@ -19,7 +19,7 @@ export function HomeWorkbenchMain() {
     <div className="min-w-0 space-y-4">
       <DatasetOverview state={assetOverviewState} />
 
-      <div className="grid grid-cols-1 gap-4 md:grid-cols-2">
+      <div className="grid grid-cols-1 gap-4 md:grid-cols-2 2xl:grid-cols-4">
         <HomeQualitySidebarOverview />
         <DataLineageOverview state={assetOverviewState} />
         <HomeVisualizationOverview />

--- a/yak-ops-ui/src/pages/home/components/QuickCreatePanel.tsx
+++ b/yak-ops-ui/src/pages/home/components/QuickCreatePanel.tsx
@@ -8,84 +8,39 @@ import {
 } from 'lucide-react';
 import type { ReactNode } from 'react';
 
-type CardTheme = 'offline' | 'realtime' | 'development' | 'workflow';
+type QuickCreateKey = 'offline' | 'realtime' | 'development' | 'workflow';
 
 interface QuickCreateItem {
-  key: CardTheme;
+  key: QuickCreateKey;
   icon: ReactNode;
+  iconClassName: string;
 }
 
 const QUICK_CREATE_ITEMS: QuickCreateItem[] = [
   {
     key: 'offline',
-    icon: <ArrowRightLeft size={18} strokeWidth={2.1} />,
+    icon: <ArrowRightLeft size={18} strokeWidth={2} />,
+    iconClassName: 'bg-[#eef2ff] text-[#6578df]',
   },
   {
     key: 'realtime',
-    icon: <RadioTower size={18} strokeWidth={2.1} />,
+    icon: <RadioTower size={18} strokeWidth={2} />,
+    iconClassName: 'bg-[#eaf8ff] text-[#2698d8]',
   },
   {
     key: 'development',
-    icon: <Braces size={18} strokeWidth={2.1} />,
+    icon: <Braces size={18} strokeWidth={2} />,
+    iconClassName: 'bg-[#fff0f3] text-[#e85a73]',
   },
   {
     key: 'workflow',
-    icon: <Workflow size={18} strokeWidth={2.1} />,
+    icon: <Workflow size={18} strokeWidth={2} />,
+    iconClassName: 'bg-[#fff8e8] text-[#b98924]',
   },
 ];
 
-const THEME_STYLES: Record<
-  CardTheme,
-  { panel: string; core: string; glow: string; particles: string }
-> = {
-  offline: {
-    panel: 'bg-[linear-gradient(180deg,#9fc7ff_0%,#d6e7ff_54%,#f1f7ff_100%)]',
-    core: 'bg-[linear-gradient(145deg,#758fff_0%,#6267f2_100%)] shadow-[inset_0_-1px_2px_rgba(60,73,214,0.22)]',
-    glow: 'bg-[#abc9ff]',
-    particles: 'bg-[radial-gradient(circle,rgba(112,142,255,0.42)_0.8px,transparent_0.9px)]',
-  },
-  realtime: {
-    panel: 'bg-[linear-gradient(180deg,#80d6ff_0%,#ccefff_54%,#effaff_100%)]',
-    core: 'bg-[linear-gradient(145deg,#35c6ff_0%,#168cf4_100%)] shadow-[inset_0_-1px_2px_rgba(0,93,231,0.22)]',
-    glow: 'bg-[#78d9ff]',
-    particles: 'bg-[radial-gradient(circle,rgba(44,173,239,0.42)_0.8px,transparent_0.9px)]',
-  },
-  development: {
-    panel: 'bg-[linear-gradient(180deg,#ff8ea5_0%,#ffd4dd_54%,#fff0f3_100%)]',
-    core: 'bg-[linear-gradient(145deg,#ff4768_0%,#fe2c55_100%)] shadow-[inset_0_-1px_2px_rgba(188,21,56,0.22)]',
-    glow: 'bg-[#ff8ea5]',
-    particles: 'bg-[radial-gradient(circle,rgba(254,44,85,0.34)_0.8px,transparent_0.9px)]',
-  },
-  workflow: {
-    panel: 'bg-[linear-gradient(180deg,#ffd95c_0%,#ffedb5_54%,#fff9e6_100%)]',
-    core: 'bg-[linear-gradient(145deg,#ffd33d_0%,#ffb900_100%)] shadow-[inset_0_-1px_2px_rgba(225,152,0,0.20)]',
-    glow: 'bg-[#ffe27d]',
-    particles: 'bg-[radial-gradient(circle,rgba(241,181,0,0.36)_0.8px,transparent_0.9px)]',
-  },
-};
-
-function LayeredIcon({ theme, icon }: { theme: CardTheme; icon: ReactNode }) {
-  const styles = THEME_STYLES[theme];
-  return (
-    <div className="pointer-events-none absolute -left-px -top-[2px] z-[3] h-[80px] w-[76px] origin-center transition-transform duration-[320ms] ease-[cubic-bezier(0.22,1,0.36,1)] group-hover:-translate-y-[1px] group-hover:scale-[1.045]">
-      <div className="absolute left-[2px] top-[8px] h-[72px] w-[59px] origin-bottom-right rotate-[20deg] rounded-[12px] border border-white/80 bg-[#d7d9df]/40 shadow-[0_4px_12px_rgba(31,35,41,0.035)] backdrop-blur-[4px] transition-[transform,border-width,border-color] duration-[360ms] ease-[cubic-bezier(0.34,1.56,0.64,1)] group-hover:rotate-[26deg] group-hover:border-2 group-hover:border-white" />
-      <div className={`absolute left-0 top-[4px] flex h-[72px] w-[61px] items-center justify-center overflow-hidden rounded-[12px] border border-white/90 shadow-[0_7px_16px_rgba(31,35,41,0.09)] ${styles.panel}`}>
-        <span className="absolute inset-x-[5px] top-[2px] h-[20px] rounded-full bg-white/25 blur-[8px]" />
-        <div className={`relative flex h-[34px] w-[34px] shrink-0 items-center justify-center overflow-hidden rounded-[9px] text-white transition-transform duration-[320ms] ease-[cubic-bezier(0.22,1,0.36,1)] group-hover:scale-[1.035] ${styles.core}`}>
-          <span className={`absolute -left-[7px] -top-[7px] h-[19px] w-[19px] rounded-full opacity-60 blur-[6px] ${styles.glow}`} />
-          <span className="absolute -bottom-[7px] -right-[6px] h-[18px] w-[18px] rounded-full bg-white/40 blur-[6px]" />
-          <span className="relative z-[2] flex h-5 w-5 items-center justify-center drop-shadow-[0_1px_1px_rgba(0,0,0,0.06)]">
-            {icon}
-          </span>
-        </div>
-      </div>
-    </div>
-  );
-}
-
 function QuickCreateCard({ item }: { item: QuickCreateItem }) {
   const intl = useIntl();
-  const styles = THEME_STYLES[item.key];
   const title = intl.formatMessage({
     id: `pages.home.quickCreate.${item.key}.title`,
   });
@@ -97,29 +52,28 @@ function QuickCreateCard({ item }: { item: QuickCreateItem }) {
     <button
       type="button"
       onClick={() => history.push(`/create?type=${item.key}`)}
-      className="group relative flex h-[76px] min-w-0 items-center overflow-visible rounded-[16px] border border-[rgba(31,35,41,0.075)] bg-white/[0.96] pr-4 text-left shadow-[0_3px_10px_rgba(31,35,41,0.045),0_1px_2px_rgba(31,35,41,0.025)] transition-[border-color,box-shadow,transform] duration-[260ms] ease-[cubic-bezier(0.22,1,0.36,1)] hover:-translate-y-px hover:border-[rgba(31,35,41,0.09)] hover:shadow-[0_8px_20px_rgba(31,35,41,0.07),0_1px_2px_rgba(31,35,41,0.025)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-sky-200/70"
+      className="group flex h-[72px] min-w-0 items-center gap-3 rounded-[16px] border border-[rgba(31,35,41,0.07)] bg-white/[0.94] px-4 text-left shadow-[0_2px_8px_rgba(31,35,41,0.035)] transition-[transform,border-color,box-shadow] duration-200 hover:-translate-y-px hover:border-[rgba(31,35,41,0.11)] hover:shadow-[0_8px_20px_rgba(31,35,41,0.065)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-sky-200/70"
     >
       <span
-        aria-hidden="true"
-        className={`pointer-events-none absolute inset-0 z-0 overflow-hidden rounded-[16px] opacity-0 transition-opacity duration-300 group-hover:opacity-100 [background-size:8px_8px] [mask-image:linear-gradient(90deg,#000_0%,rgba(0,0,0,0.84)_24%,rgba(0,0,0,0.16)_72%,transparent_100%)] ${styles.particles}`}
-      />
-      <span aria-hidden="true" className="pointer-events-none absolute inset-0 z-[1] rounded-[16px] bg-[linear-gradient(90deg,rgba(255,255,255,0.03)_0%,rgba(255,255,255,0.12)_38%,rgba(255,255,255,0.91)_100%)]" />
-      <div className="relative z-[2] h-[76px] w-[77px] shrink-0">
-        <LayeredIcon theme={item.key} icon={item.icon} />
-      </div>
-      <div className="relative z-[2] ml-2 min-w-0 flex-1">
-        <div className="truncate text-[15px] font-semibold leading-[22px] text-[#292c35]">
+        className={`flex h-10 w-10 shrink-0 items-center justify-center rounded-[12px] transition-transform duration-200 group-hover:scale-105 ${item.iconClassName}`}
+      >
+        {item.icon}
+      </span>
+
+      <span className="min-w-0 flex-1">
+        <strong className="block truncate text-[14px] font-semibold leading-5 text-[#292c35]">
           {title}
-        </div>
-        <div className="mt-0.5 flex min-w-0 items-center text-[13px] font-normal leading-5 text-[#9498a1]">
-          <span className="min-w-0 truncate">{description}</span>
-          <ChevronRight
-            size={13}
-            strokeWidth={1.8}
-            className="ml-[2px] shrink-0 -translate-x-[3px] text-[#92969f] opacity-0 transition-[opacity,transform] duration-[220ms] ease-out group-hover:translate-x-0 group-hover:opacity-100"
-          />
-        </div>
-      </div>
+        </strong>
+        <span className="mt-0.5 block truncate text-[11px] leading-4 text-[#9498a1]">
+          {description}
+        </span>
+      </span>
+
+      <ChevronRight
+        size={14}
+        strokeWidth={1.8}
+        className="shrink-0 -translate-x-1 text-[#a4a8b0] opacity-0 transition-[opacity,transform] duration-200 group-hover:translate-x-0 group-hover:opacity-100"
+      />
     </button>
   );
 }
@@ -128,11 +82,11 @@ export function QuickCreatePanel() {
   const intl = useIntl();
 
   return (
-    <section className="rounded-[22px] border border-[#f1f1f1] bg-white/[0.74] px-[22px] pb-6 pt-6 backdrop-blur-[8px]">
-      <h2 className="mb-5 text-xl font-semibold leading-7 tracking-[-0.35px] text-[#252832]">
+    <section className="px-1 pt-1">
+      <h2 className="mb-3 text-[16px] font-semibold leading-6 tracking-[-0.2px] text-[#343842]">
         {intl.formatMessage({ id: 'pages.home.quickCreate.title' })}
       </h2>
-      <div className="grid grid-cols-1 gap-[14px] sm:grid-cols-2 min-[1280px]:grid-cols-4">
+      <div className="grid grid-cols-1 gap-3 sm:grid-cols-2 min-[1280px]:grid-cols-4">
         {QUICK_CREATE_ITEMS.map((item) => (
           <QuickCreateCard key={item.key} item={item} />
         ))}

--- a/yak-ops-ui/src/pages/home/components/homeAssetOverviewShared.tsx
+++ b/yak-ops-ui/src/pages/home/components/homeAssetOverviewShared.tsx
@@ -14,6 +14,7 @@ interface SectionHeaderProps {
   title: string;
   description?: string;
   onMore?: () => void;
+  compact?: boolean;
 }
 
 export const formatMetric = (value?: number | null, locale = 'zh-CN') =>
@@ -95,12 +96,20 @@ export function SectionHeader({
   title,
   description,
   onMore,
+  compact = false,
 }: SectionHeaderProps) {
   const intl = useIntl();
+
   return (
     <header className="flex items-start justify-between gap-4">
       <div className="min-w-0">
-        <h2 className="text-xl font-semibold tracking-[-0.35px] text-[#252832]">
+        <h2
+          className={
+            compact
+              ? 'text-[15px] font-semibold leading-5 tracking-[-0.2px] text-[#343842]'
+              : 'text-xl font-semibold tracking-[-0.35px] text-[#252832]'
+          }
+        >
           {title}
         </h2>
         {description ? (
@@ -114,10 +123,12 @@ export function SectionHeader({
         <button
           type="button"
           onClick={onMore}
-          className="mt-0.5 flex shrink-0 items-center gap-0.5 border-0 bg-transparent p-0 text-[12px] text-[#747982] transition-colors hover:text-[#252832]"
+          className={`flex shrink-0 items-center gap-0.5 border-0 bg-transparent p-0 text-[#747982] transition-colors hover:text-[#252832] ${
+            compact ? 'text-[11px]' : 'mt-0.5 text-[12px]'
+          }`}
         >
           {intl.formatMessage({ id: 'pages.home.common.viewMore' })}
-          <ChevronRight size={14} strokeWidth={1.8} />
+          <ChevronRight size={compact ? 13 : 14} strokeWidth={1.8} />
         </button>
       ) : null}
     </header>


### PR DESCRIPTION
## Summary

- reshape the homepage as a focused workbench instead of a stack of equally weighted feature overviews
- keep Quick Create and Data Center as the primary actions/status area
- keep Data Center beside notification/schedule in the upper workspace, then let Dataset and the capability area span the full page width below
- simplify Dataset to its core asset count, today-created signal, table/column asset counts, and recent updates
- collapse Data Quality, Lineage, Visualization, and Data Service into lightweight equal-height capability cards
- remove heavy homepage-only visualizations such as the quality radar, lineage graph, visualization preview gallery, and data-service trend chart
- reduce secondary card title size with a compact header hierarchy so they no longer compete visually with Data Center and Dataset

## Layout details

- secondary capability cards use the same fixed `188px` height so their bottoms align
- capability cards render as 2 columns from `md` and 4 columns on `2xl`
- Data Center uses a fixed `400px` desktop height
- Data Center tab content is constrained to an internal `263px` scroll area, so Recent/Schedule content cannot stretch the outer card
- narrow viewports keep natural Data Center height to avoid clipping stacked mobile content
- Quick Create no longer has a large outer container; the four actions read as lightweight entry cards

## Scope

Frontend-only homepage refactor. No backend API or response contract changes.

## Validation

- branch is based on `main` with no commits behind at final comparison
- GitHub Actions CI #339 passed on the final PR head
- frontend build, release normalization, Yak Ops packaging, and distribution upload all completed successfully
