### PR TITLE
refactor(data-development): simplify runtime and scheduling panels

### DIFF
--- a/yak-ops-ui/src/pages/development/data-development/components/workbench/RightPanel.tsx
+++ b/yak-ops-ui/src/pages/development/data-development/components/workbench/RightPanel.tsx
@@ -1,9 +1,8 @@
 import { BRAND_CSS_VARIABLES } from '@/styles/brand';
 import { useIntl } from '@umijs/max';
-import { message } from 'antd';
 import { RefreshCw, X } from 'lucide-react';
 import type { PointerEvent as ReactPointerEvent } from 'react';
-import { useMemo, useState } from 'react';
+import { useEffect, useMemo, useState } from 'react';
 
 import type {
   DevelopmentEditorDefinition,
@@ -42,7 +41,6 @@ const panelDefinitions: Array<{
 }> = [
   { key: 'properties', messageId: 'pages.dataDevelopment.right.properties', capability: 'properties' },
   { key: 'run-config', messageId: 'pages.dataDevelopment.right.runConfig', capability: 'runConfig' },
-  { key: 'schedule-config', messageId: 'pages.dataDevelopment.right.scheduleConfig', capability: 'scheduleConfig' },
   { key: 'versions', messageId: 'pages.dataDevelopment.right.versions', capability: 'versions' },
 ];
 
@@ -61,7 +59,15 @@ const RightPanel = ({
   const items = useMemo(
     () =>
       panelDefinitions
-        .filter((item) => Boolean(definition.capabilities[item.capability]))
+        .filter((item) => {
+          if (!definition.capabilities[item.capability]) return false;
+          // Runtime config is intentionally opt-in: a tab is only useful when
+          // the editor provides a real interactive panel for it.
+          if (item.key === 'run-config') {
+            return Boolean(definition.panels?.['run-config']);
+          }
+          return true;
+        })
         .map((item) => ({
           ...item,
           label: intl.formatMessage({ id: item.messageId }),
@@ -69,6 +75,12 @@ const RightPanel = ({
     [definition, intl],
   );
   const activeItem = items.find((item) => item.key === activeTab);
+
+  useEffect(() => {
+    if (activeTab && !items.some((item) => item.key === activeTab)) {
+      setActiveTab(undefined);
+    }
+  }, [activeTab, items]);
 
   const handleResizeStart = (event: ReactPointerEvent<HTMLDivElement>) => {
     if (!activeTab) return;
@@ -138,29 +150,7 @@ const RightPanel = ({
       );
     }
 
-    if (activeTab === 'run-config') {
-      return (
-        <div className="text-[12px] leading-6 text-[#667085]">
-          <div className="font-medium text-[#344054]">
-            {intl.formatMessage({ id: 'pages.dataDevelopment.right.runConfig' })}
-          </div>
-          <div className="mt-2">
-            {intl.formatMessage({ id: 'pages.dataDevelopment.right.runConfigComing' })}
-          </div>
-        </div>
-      );
-    }
-
-    return (
-      <div className="text-[12px] leading-6 text-[#667085]">
-        <div className="font-medium text-[#344054]">
-          {intl.formatMessage({ id: 'pages.dataDevelopment.right.scheduleConfig' })}
-        </div>
-        <div className="mt-2">
-          {intl.formatMessage({ id: 'pages.dataDevelopment.right.scheduleConfigComing' })}
-        </div>
-      </div>
-    );
+    return null;
   };
 
   return (
@@ -189,26 +179,17 @@ const RightPanel = ({
             <div className="flex h-11 shrink-0 items-center justify-between border-b border-[#e5e7eb] px-4">
               <span className="text-[13px] font-semibold text-[#30323b]">{activeItem?.label}</span>
               <div className="flex items-center gap-1">
-                <button
-                  type="button"
-                  title={intl.formatMessage({ id: 'pages.dataDevelopment.common.refresh' })}
-                  onClick={() => {
-                    if (activeTab === 'versions') {
-                      setManualRefreshKey((current) => current + 1);
-                    } else {
-                      message.info(
-                        intl.formatMessage(
-                          { id: 'pages.dataDevelopment.right.refreshComing' },
-                          { panel: activeItem?.label || '' },
-                        ),
-                      );
-                    }
-                  }}
-                  className="flex h-7 items-center gap-1 rounded-[3px] px-2 text-[11px] text-[#475467] transition-colors hover:bg-[#f5f5f6]"
-                >
-                  <RefreshCw size={13} strokeWidth={1.8} />
-                  {intl.formatMessage({ id: 'pages.dataDevelopment.common.refresh' })}
-                </button>
+                {activeTab === 'versions' ? (
+                  <button
+                    type="button"
+                    title={intl.formatMessage({ id: 'pages.dataDevelopment.common.refresh' })}
+                    onClick={() => setManualRefreshKey((current) => current + 1)}
+                    className="flex h-7 items-center gap-1 rounded-[3px] px-2 text-[11px] text-[#475467] transition-colors hover:bg-[#f5f5f6]"
+                  >
+                    <RefreshCw size={13} strokeWidth={1.8} />
+                    {intl.formatMessage({ id: 'pages.dataDevelopment.common.refresh' })}
+                  </button>
+                ) : null}
                 <button
                   type="button"
                   title={intl.formatMessage({ id: 'pages.dataDevelopment.tabs.close' })}

--- a/yak-ops-ui/src/pages/development/data-development/editors/registry.tsx
+++ b/yak-ops-ui/src/pages/development/data-development/editors/registry.tsx
@@ -4,16 +4,23 @@ import JavaIcon from '@/components/data-development/icons/JavaIcon';
 import PythonIcon from '@/components/data-development/icons/PythonIcon';
 
 import type { DevelopmentNodeType, DevelopmentTaskType } from '../types';
-import { JavaEditor, JavaRunConfig, JavaRunResult } from './java/JavaEditor';
-import { PythonEditor, PythonRunConfig, PythonRunResult } from './python/PythonEditor';
-import { ShellEditor, ShellRunConfig, ShellRunResult } from './shell/ShellEditor';
-import { SqlEditor, SqlRunConfig, SqlRunResult } from './sql/SqlEditor';
+import { JavaEditor, JavaRunResult } from './java/JavaEditor';
+import { PythonEditor, PythonRunResult } from './python/PythonEditor';
+import { ShellEditor, ShellRunResult } from './shell/ShellEditor';
+import { SqlEditor, SqlRunResult } from './sql/SqlEditor';
 import SqlToolbar from './sql/SqlToolbar';
 import type {
   DevelopmentEditorContext,
   DevelopmentEditorDefinition,
 } from './types';
 
+/**
+ * Keep optional editor capabilities closed by default.
+ *
+ * Scheduling belongs to Workflow, and runConfig should only be enabled by an
+ * editor once it has a real interactive configuration panel rather than a
+ * placeholder description.
+ */
 const commonCapabilities = {
   run: false,
   stop: false,
@@ -22,8 +29,7 @@ const commonCapabilities = {
   publish: false,
   share: true,
   properties: true,
-  runConfig: true,
-  scheduleConfig: true,
+  runConfig: false,
   versions: true,
 } as const;
 
@@ -51,9 +57,6 @@ const editorRegistry: Partial<Record<DevelopmentTaskType, DevelopmentEditorDefin
     },
     Editor: SqlEditor,
     Toolbar: SqlToolbar,
-    panels: {
-      'run-config': SqlRunConfig,
-    },
     RunResult: SqlRunResult,
   },
   SHELL: {
@@ -67,9 +70,6 @@ const editorRegistry: Partial<Record<DevelopmentTaskType, DevelopmentEditorDefin
       publish: true,
     },
     Editor: ShellEditor,
-    panels: {
-      'run-config': ShellRunConfig,
-    },
     RunResult: ShellRunResult,
   },
   PYTHON: {
@@ -83,9 +83,6 @@ const editorRegistry: Partial<Record<DevelopmentTaskType, DevelopmentEditorDefin
       publish: true,
     },
     Editor: PythonEditor,
-    panels: {
-      'run-config': PythonRunConfig,
-    },
     RunResult: PythonRunResult,
   },
   JAVA: {
@@ -99,9 +96,6 @@ const editorRegistry: Partial<Record<DevelopmentTaskType, DevelopmentEditorDefin
       publish: true,
     },
     Editor: JavaEditor,
-    panels: {
-      'run-config': JavaRunConfig,
-    },
     RunResult: JavaRunResult,
   },
 };

--- a/yak-ops-ui/src/pages/development/data-development/editors/types.ts
+++ b/yak-ops-ui/src/pages/development/data-development/editors/types.ts
@@ -11,7 +11,6 @@ import type {
 export type DevelopmentEditorPanelKey =
   | 'properties'
   | 'run-config'
-  | 'schedule-config'
   | 'versions';
 
 export interface DevelopmentEditorContext {
@@ -47,8 +46,8 @@ export interface DevelopmentEditorCapabilities {
   share: boolean;
   format?: boolean;
   properties: boolean;
+  /** Optional advanced runtime configuration; closed unless an editor explicitly implements it. */
   runConfig: boolean;
-  scheduleConfig: boolean;
   versions: boolean;
   lineage?: boolean;
 }


### PR DESCRIPTION
## Summary

- remove Data Development's `schedule-config` panel/capability so scheduling has one canonical home in Workflow
- close `runConfig` by default instead of exposing placeholder runtime panels
- stop registering placeholder Run Config panels for SQL, Shell, Python, and Java
- only show a future Run Config tab when an editor explicitly enables the capability **and** provides a real panel implementation
- keep the right panel focused on usable features: Properties and Versions for the current editors
- keep refresh only on Versions; remove the non-functional refresh action from Properties/placeholder panels
- automatically close an active right-panel tab when switching to an editor that does not support it

## Product model

Data Development focuses on authoring, running, saving, and publishing task assets. Workflow owns orchestration, dependencies, and schedules. Runtime configuration remains an opt-in advanced capability and should only be surfaced once an editor has real editable settings rather than explanatory placeholder text.

For SQL, the existing datasource / database / schema selectors and platform defaults remain unchanged. This PR does not modify SQL execution defaults (`maxRows`, `timeoutSeconds`) or backend task schemas.

## Scope

Frontend Data Development workbench only. No workflow scheduling implementation, task runtime, API, persistence, or execution semantics are changed.

## Validation

- branch is based on current `main`
- changes are limited to the Data Development editor registry, editor capability types, and right panel
- GitHub Actions CI will validate the frontend build and release package
