### PR TITLE
style(workflow): simplify inspector headers and publish action

### DIFF
--- a/yak-ops-ui/src/pages/workflow/definition/components/canvas/WorkflowNodeInspector.tsx
+++ b/yak-ops-ui/src/pages/workflow/definition/components/canvas/WorkflowNodeInspector.tsx
@@ -114,14 +114,8 @@ const WorkflowNodeInspector = ({
       <header className="shrink-0 bg-white">
         <div className="flex h-12 items-center gap-2 border-b border-[#eef0f2] px-4">
           <WorkflowNodeIcon taskType={node.data.taskType} size="sm" />
-          <div className="min-w-0 flex-1">
-            <div className="truncate text-[13px] font-semibold text-[#161823]">
-              {node.data.label}
-            </div>
-            <div className="mt-0.5 truncate text-[9px] text-[#98a2b3]">
-              {node.data.typeLabel || node.data.taskType ||
-                intl.formatMessage({ id: 'pages.workflow.editor.inspector.taskNode' })}
-            </div>
+          <div className="min-w-0 flex-1 truncate text-[13px] font-semibold text-[#161823]">
+            {node.data.label}
           </div>
 
           <div className="flex shrink-0 items-center gap-0.5">

--- a/yak-ops-ui/src/pages/workflow/definition/components/canvas/WorkflowToolbar.tsx
+++ b/yak-ops-ui/src/pages/workflow/definition/components/canvas/WorkflowToolbar.tsx
@@ -459,15 +459,16 @@ const WorkflowToolbar = (props: WorkflowToolbarProps) => {
             }
           >
             <span>
-              <Button
+              <YakButton
                 type="primary"
                 loading={statusAction}
                 disabled={testing || saving || !canPublish}
                 icon={<Rocket size={13} />}
                 onClick={confirmPublish}
+                className={publishMoreItems.length ? '!rounded-r-[4px]' : undefined}
               >
                 {publishButtonText}
-              </Button>
+              </YakButton>
             </span>
           </Tooltip>
 
@@ -482,13 +483,13 @@ const WorkflowToolbar = (props: WorkflowToolbarProps) => {
                 },
               }}
             >
-              <Button
+              <YakButton
                 type="primary"
-                size="small"
+                iconOnly
                 aria-label={intl.formatMessage({ id: 'pages.workflow.editor.toolbar.morePublishActions' })}
                 disabled={testing || busy}
                 icon={<ChevronDown size={12} />}
-                className="!-ml-px !h-8 !w-7 !min-w-0 !rounded-[4px] !rounded-r-[7px] !border-l-white/30 !p-0 !shadow-none"
+                className="!-ml-px !rounded-l-[4px] !border-l-white/20"
               />
             </Dropdown>
           ) : null}


### PR DESCRIPTION
## Summary

- simplify workflow node inspector headers to show only the node icon and node name
- remove the redundant task-type subtitle for data sync, data development, data quality, and other workflow node categories
- switch the main publish action from Ant Design `Button` to the shared `YakButton`
- switch the adjacent publish dropdown trigger to `YakButton` as well so the split action keeps one consistent visual treatment

## Rationale

The node icon already communicates the task category, so repeating labels such as `数据同步`, `数据开发`, and `数据质量` directly under the node name adds visual noise without adding useful information. The publish action should also use the project's shared button component instead of a one-off Ant Design primary button.

## Scope

Presentation-only. No workflow runtime, API, persistence, task-type, or publish behavior changes.

## Validation

- branch is based on current `main`
- only `WorkflowNodeInspector.tsx` and `WorkflowToolbar.tsx` are changed
- GitHub Actions CI will validate the frontend build and package
