### PR TITLE
feat(home): wire data assets to real services

### DIFF
--- a/yak-ops-ui/src/locales/en-US/home-sections.ts
+++ b/yak-ops-ui/src/locales/en-US/home-sections.ts
@@ -5,7 +5,10 @@ export default {
   'pages.home.dataAssets.dataService': 'Data Services',
   'pages.home.dataAssets.dataServiceEmpty': 'No data service preview yet',
   'pages.home.dataAssets.dashboard': 'Dashboards',
+  'pages.home.dataAssets.dashboardTab': 'Dashboard',
   'pages.home.dataAssets.dashboardEmpty': 'No dashboard preview yet',
+  'pages.home.dataAssets.screenTab': 'Digital Screen',
+  'pages.home.dataAssets.screenEmpty': 'No digital screen preview yet',
 
   'pages.home.quickNavigation.title': 'Quick Navigation',
   'pages.home.quickNavigation.digitalScreen': 'Digital Screen',

--- a/yak-ops-ui/src/locales/zh-CN/home-sections.ts
+++ b/yak-ops-ui/src/locales/zh-CN/home-sections.ts
@@ -5,7 +5,10 @@ export default {
   'pages.home.dataAssets.dataService': '数据服务列表',
   'pages.home.dataAssets.dataServiceEmpty': '暂无数据服务预览',
   'pages.home.dataAssets.dashboard': '仪表盘列表',
+  'pages.home.dataAssets.dashboardTab': '仪表盘',
   'pages.home.dataAssets.dashboardEmpty': '暂无仪表盘预览',
+  'pages.home.dataAssets.screenTab': '大屏',
+  'pages.home.dataAssets.screenEmpty': '暂无大屏预览',
 
   'pages.home.quickNavigation.title': '快捷导航',
   'pages.home.quickNavigation.digitalScreen': '去大屏',

--- a/yak-ops-ui/src/pages/home/components/HomeDataAssets.tsx
+++ b/yak-ops-ui/src/pages/home/components/HomeDataAssets.tsx
@@ -1,6 +1,12 @@
 import YakTab from '@/components/YakTab';
-import { useIntl } from '@umijs/max';
+import type { DashboardSummary } from '@/services/dashboard';
+import type { DataServiceApi } from '@/services/data-service';
+import type { DigitalScreenInstance } from '@/services/digital-screen';
+import type { HomeAssetDatasetItem } from '@/services/home';
+import { history, useIntl } from '@umijs/max';
 import { useEffect, useRef, useState } from 'react';
+
+import { useHomeDataAssets } from '../hooks/useHomeDataAssets';
 
 type CenterTabKey = 'dashboard' | 'screen';
 
@@ -9,338 +15,188 @@ interface AssetItem {
   title: string;
   description: string;
   code: string;
-  thumbnailClassName: string;
+  path: string;
 }
 
 interface AssetListProps {
   items: AssetItem[];
+  loading: boolean;
+  failed: boolean;
+  emptyText: string;
+  viewAllPath: string;
 }
 
 const MAX_VISIBLE_ITEMS = 5;
-
 const EXIT_DURATION = 90;
 const ENTER_DURATION = 200;
 
-/**
- * Mock data only.
- *
- * These data sources will be replaced by backend APIs later.
- */
-const DATASET_ITEMS: AssetItem[] = [
-  {
-    key: 'dataset-1',
-    title: '用户订单明细数据集',
-    description: 'MySQL · 36 个字段 · 12.8 万行',
-    code: 'DS',
-    thumbnailClassName: 'bg-[#eef4ff]',
-  },
-  {
-    key: 'dataset-2',
-    title: '商品销售汇总数据集',
-    description: 'StarRocks · 28 个字段 · 8.6 万行',
-    code: 'DS',
-    thumbnailClassName: 'bg-[#f1f8ed]',
-  },
-  {
-    key: 'dataset-3',
-    title: '客户基础信息数据集',
-    description: 'PostgreSQL · 42 个字段 · 5.2 万行',
-    code: 'DS',
-    thumbnailClassName: 'bg-[#fff4e8]',
-  },
-  {
-    key: 'dataset-4',
-    title: '门店经营指标数据集',
-    description: 'Doris · 24 个字段 · 3.7 万行',
-    code: 'DS',
-    thumbnailClassName: 'bg-[#f5efff]',
-  },
-  {
-    key: 'dataset-5',
-    title: '供应链库存数据集',
-    description: 'Oracle · 31 个字段 · 16.4 万行',
-    code: 'DS',
-    thumbnailClassName: 'bg-[#edf8f7]',
-  },
-  {
-    key: 'dataset-6',
-    title: '会员行为分析数据集',
-    description: 'ClickHouse · 46 个字段 · 28.1 万行',
-    code: 'DS',
-    thumbnailClassName: 'bg-[#fff1f4]',
-  },
-];
+const DATASET_LIST_PATH = '/dataset';
+const DASHBOARD_LIST_PATH = '/dashboard';
+const DIGITAL_SCREEN_LIST_PATH = '/digital-screen';
+const DATA_SERVICE_LIST_PATH = '/data-service';
 
-const DASHBOARD_ITEMS: AssetItem[] = [
-  {
-    key: 'dashboard-1',
-    title: '销售经营分析仪表盘',
-    description: '12 个图表 · 10 分钟前更新',
-    code: 'BI',
-    thumbnailClassName: 'bg-[#f0f4ff]',
-  },
-  {
-    key: 'dashboard-2',
-    title: '用户增长分析仪表盘',
-    description: '9 个图表 · 25 分钟前更新',
-    code: 'BI',
-    thumbnailClassName: 'bg-[#fff3e9]',
-  },
-  {
-    key: 'dashboard-3',
-    title: '商品运营分析仪表盘',
-    description: '16 个图表 · 1 小时前更新',
-    code: 'BI',
-    thumbnailClassName: 'bg-[#f2f8ec]',
-  },
-  {
-    key: 'dashboard-4',
-    title: '供应链监控仪表盘',
-    description: '8 个图表 · 今天 16:40 更新',
-    code: 'BI',
-    thumbnailClassName: 'bg-[#f5f0ff]',
-  },
-  {
-    key: 'dashboard-5',
-    title: '数据质量运营仪表盘',
-    description: '11 个图表 · 今天 15:26 更新',
-    code: 'BI',
-    thumbnailClassName: 'bg-[#edf8f7]',
-  },
-  {
-    key: 'dashboard-6',
-    title: '财务指标分析仪表盘',
-    description: '14 个图表 · 昨天更新',
-    code: 'BI',
-    thumbnailClassName: 'bg-[#fff1f3]',
-  },
-];
-
-const SCREEN_ITEMS: AssetItem[] = [
-  {
-    key: 'screen-1',
-    title: '企业经营驾驶舱',
-    description: '1920 × 1080 · 18 个组件',
-    code: 'SC',
-    thumbnailClassName: 'bg-[#edf3ff]',
-  },
-  {
-    key: 'screen-2',
-    title: '实时销售数据大屏',
-    description: '1920 × 1080 · 21 个组件',
-    code: 'SC',
-    thumbnailClassName: 'bg-[#eef8f4]',
-  },
-  {
-    key: 'screen-3',
-    title: '智慧园区运营大屏',
-    description: '2560 × 1440 · 16 个组件',
-    code: 'SC',
-    thumbnailClassName: 'bg-[#fff3e8]',
-  },
-  {
-    key: 'screen-4',
-    title: '供应链实时监控大屏',
-    description: '1920 × 1080 · 24 个组件',
-    code: 'SC',
-    thumbnailClassName: 'bg-[#f5efff]',
-  },
-  {
-    key: 'screen-5',
-    title: '数据中心运行态势大屏',
-    description: '2560 × 1440 · 20 个组件',
-    code: 'SC',
-    thumbnailClassName: 'bg-[#eef7fa]',
-  },
-  {
-    key: 'screen-6',
-    title: '客户服务运营大屏',
-    description: '1920 × 1080 · 13 个组件',
-    code: 'SC',
-    thumbnailClassName: 'bg-[#fff0f4]',
-  },
-];
-
-const SERVICE_ITEMS: AssetItem[] = [
-  {
-    key: 'service-1',
-    title: '用户信息查询服务',
-    description: 'REST API · 2 个接口 · 正常',
-    code: 'API',
-    thumbnailClassName: 'bg-[#edf4ff]',
-  },
-  {
-    key: 'service-2',
-    title: '商品实时库存服务',
-    description: 'REST API · 4 个接口 · 正常',
-    code: 'API',
-    thumbnailClassName: 'bg-[#eff8ed]',
-  },
-  {
-    key: 'service-3',
-    title: '订单状态查询服务',
-    description: 'REST API · 3 个接口 · 正常',
-    code: 'API',
-    thumbnailClassName: 'bg-[#fff4e8]',
-  },
-  {
-    key: 'service-4',
-    title: '客户标签查询服务',
-    description: 'REST API · 5 个接口 · 正常',
-    code: 'API',
-    thumbnailClassName: 'bg-[#f4efff]',
-  },
-  {
-    key: 'service-5',
-    title: '经营指标聚合服务',
-    description: 'REST API · 6 个接口 · 正常',
-    code: 'API',
-    thumbnailClassName: 'bg-[#edf8f7]',
-  },
-  {
-    key: 'service-6',
-    title: '组织架构查询服务',
-    description: 'REST API · 2 个接口 · 正常',
-    code: 'API',
-    thumbnailClassName: 'bg-[#fff1f4]',
-  },
-];
+const THUMBNAIL_CLASSES = [
+  'bg-[#eef4ff]',
+  'bg-[#f1f8ed]',
+  'bg-[#fff4e8]',
+  'bg-[#f5efff]',
+  'bg-[#edf8f7]',
+] as const;
 
 const getRankClassName = (index: number) => {
   switch (index) {
     case 0:
       return 'bg-[#ff3d5f] text-white';
-
     case 1:
       return 'bg-[#ff7a1a] text-white';
-
     case 2:
       return 'bg-[#f5b700] text-white';
-
     default:
       return 'bg-[#a4a8b0] text-white';
   }
 };
 
-/**
- * Header used by dataset and data-service columns.
- *
- * Its height and underline are aligned with YakTab.
- */
+const formatRelativeTime = (value?: string | null, locale = 'zh-CN') => {
+  if (!value) return '--';
+  const timestamp = new Date(value).getTime();
+  if (!Number.isFinite(timestamp)) return value;
+
+  const minutes = Math.max(0, Math.floor((Date.now() - timestamp) / 60000));
+  const formatter = new Intl.RelativeTimeFormat(locale, { numeric: 'auto' });
+  if (minutes < 1) return formatter.format(0, 'minute');
+  if (minutes < 60) return formatter.format(-minutes, 'minute');
+  const hours = Math.floor(minutes / 60);
+  if (hours < 24) return formatter.format(-hours, 'hour');
+  const days = Math.floor(hours / 24);
+  if (days < 7) return formatter.format(-days, 'day');
+  return new Date(timestamp).toLocaleDateString(locale, {
+    month: '2-digit',
+    day: '2-digit',
+  });
+};
+
+const joinDescription = (...values: Array<string | null | undefined>) => {
+  const parts = values
+    .map((value) => value?.trim())
+    .filter((value): value is string => Boolean(value && value !== '--'));
+  return parts.join(' · ') || '--';
+};
+
+const dashboardOpenPath = (dashboard: DashboardSummary) =>
+  Number(dashboard.publishedVersionNo) > 0
+    ? `/dashboard/${encodeURIComponent(dashboard.id)}`
+    : `/dashboard/${encodeURIComponent(dashboard.id)}/edit`;
+
+const digitalScreenOpenPath = (screen: DigitalScreenInstance) =>
+  screen.status === 'published'
+    ? `/digital-screen/${encodeURIComponent(screen.id)}`
+    : `/digital-screen/${encodeURIComponent(screen.id)}/edit`;
+
 function StaticSectionHeader({ title }: { title: string }) {
   return (
     <div className="relative flex h-[35px] shrink-0 border-b border-[#eceef2]">
       <div className="relative flex h-full items-start pb-2 text-[13px] font-semibold text-[#292c35]">
         {title}
-
         <span className="absolute bottom-[-1px] left-0 right-0 h-[3px] bg-[#252832]" />
       </div>
     </div>
   );
 }
 
-/**
- * Shared asset list.
- *
- * Homepage only displays the first five items.
- */
-function AssetList({ items }: AssetListProps) {
+function AssetList({
+  items,
+  loading,
+  failed,
+  emptyText,
+  viewAllPath,
+}: AssetListProps) {
+  const intl = useIntl();
   const visibleItems = items.slice(0, MAX_VISIBLE_ITEMS);
 
   return (
     <div className="flex min-h-0 flex-1 flex-col">
       <div className="mt-2 flex-1">
-        {visibleItems.map((item, index) => (
-          <div
-            key={item.key}
-            className="group flex min-w-0 items-center gap-3 py-[9px]"
-          >
-            <div
-              className={[
-                'relative flex h-[52px] w-[52px] shrink-0 items-center justify-center',
-                'overflow-hidden rounded-[8px]',
-                item.thumbnailClassName,
-              ].join(' ')}
+        {loading ? (
+          <div className="flex min-h-[350px] items-center justify-center text-[12px] text-[#9ca0a8]">
+            {intl.formatMessage({ id: 'pages.home.common.loading' })}
+          </div>
+        ) : failed ? (
+          <div className="flex min-h-[350px] items-center justify-center text-[12px] text-[#9ca0a8]">
+            {intl.formatMessage({ id: 'pages.home.common.loadFailed' })}
+          </div>
+        ) : visibleItems.length === 0 ? (
+          <div className="flex min-h-[350px] items-center justify-center text-[12px] text-[#9ca0a8]">
+            {emptyText}
+          </div>
+        ) : (
+          visibleItems.map((item, index) => (
+            <button
+              key={item.key}
+              type="button"
+              onClick={() => history.push(item.path)}
+              className="group flex w-full min-w-0 items-center gap-3 border-0 bg-transparent py-[9px] text-left"
             >
-              <span className="text-[12px] font-semibold tracking-[0.4px] text-[#5d6470]">
-                {item.code}
-              </span>
-
               <span
                 className={[
-                  'absolute left-0 top-0 flex h-[17px] min-w-[17px]',
-                  'items-center justify-center px-1',
-                  'rounded-br-[5px] text-[10px] font-semibold leading-none',
-                  getRankClassName(index),
+                  'relative flex h-[52px] w-[52px] shrink-0 items-center justify-center',
+                  'overflow-hidden rounded-[8px]',
+                  THUMBNAIL_CLASSES[index % THUMBNAIL_CLASSES.length],
                 ].join(' ')}
               >
-                {index + 1}
+                <span className="text-[12px] font-semibold tracking-[0.4px] text-[#5d6470]">
+                  {item.code}
+                </span>
+                <span
+                  className={[
+                    'absolute left-0 top-0 flex h-[17px] min-w-[17px]',
+                    'items-center justify-center px-1',
+                    'rounded-br-[5px] text-[10px] font-semibold leading-none',
+                    getRankClassName(index),
+                  ].join(' ')}
+                >
+                  {index + 1}
+                </span>
               </span>
-            </div>
 
-            <div className="min-w-0 flex-1">
-              <div className="truncate text-[13px] font-medium leading-5 text-[#292d36] transition-colors group-hover:text-[#111318]">
-                {item.title}
-              </div>
-
-              <div className="mt-1 truncate text-[12px] leading-5 text-[#858a93]">
-                {item.description}
-              </div>
-            </div>
-          </div>
-        ))}
+              <span className="min-w-0 flex-1">
+                <span className="block truncate text-[13px] font-medium leading-5 text-[#292d36] transition-colors group-hover:text-[#111318]">
+                  {item.title}
+                </span>
+                <span className="mt-1 block truncate text-[12px] leading-5 text-[#858a93]">
+                  {item.description}
+                </span>
+              </span>
+            </button>
+          ))
+        )}
       </div>
 
       <button
         type="button"
-        className="mx-auto mt-2 flex h-7 shrink-0 items-center gap-1 text-[12px] text-[#7b8089] transition-colors hover:text-[#252832]"
+        onClick={() => history.push(viewAllPath)}
+        className="mx-auto mt-2 flex h-7 shrink-0 items-center gap-1 border-0 bg-transparent text-[12px] text-[#7b8089] transition-colors hover:text-[#252832]"
       >
-        查看全部
-
+        {intl.formatMessage({ id: 'pages.home.common.viewMore' })}
         <span className="text-[16px] leading-none">›</span>
       </button>
     </div>
   );
 }
 
-/**
- * Frontend-only homepage data-assets overview.
- *
- * Dataset, dashboard, digital-screen and data-service content currently
- * uses mock data and will be connected to backend APIs separately.
- */
 export default function HomeDataAssets() {
   const intl = useIntl();
-
-  /**
-   * Controls YakTab immediately.
-   *
-   * The tab underline responds immediately after clicking.
-   */
+  const { datasets, dashboards, screens, services } = useHomeDataAssets();
   const [activeCenterTab, setActiveCenterTab] =
     useState<CenterTabKey>('dashboard');
-
-  /**
-   * Controls the actual content being rendered.
-   *
-   * It is intentionally separated from activeCenterTab so the old content
-   * can finish fading out before we replace it with the new content.
-   */
   const [renderedCenterTab, setRenderedCenterTab] =
     useState<CenterTabKey>('dashboard');
-
   const [contentVisible, setContentVisible] = useState(true);
-
   const switchTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
-
   const animationFrameRef = useRef<number | null>(null);
 
   useEffect(() => {
     return () => {
-      if (switchTimerRef.current) {
-        clearTimeout(switchTimerRef.current);
-      }
-
+      if (switchTimerRef.current) clearTimeout(switchTimerRef.current);
       if (animationFrameRef.current !== null) {
         cancelAnimationFrame(animationFrameRef.current);
       }
@@ -349,78 +205,137 @@ export default function HomeDataAssets() {
 
   const handleCenterTabChange = (key: string) => {
     const nextTab = key as CenterTabKey;
+    if (nextTab === activeCenterTab) return;
 
-    if (nextTab === activeCenterTab) {
-      return;
-    }
-
-    /**
-     * The tab itself switches immediately.
-     */
     setActiveCenterTab(nextTab);
 
-    /**
-     * Cancel unfinished transitions when users switch tabs quickly.
-     */
     if (switchTimerRef.current) {
       clearTimeout(switchTimerRef.current);
       switchTimerRef.current = null;
     }
-
     if (animationFrameRef.current !== null) {
       cancelAnimationFrame(animationFrameRef.current);
       animationFrameRef.current = null;
     }
 
-    /**
-     * Phase 1:
-     * Fade out the current list quickly.
-     */
     setContentVisible(false);
-
     switchTimerRef.current = setTimeout(() => {
-      /**
-       * Phase 2:
-       * Replace the content while the container is invisible.
-       */
       setRenderedCenterTab(nextTab);
-
-      /**
-       * Phase 3:
-       * Wait until the browser enters the next frame,
-       * then fade the new content back in.
-       */
       animationFrameRef.current = requestAnimationFrame(() => {
         setContentVisible(true);
         animationFrameRef.current = null;
       });
-
       switchTimerRef.current = null;
     }, EXIT_DURATION);
   };
 
+  const datasetItems: AssetItem[] = datasets.items.map(
+    (item: HomeAssetDatasetItem) => {
+      const normalizedStatus = item.status?.toUpperCase();
+      const status =
+        normalizedStatus === 'ONLINE'
+          ? intl.formatMessage({ id: 'pages.home.dataset.status.online' })
+          : normalizedStatus === 'OFFLINE'
+            ? intl.formatMessage({ id: 'pages.home.dataset.status.offline' })
+            : item.status ||
+              intl.formatMessage({ id: 'pages.home.dataset.status.unknown' });
+
+      return {
+        key: `dataset-${item.id}`,
+        title: item.name,
+        description: joinDescription(
+          status,
+          formatRelativeTime(item.updatedAt, intl.locale),
+        ),
+        code: 'DS',
+        path: `/dataset/${encodeURIComponent(item.id)}`,
+      };
+    },
+  );
+
+  const dashboardItems: AssetItem[] = dashboards.items.map((item) => ({
+    key: `dashboard-${item.id}`,
+    title: item.name,
+    description: joinDescription(
+      item.description || `V${item.currentVersionNo || 0}`,
+      formatRelativeTime(item.updateTime || item.createTime, intl.locale),
+    ),
+    code: 'BI',
+    path: dashboardOpenPath(item),
+  }));
+
+  const screenItems: AssetItem[] = screens.items.map((item) => {
+    const revision =
+      item.status === 'published' && item.publishedVersionNo
+        ? `V${item.publishedVersionNo}`
+        : item.revision
+          ? `R${item.revision}`
+          : undefined;
+
+    return {
+      key: `screen-${item.id}`,
+      title: item.name,
+      description: joinDescription(
+        item.description || revision,
+        formatRelativeTime(item.updatedAt, intl.locale),
+      ),
+      code: 'SC',
+      path: digitalScreenOpenPath(item),
+    };
+  });
+
+  const serviceItems: AssetItem[] = services.items.map(
+    (item: DataServiceApi) => ({
+      key: `service-${item.id}`,
+      title: item.name,
+      description: joinDescription(
+        item.path,
+        formatRelativeTime(item.updateTime || item.createTime, intl.locale),
+      ),
+      code: 'API',
+      path: `/data-service/api/${encodeURIComponent(String(item.id))}`,
+    }),
+  );
+
+  const centerState =
+    renderedCenterTab === 'dashboard' ? dashboards : screens;
   const centerItems =
-    renderedCenterTab === 'dashboard' ? DASHBOARD_ITEMS : SCREEN_ITEMS;
+    renderedCenterTab === 'dashboard' ? dashboardItems : screenItems;
+  const centerEmptyText = intl.formatMessage({
+    id:
+      renderedCenterTab === 'dashboard'
+        ? 'pages.home.dataAssets.dashboardEmpty'
+        : 'pages.home.dataAssets.screenEmpty',
+  });
+  const centerViewAllPath =
+    renderedCenterTab === 'dashboard'
+      ? DASHBOARD_LIST_PATH
+      : DIGITAL_SCREEN_LIST_PATH;
 
   return (
     <section className="flex h-full min-h-[520px] min-w-0 flex-col rounded-[22px] border border-[#f0f1f3] bg-white px-6 pb-5 pt-5">
       <header className="shrink-0">
         <h2 className="m-0 text-xl font-semibold tracking-[-0.35px] text-[#252832]">
-          {intl.formatMessage({
-            id: 'pages.home.dataAssets.title',
-          })}
+          {intl.formatMessage({ id: 'pages.home.dataAssets.title' })}
         </h2>
       </header>
 
       <div className="mt-4 grid min-h-0 flex-1 grid-cols-1 lg:grid-cols-3">
-        {/* Dataset */}
         <div className="flex min-w-0 flex-col pb-5 lg:pb-0 lg:pr-6">
-          <StaticSectionHeader title="数据集列表" />
-
-          <AssetList items={DATASET_ITEMS} />
+          <StaticSectionHeader
+            title={intl.formatMessage({ id: 'pages.home.dataAssets.dataset' })}
+          />
+          <AssetList
+            items={datasetItems}
+            loading={datasets.loading}
+            failed={datasets.failed}
+            emptyText={intl.formatMessage({
+              id: 'pages.home.dataAssets.datasetEmpty',
+            })}
+            viewAllPath={DATASET_LIST_PATH}
+          />
         </div>
 
-        {/* Dashboard / Digital screen */}
         <div className="flex min-w-0 flex-col border-t border-[#eceef2] py-5 lg:border-l lg:border-t-0 lg:px-6 lg:py-0">
           <YakTab
             className="shrink-0"
@@ -429,33 +344,23 @@ export default function HomeDataAssets() {
             items={[
               {
                 key: 'dashboard',
-                label: '仪表盘',
+                label: intl.formatMessage({
+                  id: 'pages.home.dataAssets.dashboardTab',
+                }),
               },
               {
                 key: 'screen',
-                label: '大屏',
+                label: intl.formatMessage({
+                  id: 'pages.home.dataAssets.screenTab',
+                }),
               },
             ]}
           />
 
-          {/*
-           * Content transition
-           *
-           * Switching rhythm:
-           *
-           * old content
-           * opacity 1 -> 0
-           *
-           * replace data
-           *
-           * new content
-           * opacity 0 -> 1
-           * translateY 4px -> 0
-           */}
           <div
             className={[
               'flex min-h-0 flex-1 flex-col',
-              'transition-[opacity]',
+              'transition-[opacity,transform]',
               'ease-[cubic-bezier(0.16,1,0.3,1)]',
               contentVisible
                 ? 'translate-y-0 opacity-100'
@@ -467,15 +372,31 @@ export default function HomeDataAssets() {
                 : `${EXIT_DURATION}ms`,
             }}
           >
-            <AssetList items={centerItems} />
+            <AssetList
+              items={centerItems}
+              loading={centerState.loading}
+              failed={centerState.failed}
+              emptyText={centerEmptyText}
+              viewAllPath={centerViewAllPath}
+            />
           </div>
         </div>
 
-        {/* Data service */}
         <div className="flex min-w-0 flex-col border-t border-[#eceef2] pt-5 lg:border-l lg:border-t-0 lg:pl-6 lg:pt-0">
-          <StaticSectionHeader title="数据服务列表" />
-
-          <AssetList items={SERVICE_ITEMS} />
+          <StaticSectionHeader
+            title={intl.formatMessage({
+              id: 'pages.home.dataAssets.dataService',
+            })}
+          />
+          <AssetList
+            items={serviceItems}
+            loading={services.loading}
+            failed={services.failed}
+            emptyText={intl.formatMessage({
+              id: 'pages.home.dataAssets.dataServiceEmpty',
+            })}
+            viewAllPath={DATA_SERVICE_LIST_PATH}
+          />
         </div>
       </div>
     </section>

--- a/yak-ops-ui/src/pages/home/hooks/useHomeDataAssets.ts
+++ b/yak-ops-ui/src/pages/home/hooks/useHomeDataAssets.ts
@@ -1,0 +1,129 @@
+import {
+  fetchDashboardOverview,
+  type DashboardSummary,
+} from '@/services/dashboard';
+import {
+  listDataServices,
+  type DataServiceApi,
+} from '@/services/data-service';
+import {
+  listDigitalScreens,
+  type DigitalScreenInstance,
+} from '@/services/digital-screen';
+import {
+  homeAssetOverviewApi,
+  type HomeAssetDatasetItem,
+} from '@/services/home';
+import { useEffect, useState } from 'react';
+
+const PREVIEW_LIMIT = 5;
+
+export interface HomeDataAssetListState<T> {
+  items: T[];
+  loading: boolean;
+  failed: boolean;
+}
+
+const timestamp = (value?: string | null) => {
+  if (!value) return 0;
+  const parsed = new Date(value).getTime();
+  return Number.isFinite(parsed) ? parsed : 0;
+};
+
+const recentFirst = <T,>(
+  items: T[],
+  resolveTime: (item: T) => string | null | undefined,
+) =>
+  [...items]
+    .sort((left, right) => timestamp(resolveTime(right)) - timestamp(resolveTime(left)))
+    .slice(0, PREVIEW_LIMIT);
+
+export function useHomeDataAssets() {
+  const [datasets, setDatasets] = useState<
+    HomeDataAssetListState<HomeAssetDatasetItem>
+  >({ items: [], loading: true, failed: false });
+  const [dashboards, setDashboards] = useState<
+    HomeDataAssetListState<DashboardSummary>
+  >({ items: [], loading: true, failed: false });
+  const [screens, setScreens] = useState<
+    HomeDataAssetListState<DigitalScreenInstance>
+  >({ items: [], loading: true, failed: false });
+  const [services, setServices] = useState<
+    HomeDataAssetListState<DataServiceApi>
+  >({ items: [], loading: true, failed: false });
+
+  useEffect(() => {
+    let active = true;
+
+    void homeAssetOverviewApi
+      .overview()
+      .then((response) => {
+        if (!active) return;
+        setDatasets({
+          items: (response.data?.dataset?.recentDatasets || []).slice(
+            0,
+            PREVIEW_LIMIT,
+          ),
+          loading: false,
+          failed: false,
+        });
+      })
+      .catch(() => {
+        if (!active) return;
+        setDatasets({ items: [], loading: false, failed: true });
+      });
+
+    void fetchDashboardOverview(PREVIEW_LIMIT)
+      .then((overview) => {
+        if (!active) return;
+        setDashboards({
+          items: (overview.recentDashboards || []).slice(0, PREVIEW_LIMIT),
+          loading: false,
+          failed: false,
+        });
+      })
+      .catch(() => {
+        if (!active) return;
+        setDashboards({ items: [], loading: false, failed: true });
+      });
+
+    void listDigitalScreens()
+      .then((items) => {
+        if (!active) return;
+        setScreens({
+          items: recentFirst(items, (item) => item.updatedAt),
+          loading: false,
+          failed: false,
+        });
+      })
+      .catch(() => {
+        if (!active) return;
+        setScreens({ items: [], loading: false, failed: true });
+      });
+
+    void listDataServices()
+      .then((items) => {
+        if (!active) return;
+        setServices({
+          items: recentFirst(items, (item) => item.updateTime || item.createTime),
+          loading: false,
+          failed: false,
+        });
+      })
+      .catch(() => {
+        if (!active) return;
+        setServices({ items: [], loading: false, failed: true });
+      });
+
+    return () => {
+      active = false;
+    };
+  }, []);
+
+  return {
+    datasets,
+    dashboards,
+    screens,
+    services,
+  };
+}


### PR DESCRIPTION
## Summary
- replace the Home Data Assets mock lists with real Dataset, Dashboard, Digital Screen, and Data Service reads
- keep the existing 5-item ranked layout and Dashboard / Digital Screen fade transition
- make every preview row and every “view more” action navigate to the owning product route
- add loading / failure / empty states per column so one failed domain does not blank the entire Data Assets section
- complete the new Dashboard / Digital Screen tab i18n entries

## Real data sources
- Dataset: `GET /api/v1/home/assets/overview` via `homeAssetOverviewApi.overview()`, using `recentDatasets`
- Dashboard: `GET /api/v1/dashboards/overview?limit=5` via `fetchDashboardOverview(5)`
- Digital Screen: server-backed `listDigitalScreens()`, sorted by `updatedAt` and limited to 5
- Data Service: `listDataServices()`, sorted by `updateTime/createTime` and limited to 5

The requests are isolated in a new `useHomeDataAssets` hook. Each domain keeps its own loading/error state, and the Dashboard / Digital Screen data is prefetched once so the existing tab animation does not wait on a network request.

## Navigation fixes
- Dataset list: `/dataset`
- Dataset detail: `/dataset/:id`
- Dashboard list: `/dashboard`
- Dashboard row: published -> `/dashboard/:id`, unpublished -> `/dashboard/:id/edit`
- Digital Screen list: `/digital-screen`
- Digital Screen row: published -> `/digital-screen/:id`, draft -> `/digital-screen/:id/edit`
- Data Service list: `/data-service`
- Data Service detail: `/data-service/api/:id`

These paths match the current central route definitions in `src/config/navigation.ts` rather than the older data-catalog style path.

## Files
- `yak-ops-ui/src/pages/home/components/HomeDataAssets.tsx`
- `yak-ops-ui/src/pages/home/hooks/useHomeDataAssets.ts`
- `yak-ops-ui/src/locales/zh-CN/home-sections.ts`
- `yak-ops-ui/src/locales/en-US/home-sections.ts`

## Validation
- [x] branch is based on current `main`
- [x] branch is ahead 1 / behind 0
- [x] reviewed the existing service contracts and central route definitions before wiring
- [x] final diff is frontend-only; no backend/Flyway changes
- [ ] `npm run tsc` could not be executed in the current container because `github.com` cannot be resolved for a local checkout

## Suggested browser checks
1. open `/home` with real Dataset / Dashboard / Digital Screen / Data Service records and confirm each column shows at most 5 items
2. switch Dashboard <-> Digital Screen and confirm the existing fade transition remains smooth
3. click published/unpublished Dashboard rows and verify Viewer vs Editor routing
4. click published/draft Digital Screen rows and verify Viewer vs Editor routing
5. click Dataset and Data Service rows and confirm their detail routes
6. verify “view more” for all four asset types
7. simulate one API failure and confirm the other Data Assets columns still render normally
