### PR TITLE
feat(data-development): add dialect-aware SQL editor profiles

### DIFF
--- a/yak-ops-ui/src/pages/development/data-development/editors/sql/assistance/registerSqlHover.ts
+++ b/yak-ops-ui/src/pages/development/data-development/editors/sql/assistance/registerSqlHover.ts
@@ -1,12 +1,12 @@
 import * as monaco from 'monaco-editor/esm/vs/editor/editor.api';
 
-import { SQL_BUILTIN_FUNCTIONS } from '../completion/sqlBuiltinCatalog';
 import { loadSqlColumns, loadSqlTables } from '../metadata/sqlMetadataCache';
 import { getSqlMetadataContext } from '../metadata/sqlMetadataContextStore';
 import type {
   SqlCatalogColumn,
   SqlCatalogTable,
 } from '../metadata/sqlMetadataService';
+import { resolveSqlEditorProfile } from '../profiles/sqlEditorProfiles';
 import {
   findSqlTableReference,
   getCurrentSqlStatementText,
@@ -20,10 +20,6 @@ import {
 
 let providerDisposable: monaco.IDisposable | undefined;
 let providerConsumers = 0;
-
-const builtinFunctionMap = new Map(
-  SQL_BUILTIN_FUNCTIONS.map((definition) => [definition.name.toUpperCase(), definition]),
-);
 
 const escapeMarkdown = (value: string) =>
   value.replace(/([\\`*_{}\[\]()#+\-.!|>])/g, '\\$1');
@@ -135,7 +131,13 @@ const provideHover = async (
   if (getSqlLexicalState(textBeforePosition) !== 'code') return undefined;
 
   const range = wordRange(position, word);
-  const builtin = builtinFunctionMap.get(word.word.toUpperCase());
+  const nodeId = getSqlEditorNodeId(model);
+  const context = nodeId ? getSqlMetadataContext(nodeId) : undefined;
+  const profile = resolveSqlEditorProfile(context?.dialect);
+  const builtin = profile.functions.find(
+    (definition) =>
+      definition.name.toUpperCase() === word.word.toUpperCase(),
+  );
   if (builtin && isFunctionCall(model, position, word)) {
     return {
       range,
@@ -146,8 +148,6 @@ const provideHover = async (
     };
   }
 
-  const nodeId = getSqlEditorNodeId(model);
-  const context = nodeId ? getSqlMetadataContext(nodeId) : undefined;
   if (!context?.dataSourceId) return undefined;
 
   const references = parseSqlTableReferences(

--- a/yak-ops-ui/src/pages/development/data-development/editors/sql/assistance/registerSqlSignatureHelp.ts
+++ b/yak-ops-ui/src/pages/development/data-development/editors/sql/assistance/registerSqlSignatureHelp.ts
@@ -1,6 +1,8 @@
 import * as monaco from 'monaco-editor/esm/vs/editor/editor.api';
 
-import { SQL_BUILTIN_FUNCTIONS } from '../completion/sqlBuiltinCatalog';
+import { getSqlMetadataContext } from '../metadata/sqlMetadataContextStore';
+import { resolveSqlEditorProfile } from '../profiles/sqlEditorProfiles';
+import { getSqlEditorNodeId } from './sqlTextContext';
 
 interface FunctionFrame {
   name?: string;
@@ -18,14 +20,13 @@ type ScanState =
 let providerDisposable: monaco.IDisposable | undefined;
 let providerConsumers = 0;
 
-const functionMap = new Map(
-  SQL_BUILTIN_FUNCTIONS.map((definition) => [definition.name.toUpperCase(), definition]),
-);
-
 const previousIdentifier = (text: string, offset: number) =>
   text.slice(0, offset).match(/([A-Za-z_][\w$]*)\s*$/)?.[1];
 
-const findActiveFunction = (text: string): FunctionFrame | undefined => {
+const findActiveFunction = (
+  text: string,
+  functionNames: ReadonlySet<string>,
+): FunctionFrame | undefined => {
   const stack: FunctionFrame[] = [];
   let state: ScanState = 'code';
 
@@ -108,7 +109,7 @@ const findActiveFunction = (text: string): FunctionFrame | undefined => {
 
   for (let index = stack.length - 1; index >= 0; index -= 1) {
     const frame = stack[index];
-    if (frame.name && functionMap.has(frame.name.toUpperCase())) return frame;
+    if (frame.name && functionNames.has(frame.name.toUpperCase())) return frame;
   }
   return undefined;
 };
@@ -131,7 +132,16 @@ const createProvider = () =>
       const text = model.getValueInRange(
         new monaco.Range(1, 1, position.lineNumber, position.column),
       );
-      const frame = findActiveFunction(text);
+      const nodeId = getSqlEditorNodeId(model);
+      const context = nodeId ? getSqlMetadataContext(nodeId) : undefined;
+      const profile = resolveSqlEditorProfile(context?.dialect);
+      const functionMap = new Map(
+        profile.functions.map((definition) => [
+          definition.name.toUpperCase(),
+          definition,
+        ]),
+      );
+      const frame = findActiveFunction(text, new Set(functionMap.keys()));
       if (!frame?.name) return undefined;
 
       const definition = functionMap.get(frame.name.toUpperCase());

--- a/yak-ops-ui/src/pages/development/data-development/editors/sql/assistance/sqlTextContext.ts
+++ b/yak-ops-ui/src/pages/development/data-development/editors/sql/assistance/sqlTextContext.ts
@@ -2,6 +2,7 @@ import * as monaco from 'monaco-editor/esm/vs/editor/editor.api';
 
 import type { DevelopmentId } from '../../../types';
 import type { SqlMetadataContext } from '../metadata/sqlMetadataContextStore';
+import { resolveSqlEditorProfile } from '../profiles/sqlEditorProfiles';
 
 export type SqlLexicalState =
   | 'code'
@@ -201,10 +202,8 @@ const tableReferenceFromParts = (
 
   if (parts.length === 2) {
     const first = parts[0];
-    const mysqlLike = ['MYSQL', 'MARIADB', 'DORIS'].includes(
-      (context.dbType || '').toUpperCase(),
-    );
-    return mysqlLike
+    const profile = resolveSqlEditorProfile(context.dialect);
+    return profile.twoPartNamespace === 'database'
       ? { database: first, table, alias }
       : { database: context.database, schema: first, table, alias };
   }

--- a/yak-ops-ui/src/pages/development/data-development/editors/sql/completion/registerSqlBuiltinCompletion.ts
+++ b/yak-ops-ui/src/pages/development/data-development/editors/sql/completion/registerSqlBuiltinCompletion.ts
@@ -1,129 +1,19 @@
 import * as monaco from 'monaco-editor/esm/vs/editor/editor.api';
 
 import {
-  SQL_BUILTIN_FUNCTIONS,
-  SQL_KEYWORDS,
-} from './sqlBuiltinCatalog';
-
-type SqlLexicalState =
-  | 'code'
-  | 'single-quote'
-  | 'double-quote'
-  | 'backtick'
-  | 'bracket-identifier'
-  | 'line-comment'
-  | 'block-comment';
+  getSqlEditorNodeId,
+  getSqlLexicalState,
+  getSqlTextBeforePosition,
+} from '../assistance/sqlTextContext';
+import { getSqlMetadataContext } from '../metadata/sqlMetadataContextStore';
+import { resolveSqlEditorProfile } from '../profiles/sqlEditorProfiles';
 
 let providerDisposable: monaco.IDisposable | undefined;
 let providerConsumers = 0;
 
-const getTextBeforePosition = (
-  model: monaco.editor.ITextModel,
-  position: monaco.Position,
-) =>
-  model.getValueInRange(
-    new monaco.Range(1, 1, position.lineNumber, position.column),
-  );
-
-const getLexicalState = (text: string): SqlLexicalState => {
-  let state: SqlLexicalState = 'code';
-
-  for (let index = 0; index < text.length; index += 1) {
-    const current = text[index];
-    const next = text[index + 1];
-
-    if (state === 'line-comment') {
-      if (current === '\n') state = 'code';
-      continue;
-    }
-
-    if (state === 'block-comment') {
-      if (current === '*' && next === '/') {
-        state = 'code';
-        index += 1;
-      }
-      continue;
-    }
-
-    if (state === 'single-quote') {
-      if (current === '\\') {
-        index += 1;
-        continue;
-      }
-      if (current === "'" && next === "'") {
-        index += 1;
-        continue;
-      }
-      if (current === "'") state = 'code';
-      continue;
-    }
-
-    if (state === 'double-quote') {
-      if (current === '\\') {
-        index += 1;
-        continue;
-      }
-      if (current === '"' && next === '"') {
-        index += 1;
-        continue;
-      }
-      if (current === '"') state = 'code';
-      continue;
-    }
-
-    if (state === 'backtick') {
-      if (current === '\\') {
-        index += 1;
-        continue;
-      }
-      if (current === '`' && next === '`') {
-        index += 1;
-        continue;
-      }
-      if (current === '`') state = 'code';
-      continue;
-    }
-
-    if (state === 'bracket-identifier') {
-      if (current === ']' && next === ']') {
-        index += 1;
-        continue;
-      }
-      if (current === ']') state = 'code';
-      continue;
-    }
-
-    if (current === '-' && next === '-') {
-      state = 'line-comment';
-      index += 1;
-      continue;
-    }
-    if (current === '/' && next === '*') {
-      state = 'block-comment';
-      index += 1;
-      continue;
-    }
-    if (current === "'") {
-      state = 'single-quote';
-      continue;
-    }
-    if (current === '"') {
-      state = 'double-quote';
-      continue;
-    }
-    if (current === '`') {
-      state = 'backtick';
-      continue;
-    }
-    if (current === '[') {
-      state = 'bracket-identifier';
-    }
-  }
-
-  return state;
-};
-
 const formatCandidateName = (name: string, prefix: string) => {
+  const mixedCase = name !== name.toUpperCase() && name !== name.toLowerCase();
+  if (mixedCase) return name;
   if (prefix && prefix === prefix.toLowerCase()) return name.toLowerCase();
   return name;
 };
@@ -149,8 +39,8 @@ const shouldProvideCompletion = (
   position: monaco.Position,
   wordStartColumn: number,
 ) => {
-  const textBeforePosition = getTextBeforePosition(model, position);
-  if (getLexicalState(textBeforePosition) !== 'code') return false;
+  const textBeforePosition = getSqlTextBeforePosition(model, position);
+  if (getSqlLexicalState(textBeforePosition) !== 'code') return false;
 
   if (wordStartColumn > 1) {
     const characterBeforeWord = model.getValueInRange(
@@ -167,6 +57,12 @@ const shouldProvideCompletion = (
   return true;
 };
 
+const getProfileForModel = (model: monaco.editor.ITextModel) => {
+  const nodeId = getSqlEditorNodeId(model);
+  const context = nodeId ? getSqlMetadataContext(nodeId) : undefined;
+  return resolveSqlEditorProfile(context?.dialect);
+};
+
 const createProvider = () =>
   monaco.languages.registerCompletionItemProvider('sql', {
     provideCompletionItems: (model, position) => {
@@ -175,8 +71,9 @@ const createProvider = () =>
         return { suggestions: [] };
       }
 
+      const profile = getProfileForModel(model);
       const keywordSuggestions: monaco.languages.CompletionItem[] =
-        SQL_KEYWORDS.map((keyword) => ({
+        profile.keywords.map((keyword) => ({
           label: keyword,
           kind: monaco.languages.CompletionItemKind.Keyword,
           insertText: formatCandidateName(keyword, prefix),
@@ -187,7 +84,7 @@ const createProvider = () =>
         }));
 
       const functionSuggestions: monaco.languages.CompletionItem[] =
-        SQL_BUILTIN_FUNCTIONS.map((definition) => {
+        profile.functions.map((definition) => {
           const name = formatCandidateName(definition.name, prefix);
           return {
             label: definition.name,

--- a/yak-ops-ui/src/pages/development/data-development/editors/sql/completion/registerSqlMetadataCompletion.ts
+++ b/yak-ops-ui/src/pages/development/data-development/editors/sql/completion/registerSqlMetadataCompletion.ts
@@ -1,256 +1,28 @@
 import * as monaco from 'monaco-editor/esm/vs/editor/editor.api';
 
 import type { DevelopmentId } from '../../../types';
-import { loadSqlColumns, loadSqlTables } from '../metadata/sqlMetadataCache';
 import {
-  getSqlMetadataContext,
-  type SqlMetadataContext,
-} from '../metadata/sqlMetadataContextStore';
+  findSqlTableReference,
+  getCurrentSqlStatementText,
+  getSqlLexicalState,
+  getSqlTextBeforePosition,
+  parseSqlTableReferences,
+} from '../assistance/sqlTextContext';
+import { loadSqlColumns, loadSqlTables } from '../metadata/sqlMetadataCache';
+import { getSqlMetadataContext } from '../metadata/sqlMetadataContextStore';
 import type {
   SqlCatalogColumn,
   SqlCatalogTable,
 } from '../metadata/sqlMetadataService';
-
-type SqlLexicalState =
-  | 'code'
-  | 'single-quote'
-  | 'double-quote'
-  | 'backtick'
-  | 'bracket-identifier'
-  | 'line-comment'
-  | 'block-comment';
-
-interface SqlTableReference {
-  database?: string;
-  schema?: string;
-  table: string;
-  alias?: string;
-}
+import {
+  formatSqlIdentifierForCompletion,
+  resolveSqlEditorProfile,
+  type SqlEditorProfile,
+} from '../profiles/sqlEditorProfiles';
 
 let providerDisposable: monaco.IDisposable | undefined;
 let providerConsumers = 0;
 const modelNodeIds = new Map<string, DevelopmentId>();
-
-const STOP_ALIAS_WORDS = new Set([
-  'WHERE',
-  'JOIN',
-  'LEFT',
-  'RIGHT',
-  'FULL',
-  'INNER',
-  'OUTER',
-  'CROSS',
-  'ON',
-  'GROUP',
-  'ORDER',
-  'HAVING',
-  'LIMIT',
-  'OFFSET',
-  'UNION',
-  'EXCEPT',
-  'INTERSECT',
-  'SET',
-  'VALUES',
-  'RETURNING',
-]);
-
-const identifierPart = '(?:`[^`]+`|"[^"]+"|\\[[^\\]]+\\]|[A-Za-z_$][\\w$]*)';
-const qualifiedIdentifier = `${identifierPart}(?:\\s*\\.\\s*${identifierPart}){0,2}`;
-const tableReferencePattern = new RegExp(
-  `\\b(?:FROM|JOIN)\\s+(${qualifiedIdentifier})(?:\\s+(?:AS\\s+)?([A-Za-z_$][\\w$]*))?`,
-  'gi',
-);
-
-const getTextBeforePosition = (
-  model: monaco.editor.ITextModel,
-  position: monaco.Position,
-) =>
-  model.getValueInRange(
-    new monaco.Range(1, 1, position.lineNumber, position.column),
-  );
-
-const getCurrentStatementText = (
-  model: monaco.editor.ITextModel,
-  position: monaco.Position,
-) => {
-  const sql = model.getValue();
-  const offset = model.getOffsetAt(position);
-  const start = sql.lastIndexOf(';', Math.max(0, offset - 1)) + 1;
-  const nextSeparator = sql.indexOf(';', offset);
-  const end = nextSeparator < 0 ? sql.length : nextSeparator;
-  return sql.slice(start, end);
-};
-
-const getLexicalState = (text: string): SqlLexicalState => {
-  let state: SqlLexicalState = 'code';
-
-  for (let index = 0; index < text.length; index += 1) {
-    const current = text[index];
-    const next = text[index + 1];
-
-    if (state === 'line-comment') {
-      if (current === '\n') state = 'code';
-      continue;
-    }
-    if (state === 'block-comment') {
-      if (current === '*' && next === '/') {
-        state = 'code';
-        index += 1;
-      }
-      continue;
-    }
-    if (state === 'single-quote') {
-      if (current === "'" && next === "'") {
-        index += 1;
-        continue;
-      }
-      if (current === "'") state = 'code';
-      continue;
-    }
-    if (state === 'double-quote') {
-      if (current === '"' && next === '"') {
-        index += 1;
-        continue;
-      }
-      if (current === '"') state = 'code';
-      continue;
-    }
-    if (state === 'backtick') {
-      if (current === '`' && next === '`') {
-        index += 1;
-        continue;
-      }
-      if (current === '`') state = 'code';
-      continue;
-    }
-    if (state === 'bracket-identifier') {
-      if (current === ']' && next === ']') {
-        index += 1;
-        continue;
-      }
-      if (current === ']') state = 'code';
-      continue;
-    }
-
-    if (current === '-' && next === '-') {
-      state = 'line-comment';
-      index += 1;
-    } else if (current === '/' && next === '*') {
-      state = 'block-comment';
-      index += 1;
-    } else if (current === "'") {
-      state = 'single-quote';
-    } else if (current === '"') {
-      state = 'double-quote';
-    } else if (current === '`') {
-      state = 'backtick';
-    } else if (current === '[') {
-      state = 'bracket-identifier';
-    }
-  }
-
-  return state;
-};
-
-const stripQuotedValue = (value: string) => {
-  const normalized = value.trim();
-  if (
-    (normalized.startsWith('`') && normalized.endsWith('`')) ||
-    (normalized.startsWith('"') && normalized.endsWith('"')) ||
-    (normalized.startsWith('[') && normalized.endsWith(']'))
-  ) {
-    return normalized.slice(1, -1);
-  }
-  return normalized;
-};
-
-const splitQualifiedIdentifier = (value: string) => {
-  const parts: string[] = [];
-  let current = '';
-  let quote: '`' | '"' | '[' | undefined;
-
-  for (let index = 0; index < value.length; index += 1) {
-    const char = value[index];
-    if (!quote && (char === '`' || char === '"' || char === '[')) {
-      quote = char as '`' | '"' | '[';
-      current += char;
-      continue;
-    }
-    if (quote === '`' && char === '`') quote = undefined;
-    else if (quote === '"' && char === '"') quote = undefined;
-    else if (quote === '[' && char === ']') quote = undefined;
-
-    if (!quote && char === '.') {
-      if (current.trim()) parts.push(stripQuotedValue(current));
-      current = '';
-      continue;
-    }
-    current += char;
-  }
-
-  if (current.trim()) parts.push(stripQuotedValue(current));
-  return parts;
-};
-
-const tableReferenceFromParts = (
-  parts: string[],
-  alias: string | undefined,
-  context: SqlMetadataContext,
-): SqlTableReference | undefined => {
-  if (!parts.length) return undefined;
-  const table = parts[parts.length - 1];
-  if (!table) return undefined;
-
-  if (parts.length >= 3) {
-    return {
-      database: parts[parts.length - 3],
-      schema: parts[parts.length - 2],
-      table,
-      alias,
-    };
-  }
-
-  if (parts.length === 2) {
-    const first = parts[0];
-    const mysqlLike = ['MYSQL', 'MARIADB', 'DORIS'].includes(
-      (context.dbType || '').toUpperCase(),
-    );
-    return mysqlLike
-      ? { database: first, table, alias }
-      : { database: context.database, schema: first, table, alias };
-  }
-
-  return {
-    database: context.database,
-    schema: context.schema,
-    table,
-    alias,
-  };
-};
-
-const parseTableReferences = (
-  sql: string,
-  context: SqlMetadataContext,
-): SqlTableReference[] => {
-  const references: SqlTableReference[] = [];
-  tableReferencePattern.lastIndex = 0;
-  let match = tableReferencePattern.exec(sql);
-  while (match) {
-    const rawAlias = match[2];
-    const alias =
-      rawAlias && !STOP_ALIAS_WORDS.has(rawAlias.toUpperCase())
-        ? rawAlias
-        : undefined;
-    const reference = tableReferenceFromParts(
-      splitQualifiedIdentifier(match[1]),
-      alias,
-      context,
-    );
-    if (reference) references.push(reference);
-    match = tableReferencePattern.exec(sql);
-  }
-  return references;
-};
 
 const getCompletionRange = (
   model: monaco.editor.ITextModel,
@@ -269,7 +41,9 @@ const getQualifier = (
   model: monaco.editor.ITextModel,
   position: monaco.Position,
 ) => {
-  const line = model.getLineContent(position.lineNumber).slice(0, position.column - 1);
+  const line = model
+    .getLineContent(position.lineNumber)
+    .slice(0, position.column - 1);
   const match = line.match(/([A-Za-z_$][\w$]*)\s*\.\s*[A-Za-z_$\d]*$/);
   return match?.[1];
 };
@@ -283,10 +57,11 @@ const columnSuggestion = (
   column: SqlCatalogColumn,
   range: monaco.Range,
   owner: string,
+  profile: SqlEditorProfile,
 ): monaco.languages.CompletionItem => ({
   label: column.name,
   kind: monaco.languages.CompletionItemKind.Field,
-  insertText: column.name,
+  insertText: formatSqlIdentifierForCompletion(column.name, profile),
   detail: [column.typeName, column.primaryKey ? 'PK' : undefined, owner]
     .filter(Boolean)
     .join(' · '),
@@ -298,13 +73,14 @@ const columnSuggestion = (
 const tableSuggestion = (
   table: SqlCatalogTable,
   range: monaco.Range,
+  profile: SqlEditorProfile,
 ): monaco.languages.CompletionItem => ({
   label: table.name,
   kind:
     table.type?.toUpperCase() === 'VIEW'
       ? monaco.languages.CompletionItemKind.Interface
       : monaco.languages.CompletionItemKind.Struct,
-  insertText: table.name,
+  insertText: formatSqlIdentifierForCompletion(table.name, profile),
   detail: [table.type || 'TABLE', table.database, table.schema]
     .filter(Boolean)
     .join(' · '),
@@ -312,18 +88,6 @@ const tableSuggestion = (
   sortText: `1-${table.name}`,
   range,
 });
-
-const findReference = (
-  qualifier: string,
-  references: SqlTableReference[],
-) => {
-  const normalized = qualifier.toLowerCase();
-  return references.find(
-    (reference) =>
-      reference.alias?.toLowerCase() === normalized ||
-      reference.table.toLowerCase() === normalized,
-  );
-};
 
 const provideMetadataSuggestions = async (
   model: monaco.editor.ITextModel,
@@ -334,21 +98,22 @@ const provideMetadataSuggestions = async (
   const context = nodeId ? getSqlMetadataContext(nodeId) : undefined;
   if (!context?.dataSourceId) return { suggestions: [] };
 
-  const textBeforePosition = getTextBeforePosition(model, position);
-  if (getLexicalState(textBeforePosition) !== 'code') {
+  const textBeforePosition = getSqlTextBeforePosition(model, position);
+  if (getSqlLexicalState(textBeforePosition) !== 'code') {
     return { suggestions: [] };
   }
 
+  const profile = resolveSqlEditorProfile(context.dialect);
   const range = getCompletionRange(model, position);
   const qualifier = getQualifier(model, position);
-  const references = parseTableReferences(
-    getCurrentStatementText(model, position),
+  const references = parseSqlTableReferences(
+    getCurrentSqlStatementText(model, position),
     context,
   );
 
   try {
     if (qualifier) {
-      const reference = findReference(qualifier, references);
+      const reference = findSqlTableReference(qualifier, references);
       if (reference) {
         const columns = await loadSqlColumns(context, reference.table, {
           database: reference.database,
@@ -357,7 +122,12 @@ const provideMetadataSuggestions = async (
         if (token.isCancellationRequested) return { suggestions: [] };
         return {
           suggestions: columns.map((column) =>
-            columnSuggestion(column, range, reference.alias || reference.table),
+            columnSuggestion(
+              column,
+              range,
+              reference.alias || reference.table,
+              profile,
+            ),
           ),
         };
       }
@@ -368,7 +138,11 @@ const provideMetadataSuggestions = async (
       ) {
         const tables = await loadSqlTables(context);
         if (token.isCancellationRequested) return { suggestions: [] };
-        return { suggestions: tables.map((table) => tableSuggestion(table, range)) };
+        return {
+          suggestions: tables.map((table) =>
+            tableSuggestion(table, range, profile),
+          ),
+        };
       }
 
       return { suggestions: [] };
@@ -377,7 +151,9 @@ const provideMetadataSuggestions = async (
     if (isTablePosition(textBeforePosition)) {
       const tables = await loadSqlTables(context);
       if (token.isCancellationRequested) return { suggestions: [] };
-      return { suggestions: tables.map((table) => tableSuggestion(table, range)) };
+      return {
+        suggestions: tables.map((table) => tableSuggestion(table, range, profile)),
+      };
     }
 
     if (references.length === 1) {
@@ -389,7 +165,7 @@ const provideMetadataSuggestions = async (
       if (token.isCancellationRequested) return { suggestions: [] };
       return {
         suggestions: columns.map((column) =>
-          columnSuggestion(column, range, reference.table),
+          columnSuggestion(column, range, reference.table, profile),
         ),
       };
     }

--- a/yak-ops-ui/src/pages/development/data-development/editors/sql/completion/registerSqlSnippetCompletion.ts
+++ b/yak-ops-ui/src/pages/development/data-development/editors/sql/completion/registerSqlSnippetCompletion.ts
@@ -1,13 +1,21 @@
 import * as monaco from 'monaco-editor/esm/vs/editor/editor.api';
 
 import {
+  getSqlEditorNodeId,
   getSqlLexicalState,
   getSqlTextBeforePosition,
 } from '../assistance/sqlTextContext';
-import { SQL_SNIPPETS } from './sqlSnippetCatalog';
+import { getSqlMetadataContext } from '../metadata/sqlMetadataContextStore';
+import { resolveSqlEditorProfile } from '../profiles/sqlEditorProfiles';
 
 let providerDisposable: monaco.IDisposable | undefined;
 let providerConsumers = 0;
+
+const getProfileForModel = (model: monaco.editor.ITextModel) => {
+  const nodeId = getSqlEditorNodeId(model);
+  const context = nodeId ? getSqlMetadataContext(nodeId) : undefined;
+  return resolveSqlEditorProfile(context?.dialect);
+};
 
 const createProvider = () =>
   monaco.languages.registerCompletionItemProvider('sql', {
@@ -44,9 +52,10 @@ const createProvider = () =>
         position.lineNumber,
         word.endColumn,
       );
+      const profile = getProfileForModel(model);
 
       return {
-        suggestions: SQL_SNIPPETS.map((snippet, index) => ({
+        suggestions: profile.snippets.map((snippet, index) => ({
           label: snippet.label,
           kind: monaco.languages.CompletionItemKind.Snippet,
           insertText: snippet.body,

--- a/yak-ops-ui/src/pages/development/data-development/editors/sql/components/SqlMonacoEditor.tsx
+++ b/yak-ops-ui/src/pages/development/data-development/editors/sql/components/SqlMonacoEditor.tsx
@@ -22,6 +22,7 @@ import {
   subscribeYakEditorSettings,
 } from '../editorSettings';
 import { formatSqlText } from '../formatting/formatSqlText';
+import { getSqlMetadataContext } from '../metadata/sqlMetadataContextStore';
 import { setupMonacoEnvironment } from '../monaco/setupMonacoEnvironment';
 import {
   getSqlStatementRanges,
@@ -282,7 +283,10 @@ const SqlMonacoEditor = ({
         return;
       }
       if (command === 'format' && !readOnly) {
-        const formatted = formatSqlText(model.getValue());
+        const formatted = formatSqlText(
+          model.getValue(),
+          getSqlMetadataContext(id)?.dialect,
+        );
         if (formatted === model.getValue()) return;
         editor.pushUndoStop();
         editor.executeEdits('yak-sql-format', [{ range: model.getFullModelRange(), text: formatted, forceMoveMarkers: true }]);

--- a/yak-ops-ui/src/pages/development/data-development/editors/sql/formatting/formatSqlText.test.ts
+++ b/yak-ops-ui/src/pages/development/data-development/editors/sql/formatting/formatSqlText.test.ts
@@ -1,0 +1,42 @@
+import { formatSqlText } from './formatSqlText';
+
+describe('formatSqlText', () => {
+  it('keeps generic formatting behavior for common clauses', () => {
+    expect(
+      formatSqlText('SELECT * FROM users WHERE active = 1 ORDER BY id'),
+    ).toBe('SELECT *\nFROM users\nWHERE active = 1\nORDER BY id');
+  });
+
+  it('breaks PostgreSQL conflict and returning clauses using the profile', () => {
+    expect(
+      formatSqlText(
+        'INSERT INTO users (id) VALUES (1) ON CONFLICT (id) DO UPDATE SET id = 1 RETURNING id',
+        'POSTGRE_SQL',
+      ),
+    ).toBe(
+      'INSERT INTO users (id)\nVALUES (1)\nON CONFLICT (id)\nDO UPDATE\nSET id = 1\nRETURNING id',
+    );
+  });
+
+  it('breaks MySQL duplicate-key updates using the profile', () => {
+    expect(
+      formatSqlText(
+        'INSERT INTO users (id) VALUES (1) ON DUPLICATE KEY UPDATE id = 2',
+        'MYSQL',
+      ),
+    ).toBe(
+      'INSERT INTO users (id)\nVALUES (1)\nON DUPLICATE KEY UPDATE id = 2',
+    );
+  });
+
+  it('formats Doris distribution clauses without teaching the formatter Doris branches', () => {
+    expect(
+      formatSqlText(
+        'CREATE TABLE t (id BIGINT) DUPLICATE KEY (id) DISTRIBUTED BY HASH(id) PROPERTIES ("replication_num" = "1")',
+        'DORIS',
+      ),
+    ).toBe(
+      'CREATE TABLE t (id BIGINT) DUPLICATE KEY (id)\nDISTRIBUTED BY HASH(id)\nPROPERTIES ("replication_num" = "1")',
+    );
+  });
+});

--- a/yak-ops-ui/src/pages/development/data-development/editors/sql/formatting/formatSqlText.ts
+++ b/yak-ops-ui/src/pages/development/data-development/editors/sql/formatting/formatSqlText.ts
@@ -1,3 +1,7 @@
+import type { DevelopmentSqlDialect } from '@/services/data-development';
+
+import { resolveSqlEditorProfile } from '../profiles/sqlEditorProfiles';
+
 const protectSqlSegments = (sql: string) => {
   const segments: string[] = [];
   let output = '';
@@ -60,7 +64,10 @@ const protectSqlSegments = (sql: string) => {
 
     if (current === '/' && next === '*') {
       let end = index + 2;
-      while (end < sql.length && !(sql[end] === '*' && sql[end + 1] === '/')) {
+      while (
+        end < sql.length &&
+        !(sql[end] === '*' && sql[end + 1] === '/')
+      ) {
         end += 1;
       }
       end = Math.min(sql.length, end + 2);
@@ -83,18 +90,18 @@ const restoreSqlSegments = (sql: string, segments: string[]) =>
     sql,
   );
 
-const CLAUSE_PATTERN = [
-  'LEFT\\s+OUTER\\s+JOIN',
-  'RIGHT\\s+OUTER\\s+JOIN',
-  'FULL\\s+OUTER\\s+JOIN',
-  'LEFT\\s+JOIN',
-  'RIGHT\\s+JOIN',
-  'FULL\\s+JOIN',
-  'INNER\\s+JOIN',
-  'CROSS\\s+JOIN',
-  'GROUP\\s+BY',
-  'ORDER\\s+BY',
-  'UNION\\s+ALL',
+const BASE_CLAUSES = [
+  'LEFT OUTER JOIN',
+  'RIGHT OUTER JOIN',
+  'FULL OUTER JOIN',
+  'LEFT JOIN',
+  'RIGHT JOIN',
+  'FULL JOIN',
+  'INNER JOIN',
+  'CROSS JOIN',
+  'GROUP BY',
+  'ORDER BY',
+  'UNION ALL',
   'UNION',
   'FROM',
   'WHERE',
@@ -104,18 +111,40 @@ const CLAUSE_PATTERN = [
   'VALUES',
   'LIMIT',
   'OFFSET',
-].join('|');
+] as const;
 
-export const formatSqlText = (sql: string) => {
+const escapeRegExp = (value: string) =>
+  value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+
+const clausePattern = (value: string) =>
+  value
+    .trim()
+    .split(/\s+/)
+    .map(escapeRegExp)
+    .join('\\s+');
+
+const buildClausePattern = (dialect?: DevelopmentSqlDialect | string) => {
+  const profile = resolveSqlEditorProfile(dialect);
+  const clauses = [...BASE_CLAUSES, ...profile.formatterClauses].sort(
+    (left, right) => right.length - left.length,
+  );
+  return clauses.map(clausePattern).join('|');
+};
+
+export const formatSqlText = (
+  sql: string,
+  dialect?: DevelopmentSqlDialect | string,
+) => {
   if (!sql.trim()) return sql;
 
   const normalized = sql.replace(/\r\n?/g, '\n');
   const { output, segments } = protectSqlSegments(normalized);
+  const pattern = buildClausePattern(dialect);
 
   let formatted = output
     .replace(/[ \t]+/g, ' ')
     .replace(/ *\n */g, '\n')
-    .replace(new RegExp(`\\s+(${CLAUSE_PATTERN})\\s+`, 'gi'), '\n$1 ')
+    .replace(new RegExp(`\\s+(${pattern})\\s+`, 'gi'), '\n$1 ')
     .replace(/\s+(AND|OR)\s+/gi, '\n  $1 ')
     .replace(/\n{3,}/g, '\n\n')
     .trim();

--- a/yak-ops-ui/src/pages/development/data-development/editors/sql/profiles/sqlEditorProfiles.test.ts
+++ b/yak-ops-ui/src/pages/development/data-development/editors/sql/profiles/sqlEditorProfiles.test.ts
@@ -1,0 +1,73 @@
+import {
+  formatSqlIdentifierForCompletion,
+  getSqlDialectFamily,
+  resolveSqlEditorProfile,
+} from './sqlEditorProfiles';
+
+describe('sqlEditorProfiles', () => {
+  it('groups compatible dialects into shared editor families', () => {
+    expect(getSqlDialectFamily('MYSQL')).toBe('MYSQL');
+    expect(getSqlDialectFamily('TIDB')).toBe('MYSQL');
+    expect(getSqlDialectFamily('DORIS')).toBe('MYSQL');
+    expect(getSqlDialectFamily('STARROCKS')).toBe('MYSQL');
+    expect(getSqlDialectFamily('POSTGRE_SQL')).toBe('POSTGRESQL');
+    expect(getSqlDialectFamily('OPEN_GAUSS')).toBe('POSTGRESQL');
+    expect(getSqlDialectFamily('KINGBASE')).toBe('POSTGRESQL');
+    expect(getSqlDialectFamily('DAMENG')).toBe('ORACLE');
+  });
+
+  it('layers dialect-specific vocabulary over the family profile', () => {
+    const tidb = resolveSqlEditorProfile('TIDB');
+    const doris = resolveSqlEditorProfile('DORIS');
+    const starrocks = resolveSqlEditorProfile('STARROCKS');
+
+    expect(tidb.keywords).toContain('AUTO_RANDOM');
+    expect(doris.keywords).toContain('DUPLICATE KEY');
+    expect(doris.keywords).toContain('DISTRIBUTED BY');
+    expect(starrocks.keywords).toContain('PRIMARY KEY');
+    expect(starrocks.formatterClauses).toContain('PROPERTIES');
+  });
+
+  it('adds database-specific functions and snippets without losing generic SQL help', () => {
+    const postgres = resolveSqlEditorProfile('POSTGRE_SQL');
+    const mysql = resolveSqlEditorProfile('MYSQL');
+    const oracle = resolveSqlEditorProfile('ORACLE');
+
+    expect(postgres.functions.map((item) => item.name)).toEqual(
+      expect.arrayContaining(['COUNT', 'DATE_TRUNC', 'STRING_AGG']),
+    );
+    expect(mysql.snippets.map((item) => item.prefix)).toContain('insdup');
+    expect(oracle.snippets.map((item) => item.prefix)).toContain('merge');
+  });
+
+  it('keeps two-part namespace interpretation family-specific', () => {
+    expect(resolveSqlEditorProfile('MYSQL').twoPartNamespace).toBe('database');
+    expect(resolveSqlEditorProfile('STARROCKS').twoPartNamespace).toBe('database');
+    expect(resolveSqlEditorProfile('POSTGRE_SQL').twoPartNamespace).toBe('schema');
+    expect(resolveSqlEditorProfile('SQL_SERVER').twoPartNamespace).toBe('schema');
+  });
+
+  it('quotes only identifiers that need dialect-specific escaping', () => {
+    expect(
+      formatSqlIdentifierForCompletion(
+        'customer_id',
+        resolveSqlEditorProfile('MYSQL'),
+      ),
+    ).toBe('customer_id');
+    expect(
+      formatSqlIdentifierForCompletion('order', resolveSqlEditorProfile('MYSQL')),
+    ).toBe('`order`');
+    expect(
+      formatSqlIdentifierForCompletion(
+        'order detail',
+        resolveSqlEditorProfile('POSTGRE_SQL'),
+      ),
+    ).toBe('"order detail"');
+    expect(
+      formatSqlIdentifierForCompletion(
+        'order',
+        resolveSqlEditorProfile('SQL_SERVER'),
+      ),
+    ).toBe('[order]');
+  });
+});

--- a/yak-ops-ui/src/pages/development/data-development/editors/sql/profiles/sqlEditorProfiles.ts
+++ b/yak-ops-ui/src/pages/development/data-development/editors/sql/profiles/sqlEditorProfiles.ts
@@ -1,0 +1,534 @@
+import {
+  normalizeDevelopmentSqlDialect,
+  type DevelopmentSqlDialect,
+} from '@/services/data-development';
+
+import {
+  SQL_BUILTIN_FUNCTIONS,
+  SQL_KEYWORDS,
+  type SqlBuiltinFunctionDefinition,
+} from '../completion/sqlBuiltinCatalog';
+import {
+  SQL_SNIPPETS,
+  type SqlSnippetDefinition,
+} from '../completion/sqlSnippetCatalog';
+
+export type SqlDialectFamily =
+  | 'GENERIC'
+  | 'MYSQL'
+  | 'POSTGRESQL'
+  | 'ORACLE'
+  | 'SQL_SERVER'
+  | 'DB2'
+  | 'HANA'
+  | 'DUCKDB'
+  | 'CLICKHOUSE';
+
+export type SqlIdentifierQuote = 'DOUBLE_QUOTE' | 'BACKTICK' | 'BRACKET';
+export type SqlTwoPartNamespace = 'database' | 'schema';
+
+export interface SqlEditorProfile {
+  dialect: DevelopmentSqlDialect;
+  family: SqlDialectFamily;
+  identifierQuote: SqlIdentifierQuote;
+  twoPartNamespace: SqlTwoPartNamespace;
+  keywords: readonly string[];
+  functions: readonly SqlBuiltinFunctionDefinition[];
+  snippets: readonly SqlSnippetDefinition[];
+  formatterClauses: readonly string[];
+}
+
+interface SqlEditorProfileOverlay {
+  identifierQuote?: SqlIdentifierQuote;
+  twoPartNamespace?: SqlTwoPartNamespace;
+  keywords?: readonly string[];
+  functions?: readonly SqlBuiltinFunctionDefinition[];
+  snippets?: readonly SqlSnippetDefinition[];
+  formatterClauses?: readonly string[];
+}
+
+const sqlFunction = (
+  name: string,
+  signature: string,
+  argumentsSnippet: string,
+  description: string,
+): SqlBuiltinFunctionDefinition => ({
+  name,
+  signature,
+  argumentsSnippet,
+  description,
+});
+
+const sqlSnippet = (
+  prefix: string,
+  label: string,
+  detail: string,
+  body: string,
+): SqlSnippetDefinition => ({ prefix, label, detail, body });
+
+const DIALECT_FAMILIES: Record<DevelopmentSqlDialect, SqlDialectFamily> = {
+  GENERIC: 'GENERIC',
+  MYSQL: 'MYSQL',
+  TIDB: 'MYSQL',
+  GOLDENDB: 'MYSQL',
+  GBASE8C: 'POSTGRESQL',
+  GBASE8A: 'MYSQL',
+  GBASE8S: 'GENERIC',
+  HANA: 'HANA',
+  ORACLE: 'ORACLE',
+  POSTGRE_SQL: 'POSTGRESQL',
+  DB2: 'DB2',
+  OPEN_GAUSS: 'POSTGRESQL',
+  SQL_SERVER: 'SQL_SERVER',
+  OCEANBASE: 'GENERIC',
+  YASHAN_DB: 'GENERIC',
+  HIGHGO: 'POSTGRESQL',
+  IRIS: 'GENERIC',
+  XUGU: 'GENERIC',
+  DUCKDB: 'DUCKDB',
+  DORIS: 'MYSQL',
+  STARROCKS: 'MYSQL',
+  CLICKHOUSE: 'CLICKHOUSE',
+  KINGBASE: 'POSTGRESQL',
+  DAMENG: 'ORACLE',
+};
+
+const FAMILY_OVERLAYS: Record<SqlDialectFamily, SqlEditorProfileOverlay> = {
+  GENERIC: {},
+  MYSQL: {
+    identifierQuote: 'BACKTICK',
+    twoPartNamespace: 'database',
+    keywords: [
+      'AUTO_INCREMENT',
+      'DESCRIBE',
+      'SHOW',
+      'USE',
+      'REPLACE',
+      'ON DUPLICATE KEY UPDATE',
+    ],
+    functions: [
+      sqlFunction(
+        'IFNULL',
+        'IFNULL(value, fallback)',
+        '${1:value}, ${2:fallback}',
+        '返回第一个非 NULL 值，常用于 MySQL 兼容方言。',
+      ),
+      sqlFunction(
+        'DATE_FORMAT',
+        'DATE_FORMAT(date, format)',
+        '${1:date}, ${2:format}',
+        '按指定格式输出日期或时间。',
+      ),
+      sqlFunction(
+        'GROUP_CONCAT',
+        'GROUP_CONCAT(expression)',
+        '${1:expression}',
+        '将分组内的值连接为一个字符串。',
+      ),
+      sqlFunction(
+        'JSON_EXTRACT',
+        'JSON_EXTRACT(json_doc, path)',
+        '${1:json_doc}, ${2:path}',
+        '从 JSON 文档中提取指定路径的值。',
+      ),
+    ],
+    snippets: [
+      sqlSnippet(
+        'insdup',
+        'INSERT … ON DUPLICATE KEY UPDATE',
+        'MySQL 兼容 Upsert 模板',
+        'INSERT INTO ${1:table_name} (${2:column_name})\nVALUES (${3:value})\nON DUPLICATE KEY UPDATE ${2:column_name} = VALUES(${2:column_name});\n${0}',
+      ),
+    ],
+    formatterClauses: ['ON DUPLICATE KEY UPDATE'],
+  },
+  POSTGRESQL: {
+    identifierQuote: 'DOUBLE_QUOTE',
+    twoPartNamespace: 'schema',
+    keywords: [
+      'RETURNING',
+      'ILIKE',
+      'LATERAL',
+      'JSONB',
+      'ON CONFLICT',
+      'DO NOTHING',
+      'FILTER',
+    ],
+    functions: [
+      sqlFunction(
+        'DATE_TRUNC',
+        'DATE_TRUNC(field, source)',
+        '${1:field}, ${2:source}',
+        '按指定时间粒度截断日期或时间。',
+      ),
+      sqlFunction(
+        'STRING_AGG',
+        'STRING_AGG(expression, delimiter)',
+        '${1:expression}, ${2:delimiter}',
+        '将分组内的字符串按分隔符聚合。',
+      ),
+      sqlFunction(
+        'JSONB_BUILD_OBJECT',
+        'JSONB_BUILD_OBJECT(key, value, ...)',
+        '${1:key}, ${2:value}',
+        '构造 JSONB 对象。',
+      ),
+      sqlFunction(
+        'TO_CHAR',
+        'TO_CHAR(value, format)',
+        '${1:value}, ${2:format}',
+        '按指定格式将值转换为字符串。',
+      ),
+    ],
+    snippets: [
+      sqlSnippet(
+        'insconflict',
+        'INSERT … ON CONFLICT',
+        'PostgreSQL 兼容 Upsert 模板',
+        'INSERT INTO ${1:table_name} (${2:id}, ${3:column_name})\nVALUES (${4:id_value}, ${5:value})\nON CONFLICT (${2:id}) DO UPDATE\nSET ${3:column_name} = EXCLUDED.${3:column_name}\nRETURNING *;\n${0}',
+      ),
+    ],
+    formatterClauses: ['ON CONFLICT', 'DO UPDATE', 'RETURNING'],
+  },
+  ORACLE: {
+    identifierQuote: 'DOUBLE_QUOTE',
+    twoPartNamespace: 'schema',
+    keywords: ['MERGE', 'ROWNUM', 'DUAL', 'CONNECT BY', 'START WITH', 'RETURNING'],
+    functions: [
+      sqlFunction(
+        'NVL',
+        'NVL(value, fallback)',
+        '${1:value}, ${2:fallback}',
+        '值为 NULL 时返回备用值。',
+      ),
+      sqlFunction(
+        'DECODE',
+        'DECODE(expression, search, result, default)',
+        '${1:expression}, ${2:search}, ${3:result}, ${4:default}',
+        '按匹配值返回对应结果。',
+      ),
+      sqlFunction(
+        'TO_DATE',
+        'TO_DATE(value, format)',
+        '${1:value}, ${2:format}',
+        '按指定格式将字符串转换为日期。',
+      ),
+      sqlFunction(
+        'TO_CHAR',
+        'TO_CHAR(value, format)',
+        '${1:value}, ${2:format}',
+        '按指定格式将日期或数值转换为字符串。',
+      ),
+    ],
+    snippets: [
+      sqlSnippet(
+        'merge',
+        'MERGE INTO',
+        'Oracle 兼容 MERGE 模板',
+        'MERGE INTO ${1:target_table} t\nUSING ${2:source_table} s\nON (${3:t.id = s.id})\nWHEN MATCHED THEN\n  UPDATE SET ${4:t.column_name = s.column_name}\nWHEN NOT MATCHED THEN\n  INSERT (${5:column_name}) VALUES (${6:s.column_name});\n${0}',
+      ),
+    ],
+    formatterClauses: ['USING', 'WHEN MATCHED THEN', 'WHEN NOT MATCHED THEN', 'CONNECT BY', 'START WITH', 'RETURNING'],
+  },
+  SQL_SERVER: {
+    identifierQuote: 'BRACKET',
+    twoPartNamespace: 'schema',
+    keywords: ['TOP', 'GO', 'OUTPUT', 'IDENTITY', 'MERGE'],
+    functions: [
+      sqlFunction(
+        'ISNULL',
+        'ISNULL(value, fallback)',
+        '${1:value}, ${2:fallback}',
+        '值为 NULL 时返回备用值。',
+      ),
+      sqlFunction(
+        'GETDATE',
+        'GETDATE()',
+        '',
+        '返回当前数据库服务器日期和时间。',
+      ),
+      sqlFunction(
+        'DATEADD',
+        'DATEADD(datepart, number, date)',
+        '${1:datepart}, ${2:number}, ${3:date}',
+        '为日期增加指定的时间间隔。',
+      ),
+      sqlFunction(
+        'DATEDIFF',
+        'DATEDIFF(datepart, startdate, enddate)',
+        '${1:datepart}, ${2:startdate}, ${3:enddate}',
+        '返回两个日期之间指定粒度的差值。',
+      ),
+    ],
+    snippets: [
+      sqlSnippet(
+        'seltop',
+        'SELECT TOP',
+        'SQL Server TOP 查询模板',
+        'SELECT TOP (${1:100}) ${2:*}\nFROM ${3:table_name}\nWHERE ${4:1 = 1};\n${0}',
+      ),
+    ],
+    formatterClauses: ['OUTPUT'],
+  },
+  DB2: {
+    identifierQuote: 'DOUBLE_QUOTE',
+    twoPartNamespace: 'schema',
+    keywords: ['FETCH FIRST', 'WITH UR', 'GENERATED ALWAYS'],
+    functions: [
+      sqlFunction(
+        'VARCHAR_FORMAT',
+        'VARCHAR_FORMAT(value, format)',
+        '${1:value}, ${2:format}',
+        '按指定格式将日期或数值转换为字符串。',
+      ),
+      sqlFunction(
+        'TIMESTAMP_FORMAT',
+        'TIMESTAMP_FORMAT(value, format)',
+        '${1:value}, ${2:format}',
+        '按指定格式将字符串转换为时间戳。',
+      ),
+    ],
+    formatterClauses: ['FETCH FIRST', 'WITH UR'],
+  },
+  HANA: {
+    identifierQuote: 'DOUBLE_QUOTE',
+    twoPartNamespace: 'schema',
+    keywords: ['UPSERT', 'DUMMY', 'TOP'],
+    functions: [
+      sqlFunction(
+        'IFNULL',
+        'IFNULL(value, fallback)',
+        '${1:value}, ${2:fallback}',
+        '值为 NULL 时返回备用值。',
+      ),
+      sqlFunction(
+        'TO_VARCHAR',
+        'TO_VARCHAR(value, format)',
+        '${1:value}, ${2:format}',
+        '将值转换为字符串。',
+      ),
+      sqlFunction(
+        'ADD_DAYS',
+        'ADD_DAYS(date, days)',
+        '${1:date}, ${2:days}',
+        '为日期增加指定天数。',
+      ),
+    ],
+    formatterClauses: [],
+  },
+  DUCKDB: {
+    identifierQuote: 'DOUBLE_QUOTE',
+    twoPartNamespace: 'schema',
+    keywords: ['QUALIFY', 'PIVOT', 'UNPIVOT', 'SAMPLE'],
+    functions: [
+      sqlFunction(
+        'DATE_TRUNC',
+        'DATE_TRUNC(part, date)',
+        '${1:part}, ${2:date}',
+        '按指定时间粒度截断日期或时间。',
+      ),
+      sqlFunction(
+        'STRUCT_PACK',
+        'STRUCT_PACK(name := value, ...)',
+        '${1:name} := ${2:value}',
+        '构造 STRUCT 值。',
+      ),
+    ],
+    snippets: [
+      sqlSnippet(
+        'qualify',
+        'QUALIFY window result',
+        'DuckDB QUALIFY 查询模板',
+        'SELECT ${1:*}\nFROM ${2:table_name}\nQUALIFY ${3:ROW_NUMBER() OVER (PARTITION BY id ORDER BY updated_at DESC) = 1};\n${0}',
+      ),
+    ],
+    formatterClauses: ['QUALIFY'],
+  },
+  CLICKHOUSE: {
+    identifierQuote: 'BACKTICK',
+    twoPartNamespace: 'database',
+    keywords: ['PREWHERE', 'ARRAY JOIN', 'FINAL', 'SETTINGS', 'SAMPLE'],
+    functions: [
+      sqlFunction(
+        'toDate',
+        'toDate(value)',
+        '${1:value}',
+        '将值转换为 Date。',
+      ),
+      sqlFunction(
+        'uniq',
+        'uniq(expression)',
+        '${1:expression}',
+        '近似计算唯一值数量。',
+      ),
+      sqlFunction(
+        'groupArray',
+        'groupArray(expression)',
+        '${1:expression}',
+        '将分组内的值聚合为数组。',
+      ),
+    ],
+    snippets: [
+      sqlSnippet(
+        'selpre',
+        'SELECT … PREWHERE',
+        'ClickHouse PREWHERE 查询模板',
+        'SELECT ${1:*}\nFROM ${2:table_name}\nPREWHERE ${3:condition}\nWHERE ${4:1 = 1};\n${0}',
+      ),
+    ],
+    formatterClauses: ['ARRAY JOIN', 'PREWHERE', 'SETTINGS'],
+  },
+};
+
+const DIALECT_OVERLAYS: Partial<
+  Record<DevelopmentSqlDialect, SqlEditorProfileOverlay>
+> = {
+  TIDB: {
+    keywords: ['AUTO_RANDOM'],
+  },
+  DORIS: {
+    keywords: [
+      'DUPLICATE KEY',
+      'UNIQUE KEY',
+      'AGGREGATE KEY',
+      'DISTRIBUTED BY',
+      'PROPERTIES',
+    ],
+    formatterClauses: ['DISTRIBUTED BY', 'PROPERTIES'],
+  },
+  STARROCKS: {
+    keywords: [
+      'DUPLICATE KEY',
+      'UNIQUE KEY',
+      'PRIMARY KEY',
+      'AGGREGATE KEY',
+      'DISTRIBUTED BY',
+      'PROPERTIES',
+    ],
+    formatterClauses: ['DISTRIBUTED BY', 'PROPERTIES'],
+  },
+};
+
+const mergeUniqueStrings = (
+  ...groups: ReadonlyArray<ReadonlyArray<string> | undefined>
+) => {
+  const values: string[] = [];
+  const seen = new Set<string>();
+  groups.forEach((group) => {
+    group?.forEach((value) => {
+      const key = value.toUpperCase();
+      if (seen.has(key)) return;
+      seen.add(key);
+      values.push(value);
+    });
+  });
+  return values;
+};
+
+const mergeFunctions = (
+  ...groups: ReadonlyArray<
+    ReadonlyArray<SqlBuiltinFunctionDefinition> | undefined
+  >
+) => {
+  const values = new Map<string, SqlBuiltinFunctionDefinition>();
+  groups.forEach((group) => {
+    group?.forEach((definition) => {
+      values.set(definition.name.toUpperCase(), definition);
+    });
+  });
+  return [...values.values()];
+};
+
+const mergeSnippets = (
+  ...groups: ReadonlyArray<ReadonlyArray<SqlSnippetDefinition> | undefined>
+) => {
+  const values = new Map<string, SqlSnippetDefinition>();
+  groups.forEach((group) => {
+    group?.forEach((definition) => {
+      values.set(definition.prefix.toLowerCase(), definition);
+    });
+  });
+  return [...values.values()];
+};
+
+const profileCache = new Map<DevelopmentSqlDialect, SqlEditorProfile>();
+
+export const getSqlDialectFamily = (
+  dialect?: DevelopmentSqlDialect | string,
+): SqlDialectFamily =>
+  DIALECT_FAMILIES[normalizeDevelopmentSqlDialect(dialect)];
+
+export const resolveSqlEditorProfile = (
+  dialect?: DevelopmentSqlDialect | string,
+): SqlEditorProfile => {
+  const normalized = normalizeDevelopmentSqlDialect(dialect);
+  const cached = profileCache.get(normalized);
+  if (cached) return cached;
+
+  const family = DIALECT_FAMILIES[normalized];
+  const familyOverlay = FAMILY_OVERLAYS[family];
+  const dialectOverlay = DIALECT_OVERLAYS[normalized];
+  const profile: SqlEditorProfile = {
+    dialect: normalized,
+    family,
+    identifierQuote:
+      dialectOverlay?.identifierQuote ??
+      familyOverlay.identifierQuote ??
+      'DOUBLE_QUOTE',
+    twoPartNamespace:
+      dialectOverlay?.twoPartNamespace ??
+      familyOverlay.twoPartNamespace ??
+      'schema',
+    keywords: mergeUniqueStrings(
+      SQL_KEYWORDS,
+      familyOverlay.keywords,
+      dialectOverlay?.keywords,
+    ),
+    functions: mergeFunctions(
+      SQL_BUILTIN_FUNCTIONS,
+      familyOverlay.functions,
+      dialectOverlay?.functions,
+    ),
+    snippets: mergeSnippets(
+      SQL_SNIPPETS,
+      familyOverlay.snippets,
+      dialectOverlay?.snippets,
+    ),
+    formatterClauses: mergeUniqueStrings(
+      familyOverlay.formatterClauses,
+      dialectOverlay?.formatterClauses,
+    ),
+  };
+
+  profileCache.set(normalized, profile);
+  return profile;
+};
+
+const SIMPLE_IDENTIFIER = /^[A-Za-z_][A-Za-z0-9_$]*$/;
+
+export const quoteSqlIdentifier = (
+  identifier: string,
+  profile: SqlEditorProfile,
+) => {
+  if (profile.identifierQuote === 'BACKTICK') {
+    return `\`${identifier.replace(/`/g, '``')}\``;
+  }
+  if (profile.identifierQuote === 'BRACKET') {
+    return `[${identifier.replace(/]/g, ']]')}]`;
+  }
+  return `"${identifier.replace(/"/g, '""')}"`;
+};
+
+export const formatSqlIdentifierForCompletion = (
+  identifier: string,
+  profile: SqlEditorProfile,
+) => {
+  const normalized = identifier.trim();
+  if (!normalized) return identifier;
+
+  const reserved = profile.keywords.some(
+    (keyword) => keyword.toUpperCase() === normalized.toUpperCase(),
+  );
+  if (SIMPLE_IDENTIFIER.test(normalized) && !reserved) return normalized;
+  return quoteSqlIdentifier(normalized, profile);
+};


### PR DESCRIPTION
## Summary

PR3 of the Data Development SQL dialect rollout, building directly on PR #1063 (canonical SQL dialect model) and PR #1064 (database-specific SQL node creation).

- add one dialect-aware SQL editor profile boundary instead of spreading database-name checks across Monaco/editor helpers
- model editor behavior as shared SQL families plus small dialect overrides
- drive builtin keywords, functions, snippets, hover and signature help from the active node dialect
- make Catalog table/column completion use dialect-aware identifier quoting only when an identifier actually needs quoting
- centralize two-part namespace interpretation (`database.table` vs `schema.table`) in the editor profile
- make the existing formatter consume dialect-specific clauses without introducing database branches into the formatter
- preserve Generic SQL behavior for historical nodes whose dialect is still `GENERIC`

## Editor profile model

```text
SQL task
  -> canonical dialect from PR1
  -> SqlEditorProfile
      -> family
      -> identifier quote
      -> two-part namespace semantics
      -> keywords
      -> functions
      -> snippets
      -> formatter clauses
```

Profiles intentionally use **family + override** rather than one duplicated editor configuration per database.

Examples:

```text
MYSQL family
  MySQL / TiDB / GoldenDB / GBase 8a / Doris / StarRocks

POSTGRESQL family
  PostgreSQL / openGauss / HighGo / GBase 8c / KingbaseES

ORACLE family
  Oracle / Dameng

Dedicated profiles
  SQL Server / DB2 / HANA / DuckDB / ClickHouse
```

Databases whose compatibility mode cannot be determined safely from the canonical dialect alone remain on the conservative Generic profile rather than being guessed.

## Dialect-aware assistance

### Keywords / functions

The existing generic SQL catalog stays as the common base. Profiles layer dialect vocabulary on top, for example:

- MySQL family: `AUTO_INCREMENT`, `ON DUPLICATE KEY UPDATE`, `IFNULL`, `DATE_FORMAT`, `GROUP_CONCAT`
- PostgreSQL family: `RETURNING`, `ILIKE`, `ON CONFLICT`, `DATE_TRUNC`, `STRING_AGG`
- Oracle family: `MERGE`, `ROWNUM`, `DUAL`, `NVL`, `DECODE`
- SQL Server: `TOP`, `OUTPUT`, `IDENTITY`, `ISNULL`, `GETDATE`
- ClickHouse: `PREWHERE`, `ARRAY JOIN`, `SETTINGS`, `uniq`, `groupArray`

The same resolved function set is reused by completion, hover and signature help so those features cannot drift independently.

### Snippets

Generic snippets remain available and profiles add focused dialect snippets such as:

- MySQL-compatible `INSERT ... ON DUPLICATE KEY UPDATE`
- PostgreSQL-compatible `INSERT ... ON CONFLICT`
- Oracle-compatible `MERGE INTO`
- SQL Server `SELECT TOP`
- DuckDB `QUALIFY`
- ClickHouse `PREWHERE`

### Metadata completion / quoting

Catalog suggestions now quote only identifiers that need it, using the current dialect profile:

```text
MySQL / ClickHouse -> `identifier`
PostgreSQL / Oracle / DB2 / ... -> "identifier"
SQL Server -> [identifier]
```

Simple non-reserved identifiers remain unquoted.

The same profile also replaces the previous hand-written MySQL-family checks for parsing two-part table references, so TiDB / Doris / StarRocks and future compatible dialects follow one rule.

## Formatting

`formatSqlText()` keeps the current lightweight formatter and now accepts the canonical dialect. The profile only contributes additional clause boundaries (for example `ON CONFLICT`, `RETURNING`, `ON DUPLICATE KEY UPDATE`, `DISTRIBUTED BY`, `PROPERTIES`, `PREWHERE`).

This PR does **not** introduce a vendor SQL parser or rewrite SQL semantics.

## Compatibility

- `taskType` remains `SQL`
- dialect stays in the existing SQL task config introduced by PR #1063
- historical `GENERIC` SQL nodes keep generic completion/formatting behavior
- datasource selection, execution, publishing and workflow semantics are unchanged
- Monaco still uses the existing `sql` language/tokenizer; dialect profiles enrich assistance rather than replacing it with vendor parsers

## Tests

Added focused frontend tests for:

- family resolution and dialect overrides
- MySQL/PostgreSQL/Oracle-style identifier quoting
- database-vs-schema two-part namespace behavior
- dialect keyword/function/snippet layering
- generic and dialect-aware formatter clauses for PostgreSQL, MySQL and Doris

## Scope

Frontend Data Development SQL editor only.

No backend API/schema/Flyway changes, no Task Plugin changes, no execution semantics, no datasource connection changes, and no workflow changes are included in PR3.

## Branch state

- based on the latest `main` after PR #1065
- ahead 1 / behind 0
- one focused commit: `feat(data-development): add dialect-aware SQL editor profiles`
