### PR TITLE
fix(home): complete quick navigation i18n

### DIFF
--- a/yak-ops-ui/src/locales/en-US/home-sections.ts
+++ b/yak-ops-ui/src/locales/en-US/home-sections.ts
@@ -8,6 +8,9 @@ export default {
   'pages.home.dataAssets.dashboardEmpty': 'No dashboard preview yet',
 
   'pages.home.quickNavigation.title': 'Quick Navigation',
+  'pages.home.quickNavigation.digitalScreen': 'Digital Screen',
+  'pages.home.quickNavigation.dataCatalog': 'Data Catalog',
+  'pages.home.quickNavigation.dashboard': 'Dashboard',
   'pages.home.quickNavigation.dataSource': 'Data Sources',
   'pages.home.quickNavigation.offlineSync': 'Batch Sync',
   'pages.home.quickNavigation.dataQuality': 'Data Quality',

--- a/yak-ops-ui/src/locales/zh-CN/home-sections.ts
+++ b/yak-ops-ui/src/locales/zh-CN/home-sections.ts
@@ -8,6 +8,9 @@ export default {
   'pages.home.dataAssets.dashboardEmpty': '暂无仪表盘预览',
 
   'pages.home.quickNavigation.title': '快捷导航',
+  'pages.home.quickNavigation.digitalScreen': '去大屏',
+  'pages.home.quickNavigation.dataCatalog': '数据目录',
+  'pages.home.quickNavigation.dashboard': '仪表盘',
   'pages.home.quickNavigation.dataSource': '数据源',
   'pages.home.quickNavigation.offlineSync': '离线同步',
   'pages.home.quickNavigation.dataQuality': '数据质量',


### PR DESCRIPTION
## Summary
- add zh-CN translations for the new quick navigation entries
- add en-US translations for Digital Screen, Data Catalog, and Dashboard
- keep the existing homepage quick navigation implementation unchanged

## Scope
- `yak-ops-ui/src/locales/zh-CN/home-sections.ts`
- `yak-ops-ui/src/locales/en-US/home-sections.ts`

## Notes
- This is an i18n-only follow-up for the homepage quick navigation changes already on `main`.
- No layout or navigation behavior changes are included.