### PR TITLE
feat(data-development): establish SQL dialect model

### DIFF
--- a/yak-ops-business/yak-ops-business-data-development/src/main/java/io/yak/ops/business/development/service/TableIdentityResolver.java
+++ b/yak-ops-business/yak-ops-business-data-development/src/main/java/io/yak/ops/business/development/service/TableIdentityResolver.java
@@ -62,17 +62,24 @@ public class TableIdentityResolver {
     }
   }
 
+  /**
+   * Lineage only needs SQL name-resolution families. Canonical task dialect parsing lives in the
+   * shared SPI model so authoring, runtime and lineage do not maintain separate alias rules.
+   */
   public enum SqlDialect {
     POSTGRESQL,
     MYSQL,
     UNKNOWN;
 
     public static SqlDialect from(String value) {
-      if (value == null) return UNKNOWN;
-      String normalized = value.trim().toLowerCase(Locale.ROOT);
-      if (normalized.contains("postgres")) return POSTGRESQL;
-      if (normalized.contains("mysql") || normalized.contains("mariadb")
-          || normalized.contains("doris")) return MYSQL;
+      final io.yak.ops.spi.task.model.SqlDialect dialect;
+      try {
+        dialect = io.yak.ops.spi.task.model.SqlDialect.parseOrGeneric(value);
+      } catch (IllegalArgumentException ignored) {
+        return UNKNOWN;
+      }
+      if (dialect.isPostgresFamily()) return POSTGRESQL;
+      if (dialect.isMysqlFamily()) return MYSQL;
       return UNKNOWN;
     }
   }

--- a/yak-ops-business/yak-ops-business-data-development/src/main/java/io/yak/ops/business/development/task/DevelopmentTaskDefinitionNormalizer.java
+++ b/yak-ops-business/yak-ops-business-data-development/src/main/java/io/yak/ops/business/development/task/DevelopmentTaskDefinitionNormalizer.java
@@ -3,7 +3,9 @@ package io.yak.ops.business.development.task;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ObjectNode;
 import io.yak.ops.business.development.domain.DevelopmentNode;
+import io.yak.ops.spi.task.model.SqlDialect;
 import io.yak.ops.spi.task.model.TaskDefinition;
 import java.util.Locale;
 import org.springframework.stereotype.Component;
@@ -39,19 +41,41 @@ public class DevelopmentTaskDefinitionNormalizer {
         normalizedType,
         schemaVersion,
         content == null ? "" : content,
-        normalizeConfigJson(configJson));
+        normalizeConfigJson(normalizedType, configJson));
   }
 
-  private String normalizeConfigJson(String configJson) {
+  private String normalizeConfigJson(String taskType, String configJson) {
     String raw = configJson == null || configJson.isBlank() ? "{}" : configJson.trim();
     try {
       JsonNode node = objectMapper.readTree(raw);
       if (node == null || !node.isObject()) {
         throw new IllegalArgumentException("configJson 必须是 JSON Object");
       }
-      return objectMapper.writeValueAsString(node);
+      ObjectNode object = (ObjectNode) node;
+      if ("SQL".equals(taskType)) {
+        normalizeSqlDialect(object);
+      }
+      return objectMapper.writeValueAsString(object);
     } catch (JsonProcessingException exception) {
       throw new IllegalArgumentException("configJson 不是合法 JSON", exception);
     }
+  }
+
+  private void normalizeSqlDialect(ObjectNode config) {
+    String rawDialect = text(config, "dialect");
+    if (rawDialect == null) rawDialect = text(config, "databaseType");
+    if (rawDialect == null) rawDialect = text(config, "dbType");
+
+    SqlDialect dialect = SqlDialect.parseOrGeneric(rawDialect);
+    config.put("dialect", dialect.name());
+    config.remove("databaseType");
+    config.remove("dbType");
+  }
+
+  private String text(ObjectNode config, String key) {
+    JsonNode value = config.get(key);
+    if (value == null || value.isNull()) return null;
+    String text = value.asText();
+    return text == null || text.isBlank() ? null : text.trim();
   }
 }

