### PR TITLE
feat(data-development): create database-specific SQL nodes

### DIFF
--- a/yak-ops-business/yak-ops-business-data-development/src/main/java/io/yak/ops/business/development/domain/DevelopmentNode.java
+++ b/yak-ops-business/yak-ops-business-data-development/src/main/java/io/yak/ops/business/development/domain/DevelopmentNode.java
@@ -15,7 +15,8 @@ public record DevelopmentNode(
     Instant createTime,
     Instant updateTime,
     String updatedBy,
-    boolean pendingPublish) {
+    boolean pendingPublish,
+    String sqlDialect) {
 
   /** Keeps existing callers source-compatible while tree metadata is populated by persistence. */
   public DevelopmentNode(
@@ -27,7 +28,23 @@ public record DevelopmentNode(
       boolean configured,
       Instant createTime,
       Instant updateTime) {
-    this(id, name, type, projectId, directoryId, configured, createTime, updateTime, null, false);
+    this(id, name, type, projectId, directoryId, configured, createTime, updateTime, null, false, null);
+  }
+
+  /** Keeps callers that already provide updater/publish metadata source-compatible. */
+  public DevelopmentNode(
+      Long id,
+      String name,
+      String type,
+      Long projectId,
+      Long directoryId,
+      boolean configured,
+      Instant createTime,
+      Instant updateTime,
+      String updatedBy,
+      boolean pendingPublish) {
+    this(id, name, type, projectId, directoryId, configured, createTime, updateTime, updatedBy,
+        pendingPublish, null);
   }
 
   /** Resolves the domain node type instead of spreading string parsing across application services. */

--- a/yak-ops-business/yak-ops-business-data-development/src/main/java/io/yak/ops/business/development/repository/DevelopmentNodeRepositoryAdapter.java
+++ b/yak-ops-business/yak-ops-business-data-development/src/main/java/io/yak/ops/business/development/repository/DevelopmentNodeRepositoryAdapter.java
@@ -224,7 +224,9 @@ public class DevelopmentNodeRepositoryAdapter implements DevelopmentNodeReposito
         "SELECT d.node_id, d.config_json FROM yak_dev_task_draft d "
             + "JOIN yak_dev_node n ON n.id = d.node_id "
             + "WHERE n.project_id = ? AND n.deleted = 0 AND UPPER(d.task_type) = 'SQL'",
-        rs -> result.put(rs.getLong("node_id"), parseSqlDialect(rs.getString("config_json"))),
+        rs -> {
+          result.put(rs.getLong("node_id"), parseSqlDialect(rs.getString("config_json")));
+        },
         projectId);
     return result;
   }

--- a/yak-ops-business/yak-ops-business-data-development/src/main/java/io/yak/ops/business/development/repository/DevelopmentNodeRepositoryAdapter.java
+++ b/yak-ops-business/yak-ops-business-data-development/src/main/java/io/yak/ops/business/development/repository/DevelopmentNodeRepositoryAdapter.java
@@ -2,10 +2,13 @@ package io.yak.ops.business.development.repository;
 
 import com.baomidou.mybatisplus.core.conditions.query.LambdaQueryWrapper;
 import com.baomidou.mybatisplus.core.conditions.update.LambdaUpdateWrapper;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import io.yak.ops.business.development.dao.mapper.DevelopmentNodeMapper;
 import io.yak.ops.business.development.domain.DevelopmentNode;
 import io.yak.ops.common.bean.po.development.DevelopmentNodePO;
 import io.yak.ops.core.project.CurrentProject;
+import io.yak.ops.spi.task.model.SqlDialect;
 import java.time.Instant;
 import java.util.HashMap;
 import java.util.List;
@@ -20,6 +23,7 @@ import org.springframework.stereotype.Repository;
 public class DevelopmentNodeRepositoryAdapter implements DevelopmentNodeRepository {
 
   private static final long ROOT_DIRECTORY_ID = 0L;
+  private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
 
   private final DevelopmentNodeMapper mapper;
   private final JdbcTemplate jdbcTemplate;
@@ -60,7 +64,7 @@ public class DevelopmentNodeRepositoryAdapter implements DevelopmentNodeReposito
     po.setCreateTime(now);
     po.setUpdateTime(now);
     mapper.insert(po);
-    return toDomain(po, false);
+    return toDomain(po, false, null);
   }
 
   @Override
@@ -71,7 +75,10 @@ public class DevelopmentNodeRepositoryAdapter implements DevelopmentNodeReposito
                 new LambdaQueryWrapper<DevelopmentNodePO>()
                     .eq(DevelopmentNodePO::getId, id)
                     .eq(DevelopmentNodePO::getProjectId, projectId)))
-        .map(po -> toDomain(po, hasUnpublishedChanges(po.getId())));
+        .map(po -> toDomain(
+            po,
+            hasUnpublishedChanges(po.getId()),
+            loadSqlDialect(po.getId(), projectId)));
   }
 
   @Override
@@ -83,8 +90,12 @@ public class DevelopmentNodeRepositoryAdapter implements DevelopmentNodeReposito
             .orderByAsc(DevelopmentNodePO::getName)
             .orderByAsc(DevelopmentNodePO::getId));
     Map<Long, Boolean> pendingPublishByNodeId = loadPendingPublishByNodeId(projectId);
+    Map<Long, String> sqlDialectByNodeId = loadSqlDialectByNodeId(projectId);
     return nodes.stream()
-        .map(po -> toDomain(po, Boolean.TRUE.equals(pendingPublishByNodeId.get(po.getId()))))
+        .map(po -> toDomain(
+            po,
+            Boolean.TRUE.equals(pendingPublishByNodeId.get(po.getId())),
+            sqlDialectByNodeId.get(po.getId())))
         .toList();
   }
 
@@ -207,6 +218,50 @@ public class DevelopmentNodeRepositoryAdapter implements DevelopmentNodeReposito
     return result;
   }
 
+  private Map<Long, String> loadSqlDialectByNodeId(Long projectId) {
+    Map<Long, String> result = new HashMap<>();
+    jdbcTemplate.query(
+        "SELECT d.node_id, d.config_json FROM yak_dev_task_draft d "
+            + "JOIN yak_dev_node n ON n.id = d.node_id "
+            + "WHERE n.project_id = ? AND n.deleted = 0 AND UPPER(d.task_type) = 'SQL'",
+        rs -> result.put(rs.getLong("node_id"), parseSqlDialect(rs.getString("config_json"))),
+        projectId);
+    return result;
+  }
+
+  private String loadSqlDialect(Long nodeId, Long projectId) {
+    List<String> values = jdbcTemplate.query(
+        "SELECT d.config_json FROM yak_dev_task_draft d "
+            + "JOIN yak_dev_node n ON n.id = d.node_id "
+            + "WHERE d.node_id = ? AND n.project_id = ? AND n.deleted = 0 "
+            + "AND UPPER(d.task_type) = 'SQL'",
+        (rs, rowNum) -> parseSqlDialect(rs.getString("config_json")),
+        nodeId,
+        projectId);
+    return values.isEmpty() ? null : values.get(0);
+  }
+
+  private String parseSqlDialect(String configJson) {
+    if (configJson == null || configJson.isBlank()) return SqlDialect.GENERIC.name();
+    try {
+      JsonNode root = OBJECT_MAPPER.readTree(configJson);
+      if (root == null || !root.isObject()) return SqlDialect.GENERIC.name();
+      String value = text(root, "dialect");
+      if (value == null) value = text(root, "databaseType");
+      if (value == null) value = text(root, "dbType");
+      return SqlDialect.parseOrGeneric(value).name();
+    } catch (Exception ignored) {
+      return SqlDialect.GENERIC.name();
+    }
+  }
+
+  private String text(JsonNode root, String key) {
+    JsonNode value = root.get(key);
+    if (value == null || value.isNull()) return null;
+    String text = value.asText();
+    return text == null || text.isBlank() ? null : text.trim();
+  }
+
   private boolean hasUnpublishedChanges(Long nodeId) {
     Long draftRevision = jdbcTemplate.queryForObject(
         "SELECT MAX(draft_revision) FROM yak_dev_task_draft WHERE node_id = ?",
@@ -221,7 +276,10 @@ public class DevelopmentNodeRepositoryAdapter implements DevelopmentNodeReposito
     return publishedDraftRevision == null || draftRevision > publishedDraftRevision;
   }
 
-  private DevelopmentNode toDomain(DevelopmentNodePO po, boolean pendingPublish) {
+  private DevelopmentNode toDomain(
+      DevelopmentNodePO po,
+      boolean pendingPublish,
+      String sqlDialect) {
     Long directoryId = po.getDirectoryId() == null || po.getDirectoryId() == ROOT_DIRECTORY_ID
         ? null
         : po.getDirectoryId();
@@ -235,6 +293,7 @@ public class DevelopmentNodeRepositoryAdapter implements DevelopmentNodeReposito
         po.getCreateTime(),
         po.getUpdateTime(),
         po.getUpdatedBy(),
-        pendingPublish);
+        pendingPublish,
+        "SQL".equalsIgnoreCase(po.getType()) ? sqlDialect : null);
   }
 }

