### PR TITLE
fix(home): tighten data quality overview integration

### DIFF
--- a/yak-ops-business/yak-ops-business-home/src/main/java/io/yak/ops/business/home/quality/HomeQualityOverviewReader.java
+++ b/yak-ops-business/yak-ops-business-home/src/main/java/io/yak/ops/business/home/quality/HomeQualityOverviewReader.java
@@ -34,6 +34,7 @@ public class HomeQualityOverviewReader {
 
   private OverviewResponse response(QualityOverviewReader.Overview overview) {
     return new OverviewResponse(
+        true,
         overview.rangeStart(),
         overview.rangeEnd(),
         overview.passRate(),
@@ -64,10 +65,11 @@ public class HomeQualityOverviewReader {
 
   private OverviewResponse unavailable() {
     return new OverviewResponse(
-        null, null, null, null, null, null, null, null, List.of(), List.of());
+        false, null, null, null, null, null, null, null, null, List.of(), List.of());
   }
 
   public record OverviewResponse(
+      boolean available,
       LocalDate rangeStart,
       LocalDate rangeEnd,
       Double passRate,

--- a/yak-ops-business/yak-ops-business-home/src/test/java/io/yak/ops/business/home/quality/HomeQualityOverviewReaderTest.java
+++ b/yak-ops-business/yak-ops-business-home/src/test/java/io/yak/ops/business/home/quality/HomeQualityOverviewReaderTest.java
@@ -49,6 +49,7 @@ class HomeQualityOverviewReaderTest {
     HomeQualityOverviewReader.OverviewResponse response =
         new HomeQualityOverviewReader(provider).overview();
 
+    assertThat(response.available()).isTrue();
     assertThat(response.passRate()).isEqualTo(97.5D);
     assertThat(response.monitoredTableCount()).isEqualTo(8L);
     assertThat(response.enabledRuleCount()).isEqualTo(24L);
@@ -77,6 +78,7 @@ class HomeQualityOverviewReaderTest {
     HomeQualityOverviewReader.OverviewResponse response =
         new HomeQualityOverviewReader(provider).overview();
 
+    assertThat(response.available()).isFalse();
     assertThat(response.passRate()).isNull();
     assertThat(response.monitoredTableCount()).isNull();
     assertThat(response.enabledRuleCount()).isNull();
@@ -98,6 +100,7 @@ class HomeQualityOverviewReaderTest {
     HomeQualityOverviewReader.OverviewResponse response =
         new HomeQualityOverviewReader(provider).overview();
 
+    assertThat(response.available()).isFalse();
     assertThat(response.passRate()).isNull();
     assertThat(response.monitoredTableCount()).isNull();
     assertThat(response.recentIssues()).isEmpty();

--- a/yak-ops-business/yak-ops-business-quality/src/main/java/io/yak/ops/business/quality/workspace/QualityOverviewReader.java
+++ b/yak-ops-business/yak-ops-business-quality/src/main/java/io/yak/ops/business/quality/workspace/QualityOverviewReader.java
@@ -25,7 +25,8 @@ public class QualityOverviewReader {
 
   private static final int RANGE_DAYS = 7;
   private static final int MAX_ANALYTICS_RANGE_DAYS = 90;
-  private static final int RECENT_ISSUE_LIMIT = 3;
+  private static final int HOME_RECENT_ISSUE_LIMIT = 4;
+  private static final int ISSUE_CONTRIBUTOR_LIMIT = 3;
 
   private final QualityOverviewRepository repository;
 
@@ -48,7 +49,7 @@ public class QualityOverviewReader {
         .map(this::dimension)
         .toList();
     List<RecentIssue> recentIssues = repository.recentIssues(
-            rangeStart, rangeEnd, RECENT_ISSUE_LIMIT).stream()
+            rangeStart, rangeEnd, HOME_RECENT_ISSUE_LIMIT).stream()
         .map(this::issue)
         .toList();
 
@@ -84,7 +85,7 @@ public class QualityOverviewReader {
     List<IssueContributor> contributors = dimensions.stream()
         .filter(item -> item.issues() > 0L)
         .sorted((left, right) -> Long.compare(right.issues(), left.issues()))
-        .limit(RECENT_ISSUE_LIMIT)
+        .limit(ISSUE_CONTRIBUTOR_LIMIT)
         .map(item -> new IssueContributor(
             item.dimension(), item.issues(), rate(item.issues(), totalIssues)))
         .toList();

--- a/yak-ops-business/yak-ops-business-quality/src/main/resources/mapper/quality/QualityOverviewMapper.xml
+++ b/yak-ops-business/yak-ops-business-quality/src/main/resources/mapper/quality/QualityOverviewMapper.xml
@@ -34,7 +34,9 @@
        FROM yak_quality_execution e
        WHERE e.project_id = #{projectId}
          AND e.queued_at &gt;= #{todayStart} AND e.queued_at &lt; #{todayEnd}) AS today_execution_count,
-      (SELECT COUNT(DISTINCT e.monitor_id)
+      (SELECT COUNT(DISTINCT CONCAT(
+          e.data_source_id, '|', COALESCE(e.database_name, ''), '|',
+          COALESCE(e.schema_name, ''), '|', e.table_name))
        FROM yak_quality_execution e
        WHERE e.project_id = #{projectId}
          AND e.queued_at &gt;= #{todayStart} AND e.queued_at &lt; #{todayEnd}

--- a/yak-ops-business/yak-ops-business-quality/src/test/java/io/yak/ops/business/quality/workspace/QualityOverviewReaderTest.java
+++ b/yak-ops-business/yak-ops-business-quality/src/test/java/io/yak/ops/business/quality/workspace/QualityOverviewReaderTest.java
@@ -58,6 +58,18 @@ class QualityOverviewReaderTest {
   }
 
   @Test
+  void shouldExposeFourRecentIssuesForHomepage() {
+    QualityOverviewRepository repository = new StubRepository(
+        new QualityOverviewRepository.OverviewStats(0L, 0L, 0L, 0L, 0L, 0L, 5L),
+        List.of(),
+        List.of(issue(1L), issue(2L), issue(3L), issue(4L), issue(5L)));
+
+    QualityOverviewReader.Overview overview = new QualityOverviewReader(repository).overview();
+
+    assertThat(overview.recentIssues()).hasSize(4);
+  }
+
+  @Test
   void shouldKeepPassRateUnavailableWhenNoRulesWereExecuted() {
     QualityOverviewRepository repository = new StubRepository(
         new QualityOverviewRepository.OverviewStats(0L, 0L, 0L, 0L, 0L, 0L, 0L),
@@ -123,6 +135,21 @@ class QualityOverviewReaderTest {
         LocalDate.of(2026, 1, 1), LocalDate.of(2026, 4, 15)))
         .isInstanceOf(IllegalArgumentException.class)
         .hasMessageContaining("90 天");
+  }
+
+  private static QualityOverviewRepository.IssueSummary issue(long id) {
+    return new QualityOverviewRepository.IssueSummary(
+        id,
+        "quality-" + id,
+        11L,
+        "订单质量监控",
+        "warehouse.dwd_order",
+        "dwd_order",
+        "订单号不能为空",
+        "完整性",
+        "order_id",
+        "NOT_PASSED",
+        LocalDateTime.now().minusMinutes(id));
   }
 
   private record StubRepository(

--- a/yak-ops-ui/src/services/home/api.ts
+++ b/yak-ops-ui/src/services/home/api.ts
@@ -17,6 +17,16 @@ const ASSET_PREFIX = '/api/v1/home/assets';
 const QUALITY_PREFIX = '/api/v1/home/quality';
 const SCHEDULE_CENTER_PREFIX = '/api/v1/home/schedule-center';
 
+const requireAvailableQualityOverview = (
+  response: ApiResponse<HomeQualityOverview>,
+): ApiResponse<HomeQualityOverview> => {
+  if (response.data?.available === false) {
+    throw new Error('Home quality overview unavailable');
+  }
+
+  return response;
+};
+
 export const homeCockpitApi = {
   overview: (): Promise<ApiResponse<HomeCockpitOverview>> =>
     HttpUtils.get<HomeCockpitOverview>(COCKPIT_PREFIX),
@@ -46,7 +56,9 @@ export const homeAssetOverviewApi = {
 
 export const homeQualityOverviewApi = {
   overview: (): Promise<ApiResponse<HomeQualityOverview>> =>
-    HttpUtils.get<HomeQualityOverview>(`${QUALITY_PREFIX}/overview`),
+    HttpUtils.get<HomeQualityOverview>(`${QUALITY_PREFIX}/overview`).then(
+      requireAvailableQualityOverview,
+    ),
 };
 
 export const homeScheduleCenterApi = {

--- a/yak-ops-ui/src/services/home/types.ts
+++ b/yak-ops-ui/src/services/home/types.ts
@@ -153,6 +153,8 @@ export interface HomeQualityIssue {
 }
 
 export interface HomeQualityOverview {
+  /** False means the quality read model is temporarily unavailable, not that metrics are zero. */
+  available?: boolean;
   rangeStart?: string | null;
   rangeEnd?: string | null;
   passRate: number | null;


### PR DESCRIPTION
## Summary

- add an explicit `available` flag to the home data-quality read model so the frontend can distinguish **no quality data** from **quality backend unavailable**
- keep the homepage HTTP response stable while routing unavailable quality data into the frontend's existing failed state
- fix `todayIssueTableCount` to count distinct physical tables instead of distinct monitor IDs
- align the homepage recent-issue backend limit with the 4 rows the frontend already supports, while keeping quality-overview contributor ranking at 3
- keep the existing homepage layout and styles unchanged

## Tests

- extend `HomeQualityOverviewReaderTest` for available/unavailable contracts
- add coverage for the 4-item homepage recent-issue limit
- `Backend Compile` ✅
- full `CI` is still running