--- a/yak-ops-business/yak-ops-business-data-development/src/main/java/io/yak/ops/business/development/task/DevelopmentTaskService.java
+++ b/yak-ops-business/yak-ops-business-data-development/src/main/java/io/yak/ops/business/development/task/DevelopmentTaskService.java
@@ -90,7 +90,20 @@ public class DevelopmentTaskService {
 
   public DevelopmentTaskDraft getDraft(Long nodeId) {
     DevelopmentNode node = nodes.requireTaskNode(nodeId);
-    return drafts.get(node);
+    DevelopmentTaskDraft draft = drafts.get(node);
+    TaskDefinition normalized = definitions.normalize(
+        node,
+        draft.definition().taskType(),
+        draft.definition().schemaVersion(),
+        draft.definition().content(),
+        draft.definition().configJson());
+    if (normalized.equals(draft.definition())) return draft;
+    return new DevelopmentTaskDraft(
+        draft.nodeId(),
+        normalized,
+        draft.draftRevision(),
+        draft.createTime(),
+        draft.updateTime());
   }
 
   @Transactional(transactionManager = "yakBusinessTransactionManager", rollbackFor = Exception.class)

--- a/yak-ops-business/yak-ops-business-data-development/src/main/java/io/yak/ops/business/development/task/DevelopmentTaskService.java
+++ b/yak-ops-business/yak-ops-business-data-development/src/main/java/io/yak/ops/business/development/task/DevelopmentTaskService.java
@@ -91,6 +91,8 @@ public class DevelopmentTaskService {
   public DevelopmentTaskDraft getDraft(Long nodeId) {
     DevelopmentNode node = nodes.requireTaskNode(nodeId);
     DevelopmentTaskDraft draft = drafts.get(node);
+    if (!"SQL".equalsIgnoreCase(node.type())) return draft;
+
     TaskDefinition normalized = definitions.normalize(
         node,
         draft.definition().taskType(),

--- a/yak-ops-business/yak-ops-business-data-development/src/test/java/io/yak/ops/business/development/service/TableIdentityResolverTest.java
+++ b/yak-ops-business/yak-ops-business-data-development/src/test/java/io/yak/ops/business/development/service/TableIdentityResolverTest.java
@@ -45,6 +45,15 @@ class TableIdentityResolverTest {
   }
 
   @Test
+  void canonicalDialectNamesUseTheSameResolutionFamilies() {
+    var twoPart = table("archive.orders", null, "archive", "orders");
+    assertEquals("table:1:sales.archive.orders",
+        resolve(twoPart, "1", "sales", "public", "POSTGRE_SQL").assetKey());
+    assertEquals("table:1:archive..orders",
+        resolve(twoPart, "1", "sales", "public", "STARROCKS").assetKey());
+  }
+
+  @Test
   void legacyContextIsIsolatedFromConfirmedAssets() {
     var identity = resolve(table("orders", null, null, "orders"), "1", null, null, null);
     assertEquals("table:unresolved:1:..orders", identity.assetKey());

--- a/yak-ops-business/yak-ops-business-data-development/src/test/java/io/yak/ops/business/development/task/DevelopmentTaskDefinitionNormalizerTest.java
+++ b/yak-ops-business/yak-ops-business-data-development/src/test/java/io/yak/ops/business/development/task/DevelopmentTaskDefinitionNormalizerTest.java
@@ -1,0 +1,71 @@
+package io.yak.ops.business.development.task;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.yak.ops.business.development.domain.DevelopmentNode;
+import io.yak.ops.spi.task.model.TaskDefinition;
+import org.junit.jupiter.api.Test;
+
+class DevelopmentTaskDefinitionNormalizerTest {
+
+  private final ObjectMapper objectMapper = new ObjectMapper();
+  private final DevelopmentTaskDefinitionNormalizer normalizer =
+      new DevelopmentTaskDefinitionNormalizer(objectMapper);
+
+  @Test
+  void legacySqlConfigDefaultsToGenericDialect() throws Exception {
+    TaskDefinition definition = normalizer.normalize(
+        sqlNode(),
+        "SQL",
+        1,
+        "select 1",
+        "{}");
+
+    JsonNode config = objectMapper.readTree(definition.configJson());
+    assertThat(definition.taskType()).isEqualTo("SQL");
+    assertThat(config.path("dialect").asText()).isEqualTo("GENERIC");
+  }
+
+  @Test
+  void canonicalizesDatabaseTypeAliasWithoutLosingOtherSqlConfig() throws Exception {
+    TaskDefinition definition = normalizer.normalize(
+        sqlNode(),
+        "sql",
+        1,
+        "select * from t",
+        "{\"databaseType\":\"PostgreSQL\",\"dataSourceId\":\"42\",\"maxRows\":100}");
+
+    JsonNode config = objectMapper.readTree(definition.configJson());
+    assertThat(config.path("dialect").asText()).isEqualTo("POSTGRE_SQL");
+    assertThat(config.path("dataSourceId").asText()).isEqualTo("42");
+    assertThat(config.path("maxRows").asInt()).isEqualTo(100);
+    assertThat(config.has("databaseType")).isFalse();
+  }
+
+  @Test
+  void doesNotInjectDialectIntoNonSqlTaskConfig() throws Exception {
+    DevelopmentNode shell = new DevelopmentNode(2L, "shell", "SHELL", 1L, null, false, null, null);
+    TaskDefinition definition = normalizer.normalize(shell, "SHELL", 1, "echo ok", "{}");
+
+    assertThat(objectMapper.readTree(definition.configJson()).has("dialect")).isFalse();
+  }
+
+  @Test
+  void rejectsUnknownExplicitSqlDialect() {
+    assertThatThrownBy(() -> normalizer.normalize(
+        sqlNode(),
+        "SQL",
+        1,
+        "select 1",
+        "{\"dialect\":\"NOT_A_DATABASE\"}"))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining("SQL dialect");
+  }
+
+  private DevelopmentNode sqlNode() {
+    return new DevelopmentNode(1L, "sql", "SQL", 1L, null, false, null, null);
+  }
+}

--- a/yak-ops-plugins/yak-ops-plugin-task/yak-ops-plugin-task-sql/src/main/java/io/yak/ops/plugin/task/sql/SqlTaskConfig.java
+++ b/yak-ops-plugins/yak-ops-plugin-task/yak-ops-plugin-task-sql/src/main/java/io/yak/ops/plugin/task/sql/SqlTaskConfig.java
@@ -2,13 +2,14 @@ package io.yak.ops.plugin.task.sql;
 
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import io.yak.ops.spi.task.model.SqlDialect;
 
 /** SQL task plugin-owned schemaVersion=1 configuration. */
 record SqlTaskConfig(
     String dataSourceId,
     String databaseName,
     String schemaName,
-    String dialect,
+    SqlDialect dialect,
     int maxRows,
     int timeoutSeconds) {
 
@@ -39,7 +40,7 @@ record SqlTaskConfig(
           dataSourceId,
           firstText(root, "databaseName", "database", "catalog"),
           firstText(root, "schemaName", "schema"),
-          firstText(root, "dialect", "dbType"),
+          SqlDialect.parseOrGeneric(firstText(root, "dialect", "databaseType", "dbType")),
           maxRows,
           timeoutSeconds);
     } catch (IllegalArgumentException exception) {

--- a/yak-ops-plugins/yak-ops-plugin-task/yak-ops-plugin-task-sql/src/test/java/io/yak/ops/plugin/task/sql/SqlTaskConfigTest.java
+++ b/yak-ops-plugins/yak-ops-plugin-task/yak-ops-plugin-task-sql/src/test/java/io/yak/ops/plugin/task/sql/SqlTaskConfigTest.java
@@ -1,0 +1,34 @@
+package io.yak.ops.plugin.task.sql;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import io.yak.ops.spi.task.model.SqlDialect;
+import org.junit.jupiter.api.Test;
+
+class SqlTaskConfigTest {
+
+  @Test
+  void legacyConfigUsesGenericDialect() {
+    SqlTaskConfig config = SqlTaskConfig.parse("{\"dataSourceId\":\"42\"}");
+
+    assertThat(config.dialect()).isEqualTo(SqlDialect.GENERIC);
+  }
+
+  @Test
+  void acceptsCanonicalAndCompatibilityDialectAliases() {
+    assertThat(SqlTaskConfig.parse("{\"dialect\":\"MYSQL\"}").dialect())
+        .isEqualTo(SqlDialect.MYSQL);
+    assertThat(SqlTaskConfig.parse("{\"dbType\":\"PostgreSQL\"}").dialect())
+        .isEqualTo(SqlDialect.POSTGRE_SQL);
+    assertThat(SqlTaskConfig.parse("{\"databaseType\":\"StarRocks\"}").dialect())
+        .isEqualTo(SqlDialect.STARROCKS);
+  }
+
+  @Test
+  void rejectsUnsupportedExplicitDialect() {
+    assertThatThrownBy(() -> SqlTaskConfig.parse("{\"dialect\":\"MONGODB\"}"))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining("SQL dialect");
+  }
+}

--- a/yak-ops-spi/src/main/java/io/yak/ops/spi/task/model/SqlDialect.java
+++ b/yak-ops-spi/src/main/java/io/yak/ops/spi/task/model/SqlDialect.java
@@ -1,0 +1,86 @@
+package io.yak.ops.spi.task.model;
+
+import java.util.Locale;
+
+/**
+ * Canonical SQL dialect identity shared by authoring and SQL task runtimes.
+ *
+ * <p>Task identity remains {@code taskType=SQL}. The dialect describes which database SQL
+ * semantics the task targets without turning every database into a separate task type.
+ */
+public enum SqlDialect {
+  GENERIC,
+  MYSQL,
+  TIDB,
+  GOLDENDB,
+  GBASE8C,
+  GBASE8A,
+  GBASE8S,
+  HANA,
+  ORACLE,
+  POSTGRE_SQL,
+  DB2,
+  OPEN_GAUSS,
+  SQL_SERVER,
+  OCEANBASE,
+  YASHAN_DB,
+  HIGHGO,
+  IRIS,
+  XUGU,
+  DUCKDB,
+  DORIS,
+  STARROCKS,
+  CLICKHOUSE,
+  KINGBASE,
+  DAMENG;
+
+  /** Missing dialect is the legacy SQL-node shape and intentionally resolves to GENERIC. */
+  public static SqlDialect parseOrGeneric(String value) {
+    if (value == null || value.isBlank()) return GENERIC;
+
+    String normalized = value.trim().toUpperCase(Locale.ROOT)
+        .replace('-', '_')
+        .replace(' ', '_');
+    normalized = switch (normalized) {
+      case "AUTO", "UNKNOWN", "GENERIC_SQL" -> "GENERIC";
+      case "POSTGRES", "POSTGRESQL", "PGSQL" -> "POSTGRE_SQL";
+      case "MARIADB" -> "MYSQL";
+      case "GOLDEN_DB", "ZTE_GOLDENDB" -> "GOLDENDB";
+      case "GBASE_8C" -> "GBASE8C";
+      case "GBASE_8A" -> "GBASE8A";
+      case "GBASE_8S" -> "GBASE8S";
+      case "SAP_HANA", "SAPHANA" -> "HANA";
+      case "OPENGAUSS" -> "OPEN_GAUSS";
+      case "SQLSERVER", "MSSQL" -> "SQL_SERVER";
+      case "YASHANDB", "YASDB" -> "YASHAN_DB";
+      case "HIGH_GO", "HGDB" -> "HIGHGO";
+      case "INTERSYSTEMS_IRIS" -> "IRIS";
+      case "XUGUDB" -> "XUGU";
+      case "DUCK_DB" -> "DUCKDB";
+      case "STAR_ROCKS" -> "STARROCKS";
+      case "KINGBASEES" -> "KINGBASE";
+      case "DM" -> "DAMENG";
+      default -> normalized;
+    };
+
+    try {
+      return valueOf(normalized);
+    } catch (IllegalArgumentException exception) {
+      throw new IllegalArgumentException("不支持的 SQL dialect：" + value, exception);
+    }
+  }
+
+  public boolean isMysqlFamily() {
+    return switch (this) {
+      case MYSQL, TIDB, GOLDENDB, DORIS, STARROCKS -> true;
+      default -> false;
+    };
+  }
+
+  public boolean isPostgresFamily() {
+    return switch (this) {
+      case POSTGRE_SQL, OPEN_GAUSS, GBASE8C, HIGHGO, KINGBASE -> true;
+      default -> false;
+    };
+  }
+}

--- a/yak-ops-ui/src/pages/development/data-development/editors/sql/metadata/sqlMetadataContextStore.ts
+++ b/yak-ops-ui/src/pages/development/data-development/editors/sql/metadata/sqlMetadataContextStore.ts
@@ -13,6 +13,8 @@ export interface SqlMetadataContext {
   dataSourceId?: string;
   dataSourceName?: string;
   dialect: DevelopmentSqlDialect;
+  /** @deprecated Compatibility alias for existing SQL-assistance code; use dialect. */
+  dbType?: DevelopmentSqlDialect;
   database?: string;
   schema?: string;
   updatedAt: number;
@@ -47,15 +49,17 @@ const normalizePersistedContext = (
 
   const optionalString = (key: string) =>
     typeof context[key] === 'string' ? (context[key] as string) : undefined;
+  const dialect = normalizeDevelopmentSqlDialect(
+    optionalString('dialect') || optionalString('dbType'),
+  );
 
   return {
     nodeId: context.nodeId,
     dataSourceId: optionalString('dataSourceId'),
     dataSourceName: optionalString('dataSourceName'),
     // v1 local storage used `dbType`; accept it while persisting the canonical dialect shape.
-    dialect: normalizeDevelopmentSqlDialect(
-      optionalString('dialect') || optionalString('dbType'),
-    ),
+    dialect,
+    dbType: dialect,
     database: optionalString('database'),
     schema: optionalString('schema'),
     updatedAt: context.updatedAt,
@@ -117,7 +121,9 @@ const configJsonForContext = (context: Partial<SqlMetadataContext>) =>
         dataSourceId: context.dataSourceId,
         databaseName: context.database,
         schemaName: context.schema,
-        dialect: normalizeDevelopmentSqlDialect(context.dialect),
+        dialect: normalizeDevelopmentSqlDialect(
+          context.dialect ?? context.dbType,
+        ),
       }).filter(([, value]) => value !== undefined && value !== ''),
     ),
   );
@@ -132,6 +138,7 @@ export const ensureSqlMetadataContext = (
   const context: SqlMetadataContext = {
     nodeId,
     dialect: 'GENERIC',
+    dbType: 'GENERIC',
     updatedAt: Date.now(),
   };
   contexts.set(nodeId, context);
@@ -151,10 +158,14 @@ export const updateSqlMetadataContext = (
   patch: Partial<Omit<SqlMetadataContext, 'nodeId' | 'updatedAt'>>,
 ) => {
   const current = ensureSqlMetadataContext(nodeId);
+  const dialect = normalizeDevelopmentSqlDialect(
+    patch.dialect ?? patch.dbType ?? current.dialect ?? current.dbType,
+  );
   const next: SqlMetadataContext = {
     ...current,
     ...patch,
-    dialect: normalizeDevelopmentSqlDialect(patch.dialect ?? current.dialect),
+    dialect,
+    dbType: dialect,
     nodeId,
     updatedAt: Date.now(),
   };
@@ -177,6 +188,7 @@ export const hydrateSqlTaskConfig = (
     dataSourceId: config.dataSourceId,
     dataSourceName: sameDataSource ? current.dataSourceName : undefined,
     dialect: config.dialect,
+    dbType: config.dialect,
     database: config.databaseName,
     schema: config.schemaName,
     updatedAt: Date.now(),

--- a/yak-ops-ui/src/pages/development/data-development/editors/sql/metadata/sqlMetadataContextStore.ts
+++ b/yak-ops-ui/src/pages/development/data-development/editors/sql/metadata/sqlMetadataContextStore.ts
@@ -1,23 +1,28 @@
-import { useSyncExternalStore } from "react";
+import {
+  normalizeDevelopmentSqlDialect,
+  parseDevelopmentSqlTaskConfig,
+  type DevelopmentSqlDialect,
+} from '@/services/data-development';
+import { useSyncExternalStore } from 'react';
 
-import { updateEditorSessionConfig } from "../../session/editorSessionStore";
-import type { DevelopmentId } from "../../../types";
+import { updateEditorSessionConfig } from '../../session/editorSessionStore';
+import type { DevelopmentId } from '../../../types';
 
 export interface SqlMetadataContext {
   nodeId: DevelopmentId;
   dataSourceId?: string;
   dataSourceName?: string;
-  dbType?: string;
+  dialect: DevelopmentSqlDialect;
   database?: string;
   schema?: string;
   updatedAt: number;
 }
 
-const STORAGE_KEY = "yak-data-development.sql-metadata-contexts.v1";
+const STORAGE_KEY = 'yak-data-development.sql-metadata-contexts.v1';
 
 interface PersistedSqlMetadataContexts {
   version: 1;
-  contexts: SqlMetadataContext[];
+  contexts: unknown[];
 }
 
 const contexts = new Map<DevelopmentId, SqlMetadataContext>();
@@ -26,22 +31,35 @@ const listeners = new Set<() => void>();
 let hydrated = false;
 let version = 0;
 
-const isBrowser = () => typeof window !== "undefined";
+const isBrowser = () => typeof window !== 'undefined';
 
-const isPersistedContext = (value: unknown): value is SqlMetadataContext => {
-  if (!value || typeof value !== "object") return false;
-  const context = value as Partial<SqlMetadataContext>;
-  return (
-    typeof context.nodeId === "string" &&
-    typeof context.updatedAt === "number" &&
-    (context.dataSourceId === undefined ||
-      typeof context.dataSourceId === "string") &&
-    (context.dataSourceName === undefined ||
-      typeof context.dataSourceName === "string") &&
-    (context.dbType === undefined || typeof context.dbType === "string") &&
-    (context.database === undefined || typeof context.database === "string") &&
-    (context.schema === undefined || typeof context.schema === "string")
-  );
+const normalizePersistedContext = (
+  value: unknown,
+): SqlMetadataContext | undefined => {
+  if (!value || typeof value !== 'object') return undefined;
+  const context = value as Record<string, unknown>;
+  if (
+    typeof context.nodeId !== 'string' ||
+    typeof context.updatedAt !== 'number'
+  ) {
+    return undefined;
+  }
+
+  const optionalString = (key: string) =>
+    typeof context[key] === 'string' ? (context[key] as string) : undefined;
+
+  return {
+    nodeId: context.nodeId,
+    dataSourceId: optionalString('dataSourceId'),
+    dataSourceName: optionalString('dataSourceName'),
+    // v1 local storage used `dbType`; accept it while persisting the canonical dialect shape.
+    dialect: normalizeDevelopmentSqlDialect(
+      optionalString('dialect') || optionalString('dbType'),
+    ),
+    database: optionalString('database'),
+    schema: optionalString('schema'),
+    updatedAt: context.updatedAt,
+  };
 };
 
 const ensureHydrated = () => {
@@ -54,8 +72,9 @@ const ensureHydrated = () => {
     if (!raw) return;
     const parsed = JSON.parse(raw) as Partial<PersistedSqlMetadataContexts>;
     if (parsed.version !== 1 || !Array.isArray(parsed.contexts)) return;
-    parsed.contexts.forEach((context) => {
-      if (isPersistedContext(context)) contexts.set(context.nodeId, context);
+    parsed.contexts.forEach((value) => {
+      const context = normalizePersistedContext(value);
+      if (context) contexts.set(context.nodeId, context);
     });
   } catch {
     // Ignore malformed or unavailable local storage. SQL editing still works in memory.
@@ -98,8 +117,8 @@ const configJsonForContext = (context: Partial<SqlMetadataContext>) =>
         dataSourceId: context.dataSourceId,
         databaseName: context.database,
         schemaName: context.schema,
-        dialect: context.dbType,
-      }).filter(([, value]) => value !== undefined && value !== ""),
+        dialect: normalizeDevelopmentSqlDialect(context.dialect),
+      }).filter(([, value]) => value !== undefined && value !== ''),
     ),
   );
 
@@ -112,6 +131,7 @@ export const ensureSqlMetadataContext = (
 
   const context: SqlMetadataContext = {
     nodeId,
+    dialect: 'GENERIC',
     updatedAt: Date.now(),
   };
   contexts.set(nodeId, context);
@@ -128,12 +148,13 @@ export const getSqlTaskConfigJson = (nodeId: DevelopmentId) =>
 
 export const updateSqlMetadataContext = (
   nodeId: DevelopmentId,
-  patch: Partial<Omit<SqlMetadataContext, "nodeId" | "updatedAt">>,
+  patch: Partial<Omit<SqlMetadataContext, 'nodeId' | 'updatedAt'>>,
 ) => {
   const current = ensureSqlMetadataContext(nodeId);
   const next: SqlMetadataContext = {
     ...current,
     ...patch,
+    dialect: normalizeDevelopmentSqlDialect(patch.dialect ?? current.dialect),
     nodeId,
     updatedAt: Date.now(),
   };
@@ -147,38 +168,17 @@ export const hydrateSqlTaskConfig = (
   nodeId: DevelopmentId,
   configJson: string,
 ) => {
-  let dataSourceId: string | undefined;
-  let databaseName: string | undefined;
-  let schemaName: string | undefined;
-  let dialect: string | undefined;
-  try {
-    const parsed = JSON.parse(configJson || "{}") as {
-      dataSourceId?: unknown;
-      databaseName?: unknown;
-      schemaName?: unknown;
-      dialect?: unknown;
-    };
-    dataSourceId =
-      typeof parsed.dataSourceId === "string" ? parsed.dataSourceId : undefined;
-    databaseName =
-      typeof parsed.databaseName === "string" ? parsed.databaseName : undefined;
-    schemaName =
-      typeof parsed.schemaName === "string" ? parsed.schemaName : undefined;
-    dialect = typeof parsed.dialect === "string" ? parsed.dialect : undefined;
-  } catch {
-    dataSourceId = undefined;
-  }
-
+  const config = parseDevelopmentSqlTaskConfig(configJson);
   const current = ensureSqlMetadataContext(nodeId);
-  const sameDataSource = current.dataSourceId === dataSourceId;
+  const sameDataSource = current.dataSourceId === config.dataSourceId;
   const next: SqlMetadataContext = {
     ...current,
     nodeId,
-    dataSourceId,
+    dataSourceId: config.dataSourceId,
     dataSourceName: sameDataSource ? current.dataSourceName : undefined,
-    dbType: dialect ?? (sameDataSource ? current.dbType : undefined),
-    database: databaseName,
-    schema: schemaName,
+    dialect: config.dialect,
+    database: config.databaseName,
+    schema: config.schemaName,
     updatedAt: Date.now(),
   };
   contexts.set(nodeId, next);
@@ -194,7 +194,7 @@ export const selectSqlDataSourceContext = (
   const next = updateSqlMetadataContext(nodeId, {
     dataSourceId: dataSource?.id,
     dataSourceName: dataSource?.name,
-    dbType: dataSource?.dbType,
+    dialect: normalizeDevelopmentSqlDialect(dataSource?.dbType),
     database: undefined,
     schema: undefined,
   });

--- a/yak-ops-ui/src/services/data-development/index.ts
+++ b/yak-ops-ui/src/services/data-development/index.ts
@@ -2,4 +2,5 @@ export * from './api';
 export * from './data-service';
 export * from './dataset';
 export * from './publication';
+export * from './sql-dialect';
 export type * from './types';

--- a/yak-ops-ui/src/services/data-development/sql-dialect.ts
+++ b/yak-ops-ui/src/services/data-development/sql-dialect.ts
@@ -1,0 +1,120 @@
+export const DEVELOPMENT_SQL_DIALECT_VALUES = [
+  'GENERIC',
+  'MYSQL',
+  'TIDB',
+  'GOLDENDB',
+  'GBASE8C',
+  'GBASE8A',
+  'GBASE8S',
+  'HANA',
+  'ORACLE',
+  'POSTGRE_SQL',
+  'DB2',
+  'OPEN_GAUSS',
+  'SQL_SERVER',
+  'OCEANBASE',
+  'YASHAN_DB',
+  'HIGHGO',
+  'IRIS',
+  'XUGU',
+  'DUCKDB',
+  'DORIS',
+  'STARROCKS',
+  'CLICKHOUSE',
+  'KINGBASE',
+  'DAMENG',
+] as const;
+
+export type DevelopmentSqlDialect =
+  (typeof DEVELOPMENT_SQL_DIALECT_VALUES)[number];
+
+const SQL_DIALECTS = new Set<string>(DEVELOPMENT_SQL_DIALECT_VALUES);
+
+export const normalizeDevelopmentSqlDialect = (
+  value?: unknown,
+): DevelopmentSqlDialect => {
+  if (typeof value !== 'string' || !value.trim()) return 'GENERIC';
+
+  let normalized = value.trim().toUpperCase().replaceAll('-', '_').replaceAll(' ', '_');
+  normalized =
+    {
+      AUTO: 'GENERIC',
+      UNKNOWN: 'GENERIC',
+      GENERIC_SQL: 'GENERIC',
+      POSTGRES: 'POSTGRE_SQL',
+      POSTGRESQL: 'POSTGRE_SQL',
+      PGSQL: 'POSTGRE_SQL',
+      MARIADB: 'MYSQL',
+      GOLDEN_DB: 'GOLDENDB',
+      ZTE_GOLDENDB: 'GOLDENDB',
+      GBASE_8C: 'GBASE8C',
+      GBASE_8A: 'GBASE8A',
+      GBASE_8S: 'GBASE8S',
+      SAP_HANA: 'HANA',
+      SAPHANA: 'HANA',
+      OPENGAUSS: 'OPEN_GAUSS',
+      SQLSERVER: 'SQL_SERVER',
+      MSSQL: 'SQL_SERVER',
+      YASHANDB: 'YASHAN_DB',
+      YASDB: 'YASHAN_DB',
+      HIGH_GO: 'HIGHGO',
+      HGDB: 'HIGHGO',
+      INTERSYSTEMS_IRIS: 'IRIS',
+      XUGUDB: 'XUGU',
+      DUCK_DB: 'DUCKDB',
+      STAR_ROCKS: 'STARROCKS',
+      KINGBASEES: 'KINGBASE',
+      DM: 'DAMENG',
+    }[normalized] || normalized;
+
+  return SQL_DIALECTS.has(normalized)
+    ? (normalized as DevelopmentSqlDialect)
+    : 'GENERIC';
+};
+
+export interface DevelopmentSqlTaskConfig {
+  dataSourceId?: string;
+  databaseName?: string;
+  schemaName?: string;
+  dialect: DevelopmentSqlDialect;
+  maxRows?: number;
+  timeoutSeconds?: number;
+}
+
+export const parseDevelopmentSqlTaskConfig = (
+  configJson?: string,
+): DevelopmentSqlTaskConfig => {
+  let raw: Record<string, unknown> = {};
+  try {
+    const parsed = JSON.parse(configJson || '{}');
+    if (parsed && typeof parsed === 'object' && !Array.isArray(parsed)) {
+      raw = parsed as Record<string, unknown>;
+    }
+  } catch {
+    raw = {};
+  }
+
+  const stringValue = (...keys: string[]) => {
+    for (const key of keys) {
+      const value = raw[key];
+      if (typeof value === 'string' && value.trim()) return value.trim();
+    }
+    return undefined;
+  };
+
+  const numberValue = (key: string) => {
+    const value = raw[key];
+    return typeof value === 'number' && Number.isFinite(value) ? value : undefined;
+  };
+
+  return {
+    dataSourceId: stringValue('dataSourceId'),
+    databaseName: stringValue('databaseName', 'database', 'catalog'),
+    schemaName: stringValue('schemaName', 'schema'),
+    dialect: normalizeDevelopmentSqlDialect(
+      stringValue('dialect', 'databaseType', 'dbType'),
+    ),
+    maxRows: numberValue('maxRows'),
+    timeoutSeconds: numberValue('timeoutSeconds'),
+  };
+};

--- a/yak-ops-ui/src/services/data-development/sql-dialect.ts
+++ b/yak-ops-ui/src/services/data-development/sql-dialect.ts
@@ -29,46 +29,49 @@ export type DevelopmentSqlDialect =
   (typeof DEVELOPMENT_SQL_DIALECT_VALUES)[number];
 
 const SQL_DIALECTS = new Set<string>(DEVELOPMENT_SQL_DIALECT_VALUES);
+const SQL_DIALECT_ALIASES: Record<string, DevelopmentSqlDialect> = {
+  AUTO: 'GENERIC',
+  UNKNOWN: 'GENERIC',
+  GENERIC_SQL: 'GENERIC',
+  POSTGRES: 'POSTGRE_SQL',
+  POSTGRESQL: 'POSTGRE_SQL',
+  PGSQL: 'POSTGRE_SQL',
+  MARIADB: 'MYSQL',
+  GOLDEN_DB: 'GOLDENDB',
+  ZTE_GOLDENDB: 'GOLDENDB',
+  GBASE_8C: 'GBASE8C',
+  GBASE_8A: 'GBASE8A',
+  GBASE_8S: 'GBASE8S',
+  SAP_HANA: 'HANA',
+  SAPHANA: 'HANA',
+  OPENGAUSS: 'OPEN_GAUSS',
+  SQLSERVER: 'SQL_SERVER',
+  MSSQL: 'SQL_SERVER',
+  YASHANDB: 'YASHAN_DB',
+  YASDB: 'YASHAN_DB',
+  HIGH_GO: 'HIGHGO',
+  HGDB: 'HIGHGO',
+  INTERSYSTEMS_IRIS: 'IRIS',
+  XUGUDB: 'XUGU',
+  DUCK_DB: 'DUCKDB',
+  STAR_ROCKS: 'STARROCKS',
+  KINGBASEES: 'KINGBASE',
+  DM: 'DAMENG',
+};
 
 export const normalizeDevelopmentSqlDialect = (
   value?: unknown,
 ): DevelopmentSqlDialect => {
   if (typeof value !== 'string' || !value.trim()) return 'GENERIC';
 
-  let normalized = value.trim().toUpperCase().replaceAll('-', '_').replaceAll(' ', '_');
-  normalized =
-    {
-      AUTO: 'GENERIC',
-      UNKNOWN: 'GENERIC',
-      GENERIC_SQL: 'GENERIC',
-      POSTGRES: 'POSTGRE_SQL',
-      POSTGRESQL: 'POSTGRE_SQL',
-      PGSQL: 'POSTGRE_SQL',
-      MARIADB: 'MYSQL',
-      GOLDEN_DB: 'GOLDENDB',
-      ZTE_GOLDENDB: 'GOLDENDB',
-      GBASE_8C: 'GBASE8C',
-      GBASE_8A: 'GBASE8A',
-      GBASE_8S: 'GBASE8S',
-      SAP_HANA: 'HANA',
-      SAPHANA: 'HANA',
-      OPENGAUSS: 'OPEN_GAUSS',
-      SQLSERVER: 'SQL_SERVER',
-      MSSQL: 'SQL_SERVER',
-      YASHANDB: 'YASHAN_DB',
-      YASDB: 'YASHAN_DB',
-      HIGH_GO: 'HIGHGO',
-      HGDB: 'HIGHGO',
-      INTERSYSTEMS_IRIS: 'IRIS',
-      XUGUDB: 'XUGU',
-      DUCK_DB: 'DUCKDB',
-      STAR_ROCKS: 'STARROCKS',
-      KINGBASEES: 'KINGBASE',
-      DM: 'DAMENG',
-    }[normalized] || normalized;
-
-  return SQL_DIALECTS.has(normalized)
-    ? (normalized as DevelopmentSqlDialect)
+  const normalized = value
+    .trim()
+    .toUpperCase()
+    .replace(/-/g, '_')
+    .replace(/\s+/g, '_');
+  const aliased = SQL_DIALECT_ALIASES[normalized] || normalized;
+  return SQL_DIALECTS.has(aliased)
+    ? (aliased as DevelopmentSqlDialect)
     : 'GENERIC';
 };
 


### PR DESCRIPTION
## Summary

- keep Data Development task identity as `taskType=SQL` while introducing a canonical SQL dialect dimension
- add a shared `SqlDialect` contract for JDBC-style SQL databases plus Doris and StarRocks
- normalize SQL task config to persist one canonical `dialect` field; accept legacy aliases such as `databaseType`, `dbType`, `PostgreSQL`, `MSSQL`, etc.
- treat historical SQL drafts/revisions with no dialect as `GENERIC`, without mutating storage on read
- make the SQL Task Plugin consume the typed canonical dialect while preserving existing execution behavior
- migrate the frontend SQL metadata context to canonical dialects while retaining the old `dbType` alias for existing completion/assistance code
- reuse the canonical dialect family mapping in SQL lineage so `POSTGRE_SQL`, `STARROCKS`, Doris/MySQL-family, and PostgreSQL-family names resolve consistently
- add regression tests for legacy configs, aliases, unsupported dialects, and lineage name-resolution families

## Model

This PR intentionally keeps these two concepts separate:

```text
taskType = SQL

dialect = GENERIC | MYSQL | POSTGRE_SQL | ORACLE | DORIS | STARROCKS | ...
```

Database type is therefore SQL authoring/runtime metadata, not a new Task Plugin type. Workflow and Task Catalog continue to see one stable `SQL` task type.

## Backward compatibility

- existing SQL nodes with no dialect remain valid and resolve to `GENERIC`
- existing `dbType` / `databaseType` config aliases are accepted and canonicalized on the next save/run/publish path
- existing frontend local-storage SQL metadata using `dbType` is hydrated into the new dialect model
- non-SQL task configuration is unchanged

## Persistence

No Flyway/schema migration is required. SQL dialect already belongs to the plugin-owned `configJson` payload, which is persisted unchanged through mutable drafts, immutable revisions, and execution snapshots.

## Scope

This is PR1 only. It does **not** change the Data Development create menu, database-specific icons, datasource filtering, or database-specific editor UX. Those remain for PR2/PR3.

## Validation

- `DevelopmentTaskDefinitionNormalizerTest` covers legacy `GENERIC`, alias canonicalization, non-SQL isolation, and unsupported explicit dialects
- `SqlTaskConfigTest` covers runtime parsing for legacy/canonical/compatibility dialect shapes
- `TableIdentityResolverTest` covers canonical PostgreSQL-family and StarRocks/MySQL-family resolution
- GitHub Actions CI will validate the frontend build and release package