--- a/yak-ops-ui/src/pages/development/data-development/components/CreateDevelopmentNodeModal.tsx
+++ b/yak-ops-ui/src/pages/development/data-development/components/CreateDevelopmentNodeModal.tsx
@@ -1,7 +1,9 @@
+import type { DevelopmentSqlDialect } from '@/services/data-development';
 import { useIntl } from '@umijs/max';
 import { Input, Modal, Select, Typography } from 'antd';
 import { useEffect, useMemo, useState } from 'react';
 
+import { getDevelopmentSqlDialectLabel } from '../sqlDatabaseProfiles';
 import type {
   DevelopmentDirectory,
   DevelopmentId,
@@ -11,6 +13,7 @@ import type {
 interface CreateDevelopmentNodeModalProps {
   open: boolean;
   type: DevelopmentNodeType;
+  sqlDialect?: DevelopmentSqlDialect;
   directories: DevelopmentDirectory[];
   defaultDirectoryId?: DevelopmentId;
   loading?: boolean;
@@ -26,7 +29,8 @@ const ROOT_VALUE = '__root__';
 
 const CreateDevelopmentNodeModal = ({
   open,
-  type: initialType,
+  type,
+  sqlDialect,
   directories,
   defaultDirectoryId,
   loading = false,
@@ -34,27 +38,26 @@ const CreateDevelopmentNodeModal = ({
   onNext,
 }: CreateDevelopmentNodeModalProps) => {
   const intl = useIntl();
-  const [type, setType] = useState<DevelopmentNodeType>(initialType);
   const [directoryId, setDirectoryId] = useState<DevelopmentId>();
   const [name, setName] = useState('');
 
-  const typeOptions = useMemo(
-    () => [
-      { label: 'SQL', value: 'SQL' },
-      { label: 'Shell', value: 'SHELL' },
-      { label: 'Python', value: 'PYTHON' },
-      { label: 'Java', value: 'JAVA' },
-      {
-        label: intl.formatMessage({ id: 'pages.dataDevelopment.workspace.datasetNode' }).replace(/ Node$| 节点$/, ''),
-        value: 'DATASET',
-      },
-      {
-        label: intl.formatMessage({ id: 'pages.dataDevelopment.workspace.dataServiceNode' }).replace(/ Node$| 节点$/, ''),
-        value: 'DATA_SERVICE',
-      },
-    ],
-    [intl],
-  );
+  const typeLabel = useMemo(() => {
+    if (type === 'SQL') return getDevelopmentSqlDialectLabel(sqlDialect);
+    if (type === 'SHELL') return 'Shell';
+    if (type === 'PYTHON') return 'Python';
+    if (type === 'JAVA') return 'Java';
+    if (type === 'DATASET') {
+      return intl
+        .formatMessage({ id: 'pages.dataDevelopment.workspace.datasetNode' })
+        .replace(/ Node$| 节点$/, '');
+    }
+    if (type === 'DATA_SERVICE') {
+      return intl
+        .formatMessage({ id: 'pages.dataDevelopment.workspace.dataServiceNode' })
+        .replace(/ Node$| 节点$/, '');
+    }
+    return type;
+  }, [intl, sqlDialect, type]);
 
   const pathOptions = useMemo(
     () => [
@@ -69,10 +72,9 @@ const CreateDevelopmentNodeModal = ({
 
   useEffect(() => {
     if (!open) return;
-    setType(initialType);
     setDirectoryId(defaultDirectoryId);
     setName('');
-  }, [defaultDirectoryId, initialType, open]);
+  }, [defaultDirectoryId, open, sqlDialect, type]);
 
   const normalizedName = name.trim();
 
@@ -101,13 +103,9 @@ const CreateDevelopmentNodeModal = ({
           <span className="mr-1 text-[rgba(254,44,85,1)]">*</span>
           {intl.formatMessage({ id: 'pages.dataDevelopment.modal.node.type' })}
         </Typography.Text>
-        <Select
-          value={type}
-          options={typeOptions}
-          className="w-full"
-          disabled={loading}
-          onChange={(value) => setType(value as DevelopmentNodeType)}
-        />
+        <div className="flex h-8 items-center rounded-md border border-[#d9d9d9] bg-[#fafafa] px-3 text-[13px] text-[#475467]">
+          {typeLabel}
+        </div>
 
         <Typography.Text className="text-[13px] text-[#344054]">
           <span className="mr-1 text-[rgba(254,44,85,1)]">*</span>

--- a/yak-ops-ui/src/pages/development/data-development/components/DevelopmentCreateMenu.tsx
+++ b/yak-ops-ui/src/pages/development/data-development/components/DevelopmentCreateMenu.tsx
@@ -1,0 +1,222 @@
+import type { DevelopmentSqlDialect } from '@/services/data-development';
+import { useIntl } from '@umijs/max';
+import { Popover } from 'antd';
+import {
+  ChevronRight,
+  Code2,
+  Database,
+  FolderPlus,
+  Network,
+  TerminalSquare,
+} from 'lucide-react';
+import type { ReactNode } from 'react';
+import { useState } from 'react';
+
+import JavaIcon from '@/components/data-development/icons/JavaIcon';
+import PythonIcon from '@/components/data-development/icons/PythonIcon';
+import { DATA_DEVELOPMENT_SQL_DATABASE_PROFILES } from '../sqlDatabaseProfiles';
+import type { DevelopmentNodeType } from '../types';
+
+interface DevelopmentCreateMenuProps {
+  children: ReactNode;
+  onCreateDirectory: () => void;
+  onCreateNode: (
+    type: DevelopmentNodeType,
+    sqlDialect?: DevelopmentSqlDialect,
+  ) => void;
+}
+
+type CreateMenuLevel = 'node' | 'database' | 'general';
+
+const PANEL_WIDTH = 168;
+const PANEL_GAP = 6;
+
+const MenuPanel = ({ children, className = '' }: { children: ReactNode; className?: string }) => (
+  <div
+    className={`rounded-[7px] border border-[#e1e4e8] bg-white p-1 shadow-[0_8px_28px_rgba(16,24,40,0.12)] ${className}`}
+    style={{ width: PANEL_WIDTH }}
+  >
+    {children}
+  </div>
+);
+
+const MenuItem = ({
+  label,
+  icon,
+  arrow = false,
+  active = false,
+  onMouseEnter,
+  onClick,
+}: {
+  label: ReactNode;
+  icon?: ReactNode;
+  arrow?: boolean;
+  active?: boolean;
+  onMouseEnter?: () => void;
+  onClick?: () => void;
+}) => (
+  <button
+    type="button"
+    onMouseEnter={onMouseEnter}
+    onClick={onClick}
+    className={[
+      'flex h-8 w-full items-center gap-2 rounded-[4px] px-2 text-left text-[12px] text-[#30323b] outline-none transition-colors',
+      active ? 'bg-[#f2f3f5]' : 'hover:bg-[#f5f5f6]',
+    ].join(' ')}
+  >
+    <span className="flex h-4 w-4 shrink-0 items-center justify-center text-[#667085]">
+      {icon}
+    </span>
+    <span className="min-w-0 flex-1 truncate">{label}</span>
+    {arrow ? <ChevronRight size={13} strokeWidth={1.8} className="shrink-0 text-[#98a2b3]" /> : null}
+  </button>
+);
+
+const DevelopmentCreateMenu = ({
+  children,
+  onCreateDirectory,
+  onCreateNode,
+}: DevelopmentCreateMenuProps) => {
+  const intl = useIntl();
+  const [open, setOpen] = useState(false);
+  const [level, setLevel] = useState<CreateMenuLevel>();
+
+  const closeAnd = (action: () => void) => {
+    action();
+    setOpen(false);
+    setLevel(undefined);
+  };
+
+  const content = (
+    <div className="relative" onMouseLeave={() => undefined}>
+      <MenuPanel>
+        <MenuItem
+          label={intl.formatMessage({ id: 'pages.dataDevelopment.workspace.createNode' })}
+          icon={<Code2 size={14} strokeWidth={1.8} />}
+          arrow
+          active={Boolean(level)}
+          onMouseEnter={() => setLevel('node')}
+        />
+        <MenuItem
+          label={intl.formatMessage({ id: 'pages.dataDevelopment.workspace.createDirectory' })}
+          icon={<FolderPlus size={14} strokeWidth={1.8} />}
+          onMouseEnter={() => setLevel(undefined)}
+          onClick={() => closeAnd(onCreateDirectory)}
+        />
+      </MenuPanel>
+
+      {level ? (
+        <div
+          className="absolute top-0"
+          style={{ left: PANEL_WIDTH + PANEL_GAP }}
+        >
+          <MenuPanel>
+            <MenuItem
+              label={intl.formatMessage({ id: 'pages.dataDevelopment.workspace.databaseGroup' })}
+              icon={<Database size={14} strokeWidth={1.8} />}
+              arrow
+              active={level === 'database'}
+              onMouseEnter={() => setLevel('database')}
+            />
+            <MenuItem
+              label={intl.formatMessage({ id: 'pages.dataDevelopment.workspace.generalGroup' })}
+              icon={<Code2 size={14} strokeWidth={1.8} />}
+              arrow
+              active={level === 'general'}
+              onMouseEnter={() => setLevel('general')}
+            />
+            <div className="my-1 h-px bg-[#eef0f2]" />
+            <MenuItem
+              label={intl.formatMessage({ id: 'pages.dataDevelopment.workspace.datasetNode' })}
+              icon={<Database size={14} strokeWidth={1.8} />}
+              onClick={() => closeAnd(() => onCreateNode('DATASET'))}
+            />
+            <MenuItem
+              label={intl.formatMessage({ id: 'pages.dataDevelopment.workspace.dataServiceNode' })}
+              icon={<Network size={14} strokeWidth={1.8} />}
+              onClick={() => closeAnd(() => onCreateNode('DATA_SERVICE'))}
+            />
+          </MenuPanel>
+        </div>
+      ) : null}
+
+      {level === 'database' ? (
+        <div
+          className="absolute top-0"
+          style={{ left: (PANEL_WIDTH + PANEL_GAP) * 2 }}
+        >
+          <MenuPanel className="max-h-[440px] overflow-y-auto">
+            {DATA_DEVELOPMENT_SQL_DATABASE_PROFILES.map((profile) => (
+              <MenuItem
+                key={profile.dialect}
+                label={profile.label}
+                icon={<Database size={13} strokeWidth={1.7} />}
+                onClick={() =>
+                  closeAnd(() => onCreateNode('SQL', profile.dialect))
+                }
+              />
+            ))}
+          </MenuPanel>
+        </div>
+      ) : null}
+
+      {level === 'general' ? (
+        <div
+          className="absolute top-0"
+          style={{ left: (PANEL_WIDTH + PANEL_GAP) * 2 }}
+        >
+          <MenuPanel>
+            <MenuItem
+              label={intl.formatMessage({ id: 'pages.dataDevelopment.workspace.shellNode' })}
+              icon={<TerminalSquare size={14} strokeWidth={1.8} />}
+              onClick={() => closeAnd(() => onCreateNode('SHELL'))}
+            />
+            <MenuItem
+              label={intl.formatMessage({ id: 'pages.dataDevelopment.workspace.pythonNode' })}
+              icon={<PythonIcon size={14} />}
+              onClick={() => closeAnd(() => onCreateNode('PYTHON'))}
+            />
+            <MenuItem
+              label={intl.formatMessage({ id: 'pages.dataDevelopment.workspace.javaNode' })}
+              icon={<JavaIcon size={14} />}
+              onClick={() => closeAnd(() => onCreateNode('JAVA'))}
+            />
+          </MenuPanel>
+        </div>
+      ) : null}
+    </div>
+  );
+
+  return (
+    <>
+      <Popover
+        trigger="click"
+        placement="bottomRight"
+        arrow={false}
+        open={open}
+        onOpenChange={(nextOpen) => {
+          setOpen(nextOpen);
+          if (!nextOpen) setLevel(undefined);
+        }}
+        overlayClassName="development-create-menu-popover"
+        content={content}
+      >
+        {children}
+      </Popover>
+      <style>{`
+        .development-create-menu-popover .ant-popover-inner {
+          padding: 0;
+          overflow: visible;
+          background: transparent;
+          box-shadow: none;
+        }
+        .development-create-menu-popover .ant-popover-inner-content {
+          padding: 0;
+          overflow: visible;
+        }
+      `}</style>
+    </>
+  );
+};
+
+export default DevelopmentCreateMenu;

--- a/yak-ops-ui/src/pages/development/data-development/components/DevelopmentCreateMenu.tsx
+++ b/yak-ops-ui/src/pages/development/data-development/components/DevelopmentCreateMenu.tsx
@@ -80,6 +80,9 @@ const DevelopmentCreateMenu = ({
   const intl = useIntl();
   const [open, setOpen] = useState(false);
   const [level, setLevel] = useState<CreateMenuLevel>();
+  const chinese = intl.locale.toLowerCase().startsWith('zh');
+  const databaseLabel = chinese ? '数据库' : 'Database';
+  const generalLabel = chinese ? '通用' : 'General';
 
   const closeAnd = (action: () => void) => {
     action();
@@ -88,7 +91,7 @@ const DevelopmentCreateMenu = ({
   };
 
   const content = (
-    <div className="relative" onMouseLeave={() => undefined}>
+    <div className="relative">
       <MenuPanel>
         <MenuItem
           label={intl.formatMessage({ id: 'pages.dataDevelopment.workspace.createNode' })}
@@ -112,14 +115,14 @@ const DevelopmentCreateMenu = ({
         >
           <MenuPanel>
             <MenuItem
-              label={intl.formatMessage({ id: 'pages.dataDevelopment.workspace.databaseGroup' })}
+              label={databaseLabel}
               icon={<Database size={14} strokeWidth={1.8} />}
               arrow
               active={level === 'database'}
               onMouseEnter={() => setLevel('database')}
             />
             <MenuItem
-              label={intl.formatMessage({ id: 'pages.dataDevelopment.workspace.generalGroup' })}
+              label={generalLabel}
               icon={<Code2 size={14} strokeWidth={1.8} />}
               arrow
               active={level === 'general'}

--- a/yak-ops-ui/src/pages/development/data-development/components/DevelopmentTreePane.tsx
+++ b/yak-ops-ui/src/pages/development/data-development/components/DevelopmentTreePane.tsx
@@ -1,4 +1,5 @@
 import { YakButton, YakEmpty } from '@/components/ui';
+import type { DevelopmentSqlDialect } from '@/services/data-development';
 import { useIntl } from '@umijs/max';
 import type { MenuProps, TreeProps } from 'antd';
 import { Dropdown, Input, Spin, Tooltip, Tree } from 'antd';
@@ -25,6 +26,11 @@ import { useEffect, useMemo, useRef, useState } from 'react';
 
 import JavaIcon from '@/components/data-development/icons/JavaIcon';
 import PythonIcon from '@/components/data-development/icons/PythonIcon';
+import DevelopmentCreateMenu from './DevelopmentCreateMenu';
+import {
+  DATA_DEVELOPMENT_SQL_DATABASE_PROFILES,
+  getDevelopmentSqlDialectLabel,
+} from '../sqlDatabaseProfiles';
 import type {
   DevelopmentNodeCreateType,
   DevelopmentTreeAction,
@@ -46,7 +52,10 @@ interface DevelopmentTreePaneProps {
   leftWidth: number;
   collapsed: boolean;
   onCreateDirectory: () => void;
-  onCreateNode: (type: DevelopmentNodeCreateType) => void;
+  onCreateNode: (
+    type: DevelopmentNodeCreateType,
+    sqlDialect?: DevelopmentSqlDialect,
+  ) => void;
   onResourceAction: (
     action: DevelopmentTreeAction,
     node: DevelopmentTreeNode,
@@ -65,14 +74,17 @@ const nodeTypeIconClassName = (taskType?: string) => {
   return 'text-[#667085]';
 };
 
-const nodeIcon = (taskType?: string): ReactNode => {
+const nodeIcon = (
+  taskType?: string,
+  _sqlDialect?: DevelopmentSqlDialect,
+): ReactNode => {
   const className = `shrink-0 ${nodeTypeIconClassName(taskType)}`;
   if (taskType === 'SHELL') {
     return <TerminalSquare size={13} strokeWidth={1.8} className={className} />;
   }
   if (taskType === 'PYTHON') return <PythonIcon size={13} />;
   if (taskType === 'JAVA') return <JavaIcon size={13} />;
-  if (taskType === 'DATASET') {
+  if (taskType === 'SQL' || taskType === 'DATASET') {
     return <Database size={13} strokeWidth={1.8} className={className} />;
   }
   if (taskType === 'DATA_SERVICE') {
@@ -140,18 +152,6 @@ const collectExpandedDirectoryKeys = (
       : childKeys;
   });
 
-const createTypeForMenuKey = (
-  key: string,
-): DevelopmentNodeCreateType | undefined => {
-  if (key === 'node-sql' || key === 'create-sql') return 'SQL';
-  if (key === 'node-shell' || key === 'create-shell') return 'SHELL';
-  if (key === 'node-python' || key === 'create-python') return 'PYTHON';
-  if (key === 'node-java' || key === 'create-java') return 'JAVA';
-  if (key === 'node-dataset' || key === 'create-dataset') return 'DATASET';
-  if (key === 'node-data-service' || key === 'create-data-service') return 'DATA_SERVICE';
-  return undefined;
-};
-
 const padTimePart = (value: number) => String(value).padStart(2, '0');
 const formatUpdateTime = (value?: string) => {
   if (!value) return '';
@@ -196,53 +196,51 @@ const DevelopmentTreePane = ({
   const nodeCreateItems = useMemo<NonNullable<MenuProps['items']>>(
     () => [
       {
-        key: 'node-sql',
-        label: intl.formatMessage({ id: 'pages.dataDevelopment.workspace.sqlNode' }),
-        icon: <Code2 size={14} strokeWidth={1.8} className="text-[#f79009]" />,
+        key: 'database-group',
+        label: intl.formatMessage({ id: 'pages.dataDevelopment.workspace.databaseGroup' }),
+        icon: <Database size={14} strokeWidth={1.8} />,
+        children: DATA_DEVELOPMENT_SQL_DATABASE_PROFILES.map((profile) => ({
+          key: `create-sql-dialect:${profile.dialect}`,
+          label: profile.label,
+          icon: <Database size={13} strokeWidth={1.7} className="text-[#f79009]" />,
+        })),
       },
       {
-        key: 'node-shell',
-        label: intl.formatMessage({ id: 'pages.dataDevelopment.workspace.shellNode' }),
-        icon: <TerminalSquare size={14} strokeWidth={1.8} className="text-[#6172f3]" />,
-      },
-      {
-        key: 'node-python',
-        label: intl.formatMessage({ id: 'pages.dataDevelopment.workspace.pythonNode' }),
-        icon: <PythonIcon size={14} />,
-      },
-      {
-        key: 'node-java',
-        label: intl.formatMessage({ id: 'pages.dataDevelopment.workspace.javaNode' }),
-        icon: <JavaIcon size={14} />,
+        key: 'general-group',
+        label: intl.formatMessage({ id: 'pages.dataDevelopment.workspace.generalGroup' }),
+        icon: <Code2 size={14} strokeWidth={1.8} />,
+        children: [
+          {
+            key: 'create-shell',
+            label: intl.formatMessage({ id: 'pages.dataDevelopment.workspace.shellNode' }),
+            icon: <TerminalSquare size={14} strokeWidth={1.8} className="text-[#6172f3]" />,
+          },
+          {
+            key: 'create-python',
+            label: intl.formatMessage({ id: 'pages.dataDevelopment.workspace.pythonNode' }),
+            icon: <PythonIcon size={14} />,
+          },
+          {
+            key: 'create-java',
+            label: intl.formatMessage({ id: 'pages.dataDevelopment.workspace.javaNode' }),
+            icon: <JavaIcon size={14} />,
+          },
+        ],
       },
       { type: 'divider' },
       {
-        key: 'node-dataset',
+        key: 'create-dataset',
         label: intl.formatMessage({ id: 'pages.dataDevelopment.workspace.datasetNode' }),
         icon: <Database size={14} strokeWidth={1.8} className="text-[#667085]" />,
       },
       {
-        key: 'node-data-service',
+        key: 'create-data-service',
         label: intl.formatMessage({ id: 'pages.dataDevelopment.workspace.dataServiceNode' }),
         icon: <Network size={14} strokeWidth={1.8} className="text-[#475467]" />,
       },
     ],
     [intl],
   );
-
-  const createMenuItems: MenuProps['items'] = [
-    {
-      key: 'node',
-      label: intl.formatMessage({ id: 'pages.dataDevelopment.workspace.createNode' }),
-      icon: <Code2 size={14} strokeWidth={1.8} />,
-      children: nodeCreateItems,
-    },
-    {
-      key: 'directory',
-      label: intl.formatMessage({ id: 'pages.dataDevelopment.workspace.createDirectory' }),
-      icon: <FolderPlus size={14} strokeWidth={1.8} />,
-    },
-  ];
 
   const contextMenuItems = (node: DevelopmentTreeNode): MenuProps['items'] => {
     const commonItems: MenuProps['items'] = [
@@ -281,10 +279,7 @@ const DevelopmentTreePane = ({
         key: 'create-node',
         label: intl.formatMessage({ id: 'pages.dataDevelopment.workspace.createNode' }),
         icon: <Code2 size={14} strokeWidth={1.8} />,
-        children: nodeCreateItems.map((item) => {
-          if (!item || item.type === 'divider') return item;
-          return { ...item, key: String(item.key).replace('node-', 'create-') };
-        }),
+        children: nodeCreateItems,
       },
       {
         key: 'create-directory',
@@ -312,6 +307,10 @@ const DevelopmentTreePane = ({
     ]
       .filter(Boolean)
       .join(' ');
+    const displayType =
+      node.taskType === 'SQL'
+        ? getDevelopmentSqlDialectLabel(node.sqlDialect)
+        : node.taskType;
 
     return (
       <Dropdown
@@ -336,7 +335,7 @@ const DevelopmentTreePane = ({
             </Tooltip>
           ) : null}
           {isNode ? (
-            nodeIcon(node.taskType)
+            nodeIcon(node.taskType, node.sqlDialect)
           ) : (
             <DevelopmentFolderIcon expanded={expandedDirectoryKeys.includes(node.key)} />
           )}
@@ -351,8 +350,8 @@ const DevelopmentTreePane = ({
           {isNode && updateMeta ? (
             <span className="min-w-0 flex-1 truncate text-[11px] text-[#98a2b3]">{updateMeta}</span>
           ) : null}
-          {isNode && node.taskType ? (
-            <span className="shrink-0 text-[10px] text-[#98a2b3]">{node.taskType}</span>
+          {isNode && displayType ? (
+            <span className="shrink-0 text-[10px] text-[#98a2b3]">{displayType}</span>
           ) : null}
         </div>
       </Dropdown>
@@ -370,23 +369,9 @@ const DevelopmentTreePane = ({
             <span className="text-[13px] font-semibold text-[#30323b]">
               {intl.formatMessage({ id: 'pages.dataDevelopment.workspace.catalog' })}
             </span>
-            <Dropdown
-              trigger={['click']}
-              placement="bottomRight"
-              menu={{
-                items: createMenuItems,
-                triggerSubMenuAction: 'hover',
-                subMenuOpenDelay: 0.05,
-                subMenuCloseDelay: 0.1,
-                onClick: ({ key }) => {
-                  if (key === 'directory') {
-                    onCreateDirectory();
-                    return;
-                  }
-                  const type = createTypeForMenuKey(key);
-                  if (type) onCreateNode(type);
-                },
-              }}
+            <DevelopmentCreateMenu
+              onCreateDirectory={onCreateDirectory}
+              onCreateNode={onCreateNode}
             >
               <Tooltip
                 title={intl.formatMessage({ id: 'pages.dataDevelopment.workspace.create' })}
@@ -401,7 +386,7 @@ const DevelopmentTreePane = ({
                   className="!h-7 !w-7 !p-0 hover:!bg-white"
                 />
               </Tooltip>
-            </Dropdown>
+            </DevelopmentCreateMenu>
           </div>
 
           <div className="flex h-9 shrink-0 items-center border-b border-[#e8e9ec] px-2.5">

--- a/yak-ops-ui/src/pages/development/data-development/components/workbench/EditorTabs.tsx
+++ b/yak-ops-ui/src/pages/development/data-development/components/workbench/EditorTabs.tsx
@@ -1,6 +1,6 @@
 import { useIntl } from '@umijs/max';
 import { Dropdown, Tooltip } from 'antd';
-import { Check, MoreHorizontal, X } from 'lucide-react';
+import { Check, Database, MoreHorizontal, X } from 'lucide-react';
 import { useEffect, useMemo, useRef } from 'react';
 
 import { getEditorAppearance } from '../../editors/registry';
@@ -8,6 +8,10 @@ import {
   getEditorSession,
   useEditorSessionVersion,
 } from '../../editors/session/editorSessionStore';
+import {
+  getDevelopmentResourceSqlDialect,
+  getDevelopmentSqlDialectLabel,
+} from '../../sqlDatabaseProfiles';
 import type {
   DevelopmentId,
   DevelopmentResourceNode,
@@ -29,6 +33,17 @@ interface EditorTabsProps {
   onClose: (nodeId: DevelopmentId) => void;
   onAction: (action: EditorTabAction) => void;
 }
+
+const editorAppearanceForNode = (node: DevelopmentResourceNode) => {
+  const appearance = getEditorAppearance(node.type);
+  if (node.type !== 'SQL') return appearance;
+  return {
+    ...appearance,
+    label: getDevelopmentSqlDialectLabel(getDevelopmentResourceSqlDialect(node)),
+    icon: Database,
+    iconClassName: 'text-[#f79009]',
+  };
+};
 
 const EditorTabs = ({
   nodeMap,
@@ -70,7 +85,7 @@ const EditorTabs = ({
         children: openNodeIds.map((nodeId) => {
           const node = nodeMap.get(nodeId);
           const active = nodeId === activeNodeId;
-          const appearance = node ? getEditorAppearance(node.type) : undefined;
+          const appearance = node ? editorAppearanceForNode(node) : undefined;
           const Icon = appearance?.icon;
           return {
             key: `focus:${nodeId}`,
@@ -83,6 +98,11 @@ const EditorTabs = ({
               <div className="flex min-w-[190px] items-center justify-between gap-3">
                 <span className="flex min-w-0 items-center gap-2">
                   <span className="max-w-[200px] truncate">{node?.name || nodeId}</span>
+                  {appearance ? (
+                    <span className="shrink-0 text-[10px] text-[#98a2b3]">
+                      {appearance.label}
+                    </span>
+                  ) : null}
                   {isDirty(nodeId) ? (
                     <span
                       className="h-1.5 w-1.5 shrink-0 rounded-full bg-[#667085]"
@@ -133,7 +153,7 @@ const EditorTabs = ({
             const node = nodeMap.get(nodeId);
             if (!node) return null;
             const active = nodeId === activeNodeId;
-            const appearance = getEditorAppearance(node.type);
+            const appearance = editorAppearanceForNode(node);
             const Icon = appearance.icon;
 
             return (
@@ -169,6 +189,11 @@ const EditorTabs = ({
                   ].join(' ')}>
                     {node.name}
                   </span>
+                  {node.type === 'SQL' ? (
+                    <span className="shrink-0 text-[9px] text-[#98a2b3]">
+                      {appearance.label}
+                    </span>
+                  ) : null}
                   {isDirty(nodeId) ? (
                     <span
                       className="h-1.5 w-1.5 shrink-0 rounded-full bg-[#667085]"

--- a/yak-ops-ui/src/pages/development/data-development/editors/sql/SqlEditor.tsx
+++ b/yak-ops-ui/src/pages/development/data-development/editors/sql/SqlEditor.tsx
@@ -2,6 +2,7 @@ import { useIntl } from '@umijs/max';
 import { useMemo, useState } from 'react';
 
 import SqlResultWorkspace from '../../components/sql-result/SqlResultWorkspace';
+import { getDevelopmentSqlDialectLabel } from '../../sqlDatabaseProfiles';
 import {
   updateEditorSessionContent,
   updateEditorSessionViewState,
@@ -46,6 +47,7 @@ export const SqlEditor = ({
     ],
   );
   const noDataSource = intl.formatMessage({ id: 'pages.dataDevelopment.editor.noDataSource' });
+  const dialectLabel = getDevelopmentSqlDialectLabel(metadataContext.dialect);
 
   return (
     <div className="flex h-full min-h-0 flex-col overflow-hidden bg-white">
@@ -64,7 +66,7 @@ export const SqlEditor = ({
 
       <div className="flex h-6 shrink-0 items-center justify-between border-t border-[#eef0f2] bg-[#fafafa] px-2.5 text-[10px] text-[#7b808a]">
         <div className="flex min-w-0 items-center gap-3">
-          <span className="font-medium text-[#667085]">SQL</span>
+          <span className="font-medium text-[#667085]">{dialectLabel}</span>
           <span className="truncate">{node.name}</span>
           {session.dirty ? (
             <span className="inline-flex shrink-0 items-center gap-1 text-[#667085]">

--- a/yak-ops-ui/src/pages/development/data-development/editors/sql/metadata/SqlMetadataContextToolbar.tsx
+++ b/yak-ops-ui/src/pages/development/data-development/editors/sql/metadata/SqlMetadataContextToolbar.tsx
@@ -5,6 +5,10 @@ import { ChevronDown, Database, Layers3, Search, Server } from 'lucide-react';
 import type { ReactNode } from 'react';
 import { useEffect, useMemo, useRef, useState } from 'react';
 
+import {
+  getDevelopmentSqlDialectLabel,
+  sqlDialectMatchesDataSource,
+} from '../../../sqlDatabaseProfiles';
 import type { DevelopmentId } from '../../../types';
 import {
   selectSqlDatabaseContext,
@@ -120,7 +124,7 @@ const ContextPicker = ({
             );
           })
         ) : (
-          <div className="flex h-10 items-center justify-center text-[11px] text-[#98a2b3]">
+          <div className="flex h-10 items-center justify-center px-3 text-center text-[11px] text-[#98a2b3]">
             {intl.formatMessage({ id: 'pages.dataDevelopment.editor.sqlMetadata.noMatch' })}
           </div>
         )}
@@ -231,16 +235,37 @@ const SqlMetadataContextToolbar = ({
     };
   }, []);
 
+  const compatibleDataSources = useMemo(
+    () =>
+      dataSources.filter((item) =>
+        sqlDialectMatchesDataSource(context.dialect, item.dbType),
+      ),
+    [context.dialect, dataSources],
+  );
+
   useEffect(() => {
-    if (!context.dataSourceId || context.dataSourceName || !dataSources.length) return;
+    if (!context.dataSourceId || !dataSources.length) return;
     const selected = dataSources.find((item) => item.value === context.dataSourceId);
     if (!selected) return;
+
+    if (!sqlDialectMatchesDataSource(context.dialect, selected.dbType)) {
+      selectSqlDataSourceContext(nodeId, undefined);
+      return;
+    }
+
+    if (context.dataSourceName) return;
     selectSqlDataSourceContext(nodeId, {
       id: selected.value,
       name: selected.label,
       dbType: selected.dbType,
     });
-  }, [context.dataSourceId, context.dataSourceName, dataSources, nodeId]);
+  }, [
+    context.dataSourceId,
+    context.dataSourceName,
+    context.dialect,
+    dataSources,
+    nodeId,
+  ]);
 
   useEffect(() => {
     let active = true;
@@ -281,10 +306,12 @@ const SqlMetadataContextToolbar = ({
   const showSchemaPicker = Boolean(
     context.dataSourceId &&
       normalizedDbType &&
-      !['MYSQL', 'MARIADB', 'SQLITE'].includes(normalizedDbType),
+      !['MYSQL', 'TIDB', 'GOLDENDB', 'DORIS', 'STARROCKS'].includes(
+        normalizedDbType,
+      ),
   );
 
-  const dataSourceItems = dataSources.map((item) => ({
+  const dataSourceItems = compatibleDataSources.map((item) => ({
     value: item.value,
     label: `@${item.label}`,
     searchText: item.dbType,
@@ -305,6 +332,10 @@ const SqlMetadataContextToolbar = ({
   const schemaPlaceholder = bindingLoading
     ? intl.formatMessage({ id: 'pages.dataDevelopment.editor.sqlMetadata.loading' })
     : intl.formatMessage({ id: 'pages.dataDevelopment.editor.sqlMetadata.defaultSchema' });
+  const dataSourcePlaceholder =
+    context.dialect === 'GENERIC'
+      ? '@datasource'
+      : `@${getDevelopmentSqlDialectLabel(context.dialect)}`;
 
   return (
     <>
@@ -316,7 +347,7 @@ const SqlMetadataContextToolbar = ({
           ariaLabel={intl.formatMessage({ id: 'pages.dataDevelopment.editor.sqlMetadata.selectDataSource' })}
           value={context.dataSourceId}
           displayValue={context.dataSourceName ? `@${context.dataSourceName}` : undefined}
-          placeholder="@datasource"
+          placeholder={dataSourcePlaceholder}
           icon={
             <Server
               size={13}
@@ -326,10 +357,10 @@ const SqlMetadataContextToolbar = ({
           }
           items={dataSourceItems}
           loading={dataSourceLoading}
-          popupWidth={210}
+          popupWidth={230}
           minWidthClassName="min-w-[108px]"
           onSelect={(value) => {
-            const selected = dataSources.find((item) => item.value === value);
+            const selected = compatibleDataSources.find((item) => item.value === value);
             if (!selected) return;
             selectSqlDataSourceContext(nodeId, {
               id: selected.value,

--- a/yak-ops-ui/src/pages/development/data-development/editors/sql/metadata/sqlMetadataContextStore.ts
+++ b/yak-ops-ui/src/pages/development/data-development/editors/sql/metadata/sqlMetadataContextStore.ts
@@ -57,7 +57,6 @@ const normalizePersistedContext = (
     nodeId: context.nodeId,
     dataSourceId: optionalString('dataSourceId'),
     dataSourceName: optionalString('dataSourceName'),
-    // v1 local storage used `dbType`; accept it while persisting the canonical dialect shape.
     dialect,
     dbType: dialect,
     database: optionalString('database'),
@@ -203,10 +202,14 @@ export const selectSqlDataSourceContext = (
   nodeId: DevelopmentId,
   dataSource?: { id: string; name?: string; dbType?: string },
 ) => {
+  const current = ensureSqlMetadataContext(nodeId);
+  const dialect = dataSource?.dbType
+    ? normalizeDevelopmentSqlDialect(dataSource.dbType)
+    : current.dialect;
   const next = updateSqlMetadataContext(nodeId, {
     dataSourceId: dataSource?.id,
     dataSourceName: dataSource?.name,
-    dialect: normalizeDevelopmentSqlDialect(dataSource?.dbType),
+    dialect,
     database: undefined,
     schema: undefined,
   });

--- a/yak-ops-ui/src/pages/development/data-development/hooks/useDataDevelopmentPage.ts
+++ b/yak-ops-ui/src/pages/development/data-development/hooks/useDataDevelopmentPage.ts
@@ -35,6 +35,7 @@ import {
   developmentIdFromTreeKey,
   developmentNodeKey,
   developmentNodeTypeForAction,
+  developmentSqlDialectForAction,
   filterDevelopmentTreeData,
   parseDevelopmentTreeWidth,
 } from '../utils';
@@ -256,8 +257,6 @@ export const useDataDevelopmentPage = () => {
               baseRevision: 0,
             });
           } catch (error) {
-            // Dialect is part of the SQL authoring identity in PR2. Do not leave a half-created
-            // generic node behind when its initial dialect draft cannot be persisted.
             await deleteDevelopmentNode(created.id).catch(() => undefined);
             throw error;
           }
@@ -304,7 +303,7 @@ export const useDataDevelopmentPage = () => {
 
       const type = developmentNodeTypeForAction(action);
       if (type) {
-        openCreateNode(type);
+        openCreateNode(type, developmentSqlDialectForAction(action));
         return;
       }
       if (action === 'copy-name') {

--- a/yak-ops-ui/src/pages/development/data-development/hooks/useDataDevelopmentPage.ts
+++ b/yak-ops-ui/src/pages/development/data-development/hooks/useDataDevelopmentPage.ts
@@ -9,10 +9,12 @@ import {
   moveDevelopmentNode,
   renameDevelopmentDirectory,
   renameDevelopmentNode,
+  saveDevelopmentTaskDraft,
   type DevelopmentDirectory,
   type DevelopmentId,
   type DevelopmentNodeType,
   type DevelopmentResourceNode,
+  type DevelopmentSqlDialect,
 } from '@/services/data-development';
 import { useIntl } from '@umijs/max';
 import { message } from 'antd';
@@ -61,6 +63,8 @@ export const useDataDevelopmentPage = () => {
   const [createNodeOpen, setCreateNodeOpen] = useState(false);
   const [createNodeType, setCreateNodeType] =
     useState<DevelopmentNodeType>('SQL');
+  const [createSqlDialect, setCreateSqlDialect] =
+    useState<DevelopmentSqlDialect>();
   const [nodeSaving, setNodeSaving] = useState(false);
   const [createDirectoryOpen, setCreateDirectoryOpen] = useState(false);
   const [directorySaving, setDirectorySaving] = useState(false);
@@ -181,10 +185,14 @@ export const useDataDevelopmentPage = () => {
     [treeCollapsed, treeWidth],
   );
 
-  const openCreateNode = useCallback((type: DevelopmentNodeType) => {
-    setCreateNodeType(type);
-    setCreateNodeOpen(true);
-  }, []);
+  const openCreateNode = useCallback(
+    (type: DevelopmentNodeType, sqlDialect?: DevelopmentSqlDialect) => {
+      setCreateNodeType(type);
+      setCreateSqlDialect(type === 'SQL' ? sqlDialect : undefined);
+      setCreateNodeOpen(true);
+    },
+    [],
+  );
 
   const closeCreateNode = useCallback(() => {
     if (!nodeSaving) setCreateNodeOpen(false);
@@ -226,14 +234,35 @@ export const useDataDevelopmentPage = () => {
       type: DevelopmentNodeType,
       directoryId: DevelopmentId | undefined,
       name: string,
+      sqlDialect?: DevelopmentSqlDialect,
     ) => {
       setNodeSaving(true);
+      let createdId: DevelopmentId | undefined;
       try {
         const created = await createDevelopmentNode({
           name,
           type,
           directoryId,
         });
+        createdId = created.id;
+
+        if (type === 'SQL' && sqlDialect) {
+          try {
+            await saveDevelopmentTaskDraft(created.id, {
+              taskType: 'SQL',
+              schemaVersion: 1,
+              content: '',
+              configJson: JSON.stringify({ dialect: sqlDialect }),
+              baseRevision: 0,
+            });
+          } catch (error) {
+            // Dialect is part of the SQL authoring identity in PR2. Do not leave a half-created
+            // generic node behind when its initial dialect draft cannot be persisted.
+            await deleteDevelopmentNode(created.id).catch(() => undefined);
+            throw error;
+          }
+        }
+
         setCreateNodeOpen(false);
         setTreeKeyword('');
         await loadTree();
@@ -245,6 +274,7 @@ export const useDataDevelopmentPage = () => {
             ? error.message
             : text('pages.dataDevelopment.workspace.nodeCreateFailed'),
         );
+        if (createdId) await loadTree();
       } finally {
         setNodeSaving(false);
       }
@@ -419,6 +449,7 @@ export const useDataDevelopmentPage = () => {
     treeCollapsed,
     createNodeOpen,
     createNodeType,
+    createSqlDialect,
     nodeSaving,
     createDirectoryOpen,
     directorySaving,

--- a/yak-ops-ui/src/pages/development/data-development/index.tsx
+++ b/yak-ops-ui/src/pages/development/data-development/index.tsx
@@ -50,12 +50,13 @@ export default function DataDevelopmentPage() {
         <CreateDevelopmentNodeModal
           open={page.createNodeOpen}
           type={page.createNodeType}
+          sqlDialect={page.createSqlDialect}
           directories={page.directories}
           loading={page.nodeSaving}
           defaultDirectoryId={page.directoryIdForSelection}
           onCancel={page.closeCreateNode}
           onNext={(type, directoryId, name) =>
-            void page.submitNode(type, directoryId, name)
+            void page.submitNode(type, directoryId, name, page.createSqlDialect)
           }
         />
 

--- a/yak-ops-ui/src/pages/development/data-development/sqlDatabaseProfiles.ts
+++ b/yak-ops-ui/src/pages/development/data-development/sqlDatabaseProfiles.ts
@@ -1,0 +1,73 @@
+import {
+  normalizeDevelopmentSqlDialect,
+  type DevelopmentSqlDialect,
+} from '@/services/data-development';
+
+import type { DevelopmentResourceNode } from './types';
+
+export interface DevelopmentSqlDatabaseProfile {
+  dialect: DevelopmentSqlDialect;
+  label: string;
+}
+
+/**
+ * SQL authoring databases exposed in PR2.
+ *
+ * The list intentionally follows the current JDBC-capable relational set, plus Doris and
+ * StarRocks. Search/document databases stay outside SQL authoring until they have their own
+ * development model.
+ */
+export const DATA_DEVELOPMENT_SQL_DATABASE_PROFILES: DevelopmentSqlDatabaseProfile[] = [
+  { dialect: 'MYSQL', label: 'MySQL' },
+  { dialect: 'TIDB', label: 'TiDB' },
+  { dialect: 'GOLDENDB', label: 'GoldenDB' },
+  { dialect: 'GBASE8C', label: 'GBase 8c' },
+  { dialect: 'GBASE8A', label: 'GBase 8a' },
+  { dialect: 'GBASE8S', label: 'GBase 8s' },
+  { dialect: 'HANA', label: 'SAP HANA' },
+  { dialect: 'ORACLE', label: 'Oracle' },
+  { dialect: 'POSTGRE_SQL', label: 'PostgreSQL' },
+  { dialect: 'DB2', label: 'IBM Db2' },
+  { dialect: 'OPEN_GAUSS', label: 'openGauss' },
+  { dialect: 'SQL_SERVER', label: 'SQL Server' },
+  { dialect: 'OCEANBASE', label: 'OceanBase' },
+  { dialect: 'YASHAN_DB', label: 'YashanDB' },
+  { dialect: 'HIGHGO', label: 'HighGo' },
+  { dialect: 'IRIS', label: 'InterSystems IRIS' },
+  { dialect: 'XUGU', label: 'XuguDB' },
+  { dialect: 'DUCKDB', label: 'DuckDB' },
+  { dialect: 'KINGBASE', label: 'KingbaseES' },
+  { dialect: 'DAMENG', label: '达梦' },
+  { dialect: 'DORIS', label: 'Doris' },
+  { dialect: 'STARROCKS', label: 'StarRocks' },
+];
+
+const SQL_DATABASE_PROFILE_MAP = new Map(
+  DATA_DEVELOPMENT_SQL_DATABASE_PROFILES.map((profile) => [
+    profile.dialect,
+    profile,
+  ]),
+);
+
+export const getDevelopmentSqlDialectLabel = (
+  dialect?: DevelopmentSqlDialect | string,
+) => {
+  const normalized = normalizeDevelopmentSqlDialect(dialect);
+  if (normalized === 'GENERIC') return 'SQL';
+  return SQL_DATABASE_PROFILE_MAP.get(normalized)?.label || normalized;
+};
+
+export const getDevelopmentResourceSqlDialect = (
+  node?: DevelopmentResourceNode,
+): DevelopmentSqlDialect => {
+  if (!node || node.type !== 'SQL') return 'GENERIC';
+  const projected = (node as unknown as { sqlDialect?: unknown }).sqlDialect;
+  return normalizeDevelopmentSqlDialect(projected);
+};
+
+export const sqlDialectMatchesDataSource = (
+  dialect: DevelopmentSqlDialect,
+  dbType?: string,
+) =>
+  dialect === 'GENERIC' ||
+  normalizeDevelopmentSqlDialect(dbType) === dialect;

--- a/yak-ops-ui/src/pages/development/data-development/types.ts
+++ b/yak-ops-ui/src/pages/development/data-development/types.ts
@@ -2,6 +2,7 @@ import type { ApiResponse } from '@/services/http/response';
 import type {
   DevelopmentId,
   DevelopmentNodeType,
+  DevelopmentSqlDialect,
 } from '@/services/data-development';
 import type { DataNode } from 'antd/es/tree';
 
@@ -35,6 +36,7 @@ export interface DevelopmentTreeNode extends DataNode {
   resourceId: DevelopmentId;
   resourcePath: string;
   taskType?: DevelopmentNodeType;
+  sqlDialect?: DevelopmentSqlDialect;
   searchText?: string;
   updatedBy?: string | null;
   updateTime?: string;

--- a/yak-ops-ui/src/pages/development/data-development/types.ts
+++ b/yak-ops-ui/src/pages/development/data-development/types.ts
@@ -18,6 +18,7 @@ export type DevelopmentNodeCreateType = DevelopmentNodeType;
 export type DevelopmentTreeAction =
   | 'create-directory'
   | 'create-sql'
+  | `create-sql-dialect:${DevelopmentSqlDialect}`
   | 'create-shell'
   | 'create-python'
   | 'create-java'

--- a/yak-ops-ui/src/pages/development/data-development/utils.ts
+++ b/yak-ops-ui/src/pages/development/data-development/utils.ts
@@ -3,6 +3,10 @@ import {
   DATA_DEVELOPMENT_MAX_TREE_WIDTH,
   DATA_DEVELOPMENT_MIN_TREE_WIDTH,
 } from './constants';
+import {
+  getDevelopmentResourceSqlDialect,
+  getDevelopmentSqlDialectLabel,
+} from './sqlDatabaseProfiles';
 import type {
   DevelopmentDirectory,
   DevelopmentId,
@@ -73,6 +77,11 @@ export const buildDevelopmentTreeData = (
         const parentPath = directoryId
           ? directoryPathMap.get(directoryId) || ''
           : '';
+        const sqlDialect =
+          node.type === 'SQL' ? getDevelopmentResourceSqlDialect(node) : undefined;
+        const displayType = sqlDialect
+          ? getDevelopmentSqlDialectLabel(sqlDialect)
+          : node.type;
         return {
           key: developmentNodeKey(node.id),
           title: node.name,
@@ -80,7 +89,8 @@ export const buildDevelopmentTreeData = (
           resourceId: node.id,
           resourcePath: `${parentPath}/${node.name}`,
           taskType: node.type,
-          searchText: `${node.name} ${node.type} ${node.id}`,
+          sqlDialect,
+          searchText: `${node.name} ${node.type} ${displayType} ${node.id}`,
           updatedBy: node.updatedBy,
           updateTime: node.updateTime,
           pendingPublish: node.pendingPublish,

--- a/yak-ops-ui/src/pages/development/data-development/utils.ts
+++ b/yak-ops-ui/src/pages/development/data-development/utils.ts
@@ -1,3 +1,4 @@
+import { normalizeDevelopmentSqlDialect } from '@/services/data-development';
 import {
   DATA_DEVELOPMENT_DEFAULT_TREE_WIDTH,
   DATA_DEVELOPMENT_MAX_TREE_WIDTH,
@@ -12,6 +13,7 @@ import type {
   DevelopmentId,
   DevelopmentNodeType,
   DevelopmentResourceNode,
+  DevelopmentSqlDialect,
   DevelopmentTreeAction,
   DevelopmentTreeNode,
   DevelopmentTreeNodeKey,
@@ -50,13 +52,22 @@ export const parseDevelopmentTreeWidth = (storedValue: string | null) => {
 export const developmentNodeTypeForAction = (
   action: DevelopmentTreeAction,
 ): DevelopmentNodeType | undefined => {
-  if (action === 'create-sql') return 'SQL';
+  if (action === 'create-sql' || action.startsWith('create-sql-dialect:')) return 'SQL';
   if (action === 'create-shell') return 'SHELL';
   if (action === 'create-python') return 'PYTHON';
   if (action === 'create-java') return 'JAVA';
   if (action === 'create-dataset') return 'DATASET';
   if (action === 'create-data-service') return 'DATA_SERVICE';
   return undefined;
+};
+
+export const developmentSqlDialectForAction = (
+  action: DevelopmentTreeAction,
+): DevelopmentSqlDialect | undefined => {
+  const prefix = 'create-sql-dialect:';
+  if (!action.startsWith(prefix)) return undefined;
+  const dialect = normalizeDevelopmentSqlDialect(action.substring(prefix.length));
+  return dialect === 'GENERIC' ? undefined : dialect;
 };
 
 export const buildDevelopmentTreeData = (


### PR DESCRIPTION
## Summary

- replace the flat Data Development create dropdown with a lightweight cascading create menu
- group authoring nodes into Database and General categories while keeping Dataset/Data Service as direct options
- expose the current JDBC relational database set plus Doris and StarRocks as SQL authoring choices
- keep runtime identity stable as `taskType=SQL`; database selection initializes the PR1 `configJson.dialect` model instead of introducing database task types
- project SQL dialect from existing task drafts into the node list read model, without adding a duplicate node-table column or Flyway migration
- show concrete database identity in the development tree, editor tabs, and SQL status bar
- filter the SQL datasource picker so a MySQL/PostgreSQL/Doris/StarRocks/etc. node only offers compatible datasource instances
- preserve legacy Generic SQL nodes: they continue to see all SQL-capable datasource options until a concrete dialect is chosen

## Creation flow

```text
Create node
  -> Database
      -> MySQL / PostgreSQL / Oracle / ... / Doris / StarRocks
  -> General
      -> Shell / Python / Java
  -> Dataset
  -> Data Service
```

A database selection creates the same SQL task node as before and immediately initializes an empty draft with only the canonical dialect, for example:

```json
{
  "dialect": "MYSQL"
}
```

If that initial dialect draft cannot be saved, the newly-created node is best-effort rolled back so the UI does not leave a misleading Generic SQL node behind.

## Persistence model

No schema migration is introduced. `yak_dev_node.type` remains `SQL`; dialect remains plugin-owned task metadata in `yak_dev_task_draft.config_json` / revisions / execution snapshots. The node-list API only projects that existing value as `sqlDialect` for efficient UI rendering, avoiding one draft request per tree node.

## Backward compatibility

- historical SQL nodes without a draft/dialect render as `SQL` / `GENERIC`
- historical Generic SQL nodes still list all SQL datasource types
- non-SQL nodes and task runtimes are unchanged
- PR3 database-specific syntax/completion/editor profiles are intentionally out of scope

## Scope

PR2 only: creation UX, dialect initialization/projection, database identity presentation, and datasource filtering. No database-specific SQL parser, formatter, completion dictionary, or execution semantics are changed here.
