### PR TITLE
feat(home): add data asset and utility panels

### DIFF
--- a/yak-ops-ui/src/locales/en-US.ts
+++ b/yak-ops-ui/src/locales/en-US.ts
@@ -13,6 +13,7 @@ import dataService from './en-US/data-service';
 import dataSource from './en-US/data-source';
 import globalHeader from './en-US/globalHeader';
 import home from './en-US/home';
+import homeSections from './en-US/home-sections';
 import menu from './en-US/menu';
 import pages from './en-US/pages';
 import pwa from './en-US/pwa';
@@ -47,6 +48,7 @@ export default {
   ...realtimeSync,
   ...dataQuality,
   ...home,
+  ...homeSections,
   ...dataDevelopment,
   ...dataDevelopmentEditor,
   ...workflow,

--- a/yak-ops-ui/src/locales/en-US/home-sections.ts
+++ b/yak-ops-ui/src/locales/en-US/home-sections.ts
@@ -1,0 +1,23 @@
+export default {
+  'pages.home.dataAssets.title': 'Data Assets',
+  'pages.home.dataAssets.dataset': 'Datasets',
+  'pages.home.dataAssets.datasetEmpty': 'No dataset preview yet',
+  'pages.home.dataAssets.dataService': 'Data Services',
+  'pages.home.dataAssets.dataServiceEmpty': 'No data service preview yet',
+  'pages.home.dataAssets.dashboard': 'Dashboards',
+  'pages.home.dataAssets.dashboardEmpty': 'No dashboard preview yet',
+
+  'pages.home.quickNavigation.title': 'Quick Navigation',
+  'pages.home.quickNavigation.dataSource': 'Data Sources',
+  'pages.home.quickNavigation.offlineSync': 'Batch Sync',
+  'pages.home.quickNavigation.dataQuality': 'Data Quality',
+  'pages.home.quickNavigation.dataService': 'Data Services',
+
+  'pages.home.resourceCenter.title': 'Resource Center',
+  'pages.home.resourceCenter.files': 'Files',
+  'pages.home.resourceCenter.folders': 'Folders',
+  'pages.home.resourceCenter.storage': 'Storage',
+  'pages.home.resourceCenter.recent': 'Recent Resources',
+  'pages.home.resourceCenter.preview': 'Preview',
+  'pages.home.resourceCenter.empty': 'No resource preview yet',
+};

--- a/yak-ops-ui/src/locales/zh-CN.ts
+++ b/yak-ops-ui/src/locales/zh-CN.ts
@@ -13,6 +13,7 @@ import dataService from './zh-CN/data-service';
 import dataSource from './zh-CN/data-source';
 import globalHeader from './zh-CN/globalHeader';
 import home from './zh-CN/home';
+import homeSections from './zh-CN/home-sections';
 import menu from './zh-CN/menu';
 import pages from './zh-CN/pages';
 import pwa from './zh-CN/pwa';
@@ -40,6 +41,7 @@ export default {
   ...realtimeSync,
   ...dataQuality,
   ...home,
+  ...homeSections,
   ...dataDevelopment,
   ...dataDevelopmentEditor,
   ...workflow,

--- a/yak-ops-ui/src/locales/zh-CN/home-sections.ts
+++ b/yak-ops-ui/src/locales/zh-CN/home-sections.ts
@@ -1,0 +1,23 @@
+export default {
+  'pages.home.dataAssets.title': '数据资产',
+  'pages.home.dataAssets.dataset': '数据集列表',
+  'pages.home.dataAssets.datasetEmpty': '暂无数据集预览',
+  'pages.home.dataAssets.dataService': '数据服务列表',
+  'pages.home.dataAssets.dataServiceEmpty': '暂无数据服务预览',
+  'pages.home.dataAssets.dashboard': '仪表盘列表',
+  'pages.home.dataAssets.dashboardEmpty': '暂无仪表盘预览',
+
+  'pages.home.quickNavigation.title': '快捷导航',
+  'pages.home.quickNavigation.dataSource': '数据源',
+  'pages.home.quickNavigation.offlineSync': '离线同步',
+  'pages.home.quickNavigation.dataQuality': '数据质量',
+  'pages.home.quickNavigation.dataService': '数据服务',
+
+  'pages.home.resourceCenter.title': '资源中心',
+  'pages.home.resourceCenter.files': '文件数量',
+  'pages.home.resourceCenter.folders': '文件夹',
+  'pages.home.resourceCenter.storage': '存储占用',
+  'pages.home.resourceCenter.recent': '最近资源',
+  'pages.home.resourceCenter.preview': '资源预览',
+  'pages.home.resourceCenter.empty': '暂无资源预览',
+};

--- a/yak-ops-ui/src/pages/home/HomePage.tsx
+++ b/yak-ops-ui/src/pages/home/HomePage.tsx
@@ -1,6 +1,9 @@
 import DataCenter from './components/DataCenter';
+import HomeDataAssets from './components/HomeDataAssets';
 import { HomeBackground } from './components/HomeBackground';
 import { HomeHeader } from './components/HomeHeader';
+import HomeQuickNavigation from './components/HomeQuickNavigation';
+import HomeResourceCenter from './components/HomeResourceCenter';
 import { HomeWorkbenchMain } from './components/HomeWorkbench';
 import NotificationCenter from './components/NotificationCenter';
 import { QuickCreatePanel } from './components/QuickCreatePanel';
@@ -22,17 +25,18 @@ export default function HomePage() {
             <QuickCreatePanel />
           </div>
 
-          <div className="mt-4 grid grid-cols-1 gap-4 xl:grid-cols-[minmax(0,1fr)_380px] xl:items-stretch 2xl:grid-cols-[minmax(0,1fr)_410px]">
+          <div className="mt-4 grid grid-cols-1 gap-4 xl:grid-cols-[minmax(0,1fr)_380px] xl:items-start 2xl:grid-cols-[minmax(0,1fr)_410px]">
             <div className="flex min-w-0 flex-col gap-4">
               <DataCenter />
               <HomeWorkbenchMain />
+              <HomeDataAssets />
             </div>
 
             <aside className="flex min-w-0 flex-col gap-4">
               <NotificationCenter />
-              <div className="xl:flex-1 xl:[&>section]:h-full">
-                <ScheduleCenter />
-              </div>
+              <ScheduleCenter />
+              <HomeQuickNavigation />
+              <HomeResourceCenter />
             </aside>
           </div>
         </main>

--- a/yak-ops-ui/src/pages/home/components/HomeDataAssets.tsx
+++ b/yak-ops-ui/src/pages/home/components/HomeDataAssets.tsx
@@ -1,0 +1,123 @@
+import { Link, useIntl } from '@umijs/max';
+
+import HomePrimitiveIcon, {
+  type HomePrimitiveIconName,
+} from './HomePrimitiveIcon';
+
+interface AssetColumnDefinition {
+  key: string;
+  titleId: string;
+  emptyId: string;
+  path: string;
+  icon: HomePrimitiveIconName;
+}
+
+const ASSET_COLUMNS: AssetColumnDefinition[] = [
+  {
+    key: 'dataset',
+    titleId: 'pages.home.dataAssets.dataset',
+    emptyId: 'pages.home.dataAssets.datasetEmpty',
+    path: '/dataset',
+    icon: 'dataset',
+  },
+  {
+    key: 'service',
+    titleId: 'pages.home.dataAssets.dataService',
+    emptyId: 'pages.home.dataAssets.dataServiceEmpty',
+    path: '/data-service',
+    icon: 'service',
+  },
+  {
+    key: 'dashboard',
+    titleId: 'pages.home.dataAssets.dashboard',
+    emptyId: 'pages.home.dataAssets.dashboardEmpty',
+    path: '/dashboard',
+    icon: 'dashboard',
+  },
+];
+
+function AssetColumn({
+  definition,
+  divider,
+}: {
+  definition: AssetColumnDefinition;
+  divider: boolean;
+}) {
+  const intl = useIntl();
+
+  return (
+    <div
+      className={`flex min-w-0 flex-col px-0 md:px-6 ${
+        divider ? 'md:border-r md:border-[#eceef1]' : ''
+      }`}
+    >
+      <div className="flex items-center justify-between gap-4">
+        <div className="flex min-w-0 items-center gap-2.5">
+          <span className="flex h-9 w-9 shrink-0 items-center justify-center rounded-[10px] bg-[#f6f7f9] text-[#676d77]">
+            <HomePrimitiveIcon name={definition.icon} size={19} />
+          </span>
+          <h3 className="m-0 truncate text-[14px] font-semibold text-[#343841]">
+            {intl.formatMessage({ id: definition.titleId })}
+          </h3>
+        </div>
+
+        <strong className="shrink-0 text-[15px] font-semibold text-[#a0a4ab]">
+          --
+        </strong>
+      </div>
+
+      <div className="mt-3 border-t border-[#eef0f2]" />
+
+      <div className="flex min-h-[220px] flex-1 items-center justify-center px-5 py-7">
+        <div className="flex max-w-[220px] flex-col items-center text-center">
+          <span className="flex h-12 w-12 items-center justify-center rounded-full bg-[#f7f8fa] text-[#c4c8ce]">
+            <HomePrimitiveIcon name={definition.icon} size={24} />
+          </span>
+          <span className="mt-3 text-[12px] font-medium text-[#8b9098]">
+            {intl.formatMessage({ id: definition.emptyId })}
+          </span>
+        </div>
+      </div>
+
+      <Link
+        to={definition.path}
+        className="group mx-auto flex items-center gap-1 text-[12px] font-medium text-[#787e87] transition-colors hover:text-[#30353d]"
+      >
+        {intl.formatMessage({ id: 'pages.home.common.viewAll' })}
+        <span className="text-[15px] font-light leading-none transition-transform group-hover:translate-x-0.5">
+          ›
+        </span>
+      </Link>
+    </div>
+  );
+}
+
+/**
+ * Homepage data-asset shell.
+ *
+ * This PR intentionally keeps the panel frontend-only. Dataset, data-service,
+ * and dashboard summaries will receive their read models in a later backend PR.
+ */
+export default function HomeDataAssets() {
+  const intl = useIntl();
+
+  return (
+    <section className="min-h-[390px] rounded-[22px] border border-[#f0f1f3] bg-white px-6 pb-5 pt-5">
+      <header className="flex items-center justify-between gap-4">
+        <h2 className="m-0 text-xl font-semibold tracking-[-0.35px] text-[#252832]">
+          {intl.formatMessage({ id: 'pages.home.dataAssets.title' })}
+        </h2>
+      </header>
+
+      <div className="mt-4 grid grid-cols-1 gap-6 border-t border-[#eef0f2] pt-4 md:grid-cols-3 md:gap-0">
+        {ASSET_COLUMNS.map((definition, index) => (
+          <AssetColumn
+            key={definition.key}
+            definition={definition}
+            divider={index < ASSET_COLUMNS.length - 1}
+          />
+        ))}
+      </div>
+    </section>
+  );
+}

--- a/yak-ops-ui/src/pages/home/components/HomePrimitiveIcon.tsx
+++ b/yak-ops-ui/src/pages/home/components/HomePrimitiveIcon.tsx
@@ -1,0 +1,110 @@
+import type { ReactNode, SVGProps } from 'react';
+
+export type HomePrimitiveIconName =
+  | 'dataset'
+  | 'service'
+  | 'dashboard'
+  | 'dataSource'
+  | 'sync'
+  | 'quality'
+  | 'file'
+  | 'folder'
+  | 'storage';
+
+export interface HomePrimitiveIconProps
+  extends Omit<SVGProps<SVGSVGElement>, 'children' | 'height' | 'width'> {
+  name: HomePrimitiveIconName;
+  size?: number;
+}
+
+function iconPaths(name: HomePrimitiveIconName): ReactNode {
+  switch (name) {
+    case 'dataset':
+    case 'dataSource':
+      return (
+        <>
+          <ellipse cx="12" cy="5.5" rx="7" ry="2.5" />
+          <path d="M5 5.5v5c0 1.38 3.13 2.5 7 2.5s7-1.12 7-2.5v-5" />
+          <path d="M5 10.5v5c0 1.38 3.13 2.5 7 2.5s7-1.12 7-2.5v-5" />
+        </>
+      );
+    case 'service':
+      return (
+        <>
+          <path d="M8.2 5.2 4.7 8.7a2 2 0 0 0 0 2.8l3.5 3.5" />
+          <path d="m15.8 5.2 3.5 3.5a2 2 0 0 1 0 2.8L15.8 15" />
+          <path d="m13.7 4-3.4 16" />
+        </>
+      );
+    case 'dashboard':
+      return (
+        <>
+          <rect x="4" y="4" width="16" height="16" rx="2.5" />
+          <path d="M4 10h16M10 10v10" />
+          <path d="m13 16 2-2 2 1 2-3" />
+        </>
+      );
+    case 'sync':
+      return (
+        <>
+          <path d="M5 8h12.5" />
+          <path d="m14.5 5 3 3-3 3" />
+          <path d="M19 16H6.5" />
+          <path d="m9.5 13-3 3 3 3" />
+        </>
+      );
+    case 'quality':
+      return (
+        <>
+          <circle cx="12" cy="12" r="8" />
+          <path d="m8.5 12 2.3 2.4 4.9-5" />
+        </>
+      );
+    case 'file':
+      return (
+        <>
+          <path d="M7 3.8h6l4 4V20H7z" />
+          <path d="M13 3.8V8h4M9.5 12h5M9.5 15.5h5" />
+        </>
+      );
+    case 'folder':
+      return (
+        <path d="M3.8 7.5c0-1.1.9-2 2-2h4l1.8 2H18c1.2 0 2.2 1 2.2 2.2v7.1c0 1.2-1 2.2-2.2 2.2H6c-1.2 0-2.2-1-2.2-2.2z" />
+      );
+    case 'storage':
+      return (
+        <>
+          <ellipse cx="12" cy="5.5" rx="7" ry="2.5" />
+          <path d="M5 5.5v11c0 1.38 3.13 2.5 7 2.5s7-1.12 7-2.5v-11" />
+          <path d="M5 11c0 1.38 3.13 2.5 7 2.5s7-1.12 7-2.5" />
+        </>
+      );
+    default:
+      return null;
+  }
+}
+
+/** Small homepage-only SVG glyphs. Keep these dependency-free. */
+export default function HomePrimitiveIcon({
+  name,
+  size = 20,
+  ...props
+}: HomePrimitiveIconProps) {
+  return (
+    <svg
+      viewBox="0 0 24 24"
+      width={size}
+      height={size}
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="1.7"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      aria-hidden="true"
+      focusable="false"
+      {...props}
+    >
+      {iconPaths(name)}
+    </svg>
+  );
+}

--- a/yak-ops-ui/src/pages/home/components/HomeQuickNavigation.tsx
+++ b/yak-ops-ui/src/pages/home/components/HomeQuickNavigation.tsx
@@ -1,0 +1,90 @@
+import {
+  canAccessNavigationRoute,
+  getRouteMetadata,
+} from '@/config/navigation';
+import { Link, useIntl, useModel } from '@umijs/max';
+import { useMemo } from 'react';
+
+import HomePrimitiveIcon, {
+  type HomePrimitiveIconName,
+} from './HomePrimitiveIcon';
+
+interface QuickNavigationItem {
+  key: string;
+  labelId: string;
+  path: string;
+  icon: HomePrimitiveIconName;
+}
+
+const QUICK_NAVIGATION_ITEMS: QuickNavigationItem[] = [
+  {
+    key: 'data-source',
+    labelId: 'pages.home.quickNavigation.dataSource',
+    path: '/data-source',
+    icon: 'dataSource',
+  },
+  {
+    key: 'offline-sync',
+    labelId: 'pages.home.quickNavigation.offlineSync',
+    path: '/sync/batch-link-up',
+    icon: 'sync',
+  },
+  {
+    key: 'data-quality',
+    labelId: 'pages.home.quickNavigation.dataQuality',
+    path: '/data-quality/overview',
+    icon: 'quality',
+  },
+  {
+    key: 'data-service',
+    labelId: 'pages.home.quickNavigation.dataService',
+    path: '/data-service',
+    icon: 'service',
+  },
+];
+
+export default function HomeQuickNavigation() {
+  const intl = useIntl();
+  const { initialState } = useModel('@@initialState');
+  const permissionCodes = initialState?.currentUser?.permissionCodes;
+  const menuCodes = initialState?.currentUser?.menuCodes;
+
+  const navigationItems = useMemo(
+    () =>
+      QUICK_NAVIGATION_ITEMS.filter((item) => {
+        const route = getRouteMetadata(item.path);
+        return (
+          !route ||
+          canAccessNavigationRoute(route, permissionCodes, menuCodes)
+        );
+      }),
+    [menuCodes, permissionCodes],
+  );
+
+  return (
+    <section className="rounded-[22px] border border-[#f0f1f3] bg-white px-6 pb-5 pt-5">
+      <header>
+        <h2 className="m-0 text-xl font-semibold tracking-[-0.35px] text-[#252832]">
+          {intl.formatMessage({ id: 'pages.home.quickNavigation.title' })}
+        </h2>
+      </header>
+
+      <div className="mt-5 grid grid-cols-4 gap-2">
+        {navigationItems.map((item) => (
+          <Link
+            key={item.key}
+            to={item.path}
+            className="group flex min-w-0 flex-col items-center text-center text-[#555b65] transition-colors hover:text-[#252832]"
+          >
+            <span className="flex h-11 w-11 items-center justify-center rounded-[12px] border border-[#eef0f3] bg-[#fafbfc] text-[#69707a] transition-all duration-150 group-hover:border-[#e3e6ea] group-hover:bg-[#f5f6f8] group-hover:text-[#343941]">
+              <HomePrimitiveIcon name={item.icon} size={21} />
+            </span>
+            <span className="mt-2 w-full truncate text-[11px] font-medium leading-4">
+              {intl.formatMessage({ id: item.labelId })}
+            </span>
+          </Link>
+        ))}
+      </div>
+    </section>
+  );
+}

--- a/yak-ops-ui/src/pages/home/components/HomeResourceCenter.tsx
+++ b/yak-ops-ui/src/pages/home/components/HomeResourceCenter.tsx
@@ -1,0 +1,93 @@
+import { Link, useIntl } from '@umijs/max';
+
+import HomePrimitiveIcon, {
+  type HomePrimitiveIconName,
+} from './HomePrimitiveIcon';
+
+interface ResourceMetricDefinition {
+  key: string;
+  labelId: string;
+  icon: HomePrimitiveIconName;
+}
+
+const RESOURCE_METRICS: ResourceMetricDefinition[] = [
+  {
+    key: 'files',
+    labelId: 'pages.home.resourceCenter.files',
+    icon: 'file',
+  },
+  {
+    key: 'folders',
+    labelId: 'pages.home.resourceCenter.folders',
+    icon: 'folder',
+  },
+  {
+    key: 'storage',
+    labelId: 'pages.home.resourceCenter.storage',
+    icon: 'storage',
+  },
+];
+
+/**
+ * Frontend-only resource summary shell. The values deliberately remain `--`
+ * until a dedicated home resource summary endpoint is introduced.
+ */
+export default function HomeResourceCenter() {
+  const intl = useIntl();
+
+  return (
+    <section className="rounded-[22px] border border-[#f0f1f3] bg-white px-6 pb-5 pt-5">
+      <header className="flex items-center justify-between gap-4">
+        <h2 className="m-0 text-xl font-semibold tracking-[-0.35px] text-[#252832]">
+          {intl.formatMessage({ id: 'pages.home.resourceCenter.title' })}
+        </h2>
+
+        <Link
+          to="/resource-management"
+          className="group flex shrink-0 items-center gap-0.5 text-[12px] font-medium text-[#7a8089] transition-colors hover:text-[#30353d]"
+        >
+          {intl.formatMessage({ id: 'pages.home.common.viewMore' })}
+          <span className="text-[15px] font-light leading-none transition-transform group-hover:translate-x-0.5">
+            ›
+          </span>
+        </Link>
+      </header>
+
+      <div className="mt-4 grid grid-cols-3 gap-2 border-t border-[#eef0f2] pt-4">
+        {RESOURCE_METRICS.map((metric) => (
+          <div key={metric.key} className="min-w-0 text-center">
+            <span className="mx-auto flex h-9 w-9 items-center justify-center rounded-[10px] bg-[#f7f8fa] text-[#7b818b]">
+              <HomePrimitiveIcon name={metric.icon} size={18} />
+            </span>
+            <strong className="mt-2 block text-[17px] font-semibold leading-5 text-[#434851]">
+              --
+            </strong>
+            <span className="mt-1 block truncate text-[10px] text-[#969ba3]">
+              {intl.formatMessage({ id: metric.labelId })}
+            </span>
+          </div>
+        ))}
+      </div>
+
+      <div className="mt-4 border-t border-[#eef0f2] pt-3.5">
+        <div className="flex items-center justify-between gap-3">
+          <strong className="text-[12px] font-semibold text-[#555a64]">
+            {intl.formatMessage({ id: 'pages.home.resourceCenter.recent' })}
+          </strong>
+          <span className="text-[10px] text-[#a0a5ad]">
+            {intl.formatMessage({ id: 'pages.home.resourceCenter.preview' })}
+          </span>
+        </div>
+
+        <div className="mt-3 flex min-h-[74px] items-center justify-center rounded-[12px] bg-[#fafbfc] px-4 text-center">
+          <div className="flex items-center gap-2 text-[#a0a5ad]">
+            <HomePrimitiveIcon name="file" size={18} />
+            <span className="text-[11px]">
+              {intl.formatMessage({ id: 'pages.home.resourceCenter.empty' })}
+            </span>
+          </div>
+        </div>
+      </div>
+    </section>
+  );
+}


### PR DESCRIPTION
## Summary

- add a frontend-only **Data Assets** panel in the left column, split into **Datasets / Data Services / Dashboards**
- add **Quick Navigation** directly below Schedule Center and **Resource Center** below Quick Navigation
- keep data-asset and resource statistics as `--` / empty preview states for now; no new backend read models or APIs are introduced in this PR
- make Quick Navigation reuse existing routes and respect the current navigation permission contract
- add dedicated zh-CN / en-US copy for the new homepage sections
- use dependency-free inline SVG glyphs for all newly added icons; **no `lucide-react` is used by the new components**

## Layout

- left: Data Center → Data Quality → Data Assets
- right: Notifications → Schedule Center → Quick Navigation → Resource Center

## Scope

Frontend structure only. Backend aggregation for dataset/service/dashboard lists and file/resource statistics is intentionally deferred to a follow-up PR.