### PR TITLE
feat(home): add resource center overview API

### DIFF
--- a/yak-ops-business/yak-ops-business-home/pom.xml
+++ b/yak-ops-business/yak-ops-business-home/pom.xml
@@ -39,6 +39,10 @@
         </dependency>
         <dependency>
             <groupId>io.yak.ops</groupId>
+            <artifactId>yak-ops-business-resource</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.yak.ops</groupId>
             <artifactId>yak-ops-business-sync-offline</artifactId>
         </dependency>
         <dependency>

--- a/yak-ops-business/yak-ops-business-home/src/main/java/io/yak/ops/business/home/controller/v1/HomeResourceCenterController.java
+++ b/yak-ops-business/yak-ops-business-home/src/main/java/io/yak/ops/business/home/controller/v1/HomeResourceCenterController.java
@@ -1,0 +1,30 @@
+package io.yak.ops.business.home.controller.v1;
+
+import io.yak.framework.common.Result;
+import io.yak.framework.security.web.RequiresPermission;
+import io.yak.ops.business.home.resource.HomeResourceCenterReader;
+import io.yak.ops.business.home.resource.HomeResourceCenterReader.OverviewResponse;
+import io.yak.ops.common.constant.resource.ResourcePermissionCode;
+import io.yak.ops.core.project.ProjectScope;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+/** 首页文件资源总览接口。 */
+@RestController
+@RequestMapping("/api/v1/home/resources")
+@ProjectScope
+@RequiresPermission(ResourcePermissionCode.READ)
+public class HomeResourceCenterController {
+
+  private final HomeResourceCenterReader reader;
+
+  public HomeResourceCenterController(HomeResourceCenterReader reader) {
+    this.reader = reader;
+  }
+
+  @GetMapping("/overview")
+  public Result<OverviewResponse> overview() {
+    return Result.success(reader.overview());
+  }
+}

--- a/yak-ops-business/yak-ops-business-home/src/main/java/io/yak/ops/business/home/resource/HomeResourceCenterReader.java
+++ b/yak-ops-business/yak-ops-business-home/src/main/java/io/yak/ops/business/home/resource/HomeResourceCenterReader.java
@@ -1,0 +1,128 @@
+package io.yak.ops.business.home.resource;
+
+import io.yak.ops.business.resource.domain.ResourceNode;
+import io.yak.ops.business.resource.domain.ResourceTreeNode;
+import io.yak.ops.business.resource.namespace.ResourceTreeReader;
+import io.yak.ops.common.enums.resource.ResourceNodeType;
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.List;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.ObjectProvider;
+import org.springframework.stereotype.Component;
+
+/** 首页文件资源只读聚合。 */
+@Component
+public class HomeResourceCenterReader {
+
+  private static final Logger LOGGER = LoggerFactory.getLogger(HomeResourceCenterReader.class);
+  private static final int RECENT_DAYS = 7;
+  private static final int RECENT_FILE_LIMIT = 3;
+
+  private final ObjectProvider<ResourceTreeReader> resourceTreeReaderProvider;
+
+  public HomeResourceCenterReader(ObjectProvider<ResourceTreeReader> resourceTreeReaderProvider) {
+    this.resourceTreeReaderProvider = resourceTreeReaderProvider;
+  }
+
+  public OverviewResponse overview() {
+    ResourceTreeReader treeReader = resourceTreeReaderProvider.getIfAvailable();
+    if (treeReader == null) return unavailable();
+
+    try {
+      return aggregate(treeReader.tree(), LocalDateTime.now());
+    } catch (RuntimeException exception) {
+      LOGGER.warn("加载首页资源中心总览失败", exception);
+      return unavailable();
+    }
+  }
+
+  OverviewResponse aggregate(List<ResourceTreeNode> roots, LocalDateTime now) {
+    List<ResourceNode> resources = flatten(roots);
+    long fileCount = 0L;
+    long folderCount = 0L;
+    long totalBytes = 0L;
+    List<TimedResource> recentCandidates = new ArrayList<>();
+    LocalDateTime recentBoundary = now.minusDays(RECENT_DAYS);
+
+    for (ResourceNode resource : resources) {
+      if (resource == null) continue;
+      if (resource.getNodeType() == ResourceNodeType.DIRECTORY) {
+        folderCount += 1L;
+        continue;
+      }
+      if (resource.getNodeType() != ResourceNodeType.FILE) continue;
+
+      fileCount += 1L;
+      totalBytes += Math.max(0L, resource.getFileSize() == null ? 0L : resource.getFileSize());
+
+      LocalDateTime updatedAt = resourceUpdatedAt(resource);
+      if (updatedAt != null && !updatedAt.isBefore(recentBoundary)) {
+        recentCandidates.add(new TimedResource(resource, updatedAt));
+      }
+    }
+
+    List<RecentFile> recentFiles =
+        recentCandidates.stream()
+            .sorted(Comparator.comparing(TimedResource::updatedAt).reversed())
+            .limit(RECENT_FILE_LIMIT)
+            .map(candidate -> recentFile(candidate.resource(), candidate.updatedAt()))
+            .toList();
+
+    return new OverviewResponse(true, fileCount, folderCount, totalBytes, recentFiles);
+  }
+
+  private List<ResourceNode> flatten(List<ResourceTreeNode> roots) {
+    List<ResourceNode> resources = new ArrayList<>();
+    if (roots == null) return resources;
+    roots.forEach(root -> collect(root, resources));
+    return resources;
+  }
+
+  private void collect(ResourceTreeNode node, List<ResourceNode> resources) {
+    if (node == null) return;
+    if (node.resource() != null) resources.add(node.resource());
+    node.children().forEach(child -> collect(child, resources));
+  }
+
+  private LocalDateTime resourceUpdatedAt(ResourceNode resource) {
+    return resource.getUpdateTime() == null ? resource.getCreateTime() : resource.getUpdateTime();
+  }
+
+  private RecentFile recentFile(ResourceNode resource, LocalDateTime updatedAt) {
+    return new RecentFile(
+        String.valueOf(resource.getId()),
+        defaultText(resource.getName(), "未命名文件"),
+        resource.getFullPath(),
+        resource.getSuffix(),
+        Math.max(0L, resource.getFileSize() == null ? 0L : resource.getFileSize()),
+        updatedAt.toString());
+  }
+
+  private OverviewResponse unavailable() {
+    return new OverviewResponse(false, null, null, null, List.of());
+  }
+
+  private static String defaultText(String value, String fallback) {
+    return value == null || value.isBlank() ? fallback : value;
+  }
+
+  public record OverviewResponse(
+      boolean available,
+      Long fileCount,
+      Long folderCount,
+      Long totalBytes,
+      List<RecentFile> recentFiles) {}
+
+  public record RecentFile(
+      String id,
+      String name,
+      String fullPath,
+      String suffix,
+      Long fileSize,
+      String updatedAt) {}
+
+  private record TimedResource(ResourceNode resource, LocalDateTime updatedAt) {}
+}

--- a/yak-ops-business/yak-ops-business-home/src/test/java/io/yak/ops/business/home/HomeArchitectureTest.java
+++ b/yak-ops-business/yak-ops-business-home/src/test/java/io/yak/ops/business/home/HomeArchitectureTest.java
@@ -9,11 +9,14 @@ import io.yak.ops.business.home.controller.v1.HomeAssetOverviewController;
 import io.yak.ops.business.home.controller.v1.HomeCockpitController;
 import io.yak.ops.business.home.controller.v1.HomeDataCenterController;
 import io.yak.ops.business.home.controller.v1.HomeQualityOverviewController;
+import io.yak.ops.business.home.controller.v1.HomeResourceCenterController;
 import io.yak.ops.business.home.controller.v1.HomeScheduleCenterController;
 import io.yak.ops.business.home.datacenter.HomeDataCenterReader;
 import io.yak.ops.business.home.quality.HomeQualityOverviewReader;
+import io.yak.ops.business.home.resource.HomeResourceCenterReader;
 import io.yak.ops.business.home.schedule.HomeScheduleCenterReader;
 import io.yak.ops.business.quality.QualityPermissionCode;
+import io.yak.ops.common.constant.resource.ResourcePermissionCode;
 import io.yak.ops.core.project.ProjectMigrationMode;
 import io.yak.ops.core.project.ProjectScope;
 import java.util.LinkedHashMap;
@@ -33,6 +36,7 @@ class HomeArchitectureTest {
         HomeDataCenterReader.class,
         HomeAssetOverviewReader.class,
         HomeQualityOverviewReader.class,
+        HomeResourceCenterReader.class,
         HomeScheduleCenterReader.class)) {
       assertThat(reader.getAnnotation(Component.class))
           .as("%s must be an internal @Component read role", reader.getSimpleName())
@@ -52,6 +56,7 @@ class HomeArchitectureTest {
     expectedRoutes.put(HomeDataCenterController.class, "/api/v1/home/data-center");
     expectedRoutes.put(HomeAssetOverviewController.class, "/api/v1/home/assets");
     expectedRoutes.put(HomeQualityOverviewController.class, "/api/v1/home/quality");
+    expectedRoutes.put(HomeResourceCenterController.class, "/api/v1/home/resources");
     expectedRoutes.put(HomeScheduleCenterController.class, "/api/v1/home/schedule-center");
 
     for (Map.Entry<Class<?>, String> entry : expectedRoutes.entrySet()) {
@@ -69,5 +74,10 @@ class HomeArchitectureTest {
         HomeQualityOverviewController.class.getAnnotation(RequiresPermission.class);
     assertThat(qualityPermission).isNotNull();
     assertThat(qualityPermission.value()).isEqualTo(QualityPermissionCode.EXECUTION_READ);
+
+    RequiresPermission resourcePermission =
+        HomeResourceCenterController.class.getAnnotation(RequiresPermission.class);
+    assertThat(resourcePermission).isNotNull();
+    assertThat(resourcePermission.value()).isEqualTo(ResourcePermissionCode.READ);
   }
 }

--- a/yak-ops-business/yak-ops-business-home/src/test/java/io/yak/ops/business/home/resource/HomeResourceCenterReaderTest.java
+++ b/yak-ops-business/yak-ops-business-home/src/test/java/io/yak/ops/business/home/resource/HomeResourceCenterReaderTest.java
@@ -1,0 +1,126 @@
+package io.yak.ops.business.home.resource;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import io.yak.ops.business.resource.domain.ResourceNode;
+import io.yak.ops.business.resource.domain.ResourceTreeNode;
+import io.yak.ops.business.resource.namespace.ResourceTreeReader;
+import io.yak.ops.common.enums.resource.ResourceNodeType;
+import java.time.LocalDateTime;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.ObjectProvider;
+
+class HomeResourceCenterReaderTest {
+
+  @Test
+  void shouldAggregateResourceSummaryAndRecentFiles() {
+    @SuppressWarnings("unchecked")
+    ObjectProvider<ResourceTreeReader> provider = mock(ObjectProvider.class);
+    HomeResourceCenterReader reader = new HomeResourceCenterReader(provider);
+    LocalDateTime now = LocalDateTime.of(2026, 9, 9, 9, 0);
+
+    ResourceNode folder = resource(1L, "SQL", ResourceNodeType.DIRECTORY, null, now.minusDays(20));
+    ResourceNode newest = resource(2L, "orders.csv", ResourceNodeType.FILE, 2_048L, now.minusHours(1));
+    ResourceNode recent = resource(3L, "config.json", ResourceNodeType.FILE, 1_024L, now.minusDays(2));
+    recent.setUpdateTime(null);
+    recent.setCreateTime(now.minusDays(2));
+    ResourceNode old = resource(4L, "archive.zip", ResourceNodeType.FILE, 4_096L, now.minusDays(8));
+
+    HomeResourceCenterReader.OverviewResponse response =
+        reader.aggregate(
+            List.of(
+                new ResourceTreeNode(folder, List.of(new ResourceTreeNode(newest, List.of()))),
+                new ResourceTreeNode(recent, List.of()),
+                new ResourceTreeNode(old, List.of())),
+            now);
+
+    assertThat(response.available()).isTrue();
+    assertThat(response.fileCount()).isEqualTo(3L);
+    assertThat(response.folderCount()).isEqualTo(1L);
+    assertThat(response.totalBytes()).isEqualTo(7_168L);
+    assertThat(response.recentFiles())
+        .extracting(HomeResourceCenterReader.RecentFile::name)
+        .containsExactly("orders.csv", "config.json");
+    assertThat(response.recentFiles().get(0).fileSize()).isEqualTo(2_048L);
+  }
+
+  @Test
+  void shouldLimitRecentFilesToThreeNewestItems() {
+    @SuppressWarnings("unchecked")
+    ObjectProvider<ResourceTreeReader> provider = mock(ObjectProvider.class);
+    HomeResourceCenterReader reader = new HomeResourceCenterReader(provider);
+    LocalDateTime now = LocalDateTime.of(2026, 9, 9, 9, 0);
+
+    List<ResourceTreeNode> resources =
+        List.of(
+            new ResourceTreeNode(resource(1L, "one.txt", ResourceNodeType.FILE, 1L, now.minusHours(1)), List.of()),
+            new ResourceTreeNode(resource(2L, "two.txt", ResourceNodeType.FILE, 1L, now.minusHours(2)), List.of()),
+            new ResourceTreeNode(resource(3L, "three.txt", ResourceNodeType.FILE, 1L, now.minusHours(3)), List.of()),
+            new ResourceTreeNode(resource(4L, "four.txt", ResourceNodeType.FILE, 1L, now.minusHours(4)), List.of()));
+
+    HomeResourceCenterReader.OverviewResponse response = reader.aggregate(resources, now);
+
+    assertThat(response.recentFiles())
+        .extracting(HomeResourceCenterReader.RecentFile::name)
+        .containsExactly("one.txt", "two.txt", "three.txt");
+  }
+
+  @Test
+  void shouldExposeUnavailableStateWhenResourceModuleIsDisabled() {
+    @SuppressWarnings("unchecked")
+    ObjectProvider<ResourceTreeReader> provider = mock(ObjectProvider.class);
+    when(provider.getIfAvailable()).thenReturn(null);
+
+    HomeResourceCenterReader.OverviewResponse response =
+        new HomeResourceCenterReader(provider).overview();
+
+    assertThat(response.available()).isFalse();
+    assertThat(response.fileCount()).isNull();
+    assertThat(response.folderCount()).isNull();
+    assertThat(response.totalBytes()).isNull();
+    assertThat(response.recentFiles()).isEmpty();
+  }
+
+  @Test
+  void shouldExposeUnavailableStateWhenResourceQueryFails() {
+    ResourceTreeReader treeReader = mock(ResourceTreeReader.class);
+    @SuppressWarnings("unchecked")
+    ObjectProvider<ResourceTreeReader> provider = mock(ObjectProvider.class);
+    when(provider.getIfAvailable()).thenReturn(treeReader);
+    when(treeReader.tree()).thenThrow(new IllegalStateException("resource unavailable"));
+
+    HomeResourceCenterReader.OverviewResponse response =
+        new HomeResourceCenterReader(provider).overview();
+
+    assertThat(response.available()).isFalse();
+    assertThat(response.fileCount()).isNull();
+    assertThat(response.recentFiles()).isEmpty();
+  }
+
+  private ResourceNode resource(
+      long id,
+      String name,
+      ResourceNodeType nodeType,
+      Long fileSize,
+      LocalDateTime updatedAt) {
+    ResourceNode resource = new ResourceNode();
+    resource.setId(id);
+    resource.setParentId(0L);
+    resource.setName(name);
+    resource.setFullPath("/" + name);
+    resource.setNodeType(nodeType);
+    resource.setSuffix(nodeType == ResourceNodeType.FILE ? suffix(name) : null);
+    resource.setFileSize(fileSize);
+    resource.setCreateTime(updatedAt.minusHours(1));
+    resource.setUpdateTime(updatedAt);
+    return resource;
+  }
+
+  private String suffix(String name) {
+    int separator = name.lastIndexOf('.');
+    return separator < 0 ? null : name.substring(separator + 1);
+  }
+}

--- a/yak-ops-ui/src/pages/home/components/HomeResourceCenter.tsx
+++ b/yak-ops-ui/src/pages/home/components/HomeResourceCenter.tsx
@@ -1,12 +1,12 @@
 import { FileSuffixIcon } from '@/components/resource/FileSuffixIcon';
 import { YAK_OPS_PERMISSIONS } from '@/constants/yakOpsPermissions';
 import usePermissionAccess from '@/hooks/usePermissionAccess';
-import { API_SUCCESS_CODE } from '@/services/http/response';
 import {
-  fetchResourceTree,
-  uploadResource,
-  type ResourceItem,
-} from '@/services/resource-management';
+  homeResourceCenterApi,
+  type HomeResourceCenterOverview,
+} from '@/services/home';
+import { API_SUCCESS_CODE } from '@/services/http/response';
+import { uploadResource } from '@/services/resource-management';
 import { history, useIntl } from '@umijs/max';
 import { message } from 'antd';
 import {
@@ -18,74 +18,20 @@ import {
   RefreshCw,
   Upload,
 } from 'lucide-react';
-import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import { useCallback, useEffect, useRef, useState } from 'react';
 
 import { HomeEmptyState } from './HomeEmptyState';
 
 const RESOURCE_MANAGEMENT_PATH = '/resource-management';
 const ROOT_RESOURCE_ID = 0;
-const RECENT_WINDOW_MS = 7 * 24 * 60 * 60 * 1000;
-const RECENT_FILE_LIMIT = 3;
 
-interface ResourceSummary {
-  files: number;
-  folders: number;
-  totalBytes: number;
-}
-
-const parseResourceTime = (value?: string) => {
+const parseResourceTime = (value?: string | null) => {
   if (!value) return Number.NaN;
   const normalized = value.includes(' ') ? value.replace(' ', 'T') : value;
   return new Date(normalized).getTime();
 };
 
-const flattenResources = (resources: ResourceItem[]) => {
-  const result: ResourceItem[] = [];
-
-  const visit = (items: ResourceItem[]) => {
-    items.forEach((item) => {
-      result.push(item);
-      if (item.children?.length) visit(item.children);
-    });
-  };
-
-  visit(resources);
-  return result;
-};
-
-const summarizeResources = (resources: ResourceItem[]): ResourceSummary =>
-  flattenResources(resources).reduce<ResourceSummary>(
-    (summary, item) => {
-      if (item.nodeType === 'DIRECTORY') {
-        summary.folders += 1;
-      } else {
-        summary.files += 1;
-        summary.totalBytes += Number(item.fileSize || 0);
-      }
-      return summary;
-    },
-    { files: 0, folders: 0, totalBytes: 0 },
-  );
-
-const getRecentFiles = (resources: ResourceItem[]) => {
-  const recentBoundary = Date.now() - RECENT_WINDOW_MS;
-
-  return flattenResources(resources)
-    .filter((item) => item.nodeType === 'FILE')
-    .map((item) => ({
-      item,
-      timestamp: parseResourceTime(item.updateTime || item.createTime),
-    }))
-    .filter(
-      ({ timestamp }) =>
-        Number.isFinite(timestamp) && timestamp >= recentBoundary,
-    )
-    .sort((left, right) => right.timestamp - left.timestamp)
-    .slice(0, RECENT_FILE_LIMIT)
-    .map(({ item }) => item);
-};
-
-const formatFileSize = (bytes?: number) => {
+const formatFileSize = (bytes?: number | null) => {
   const value = Number(bytes || 0);
   if (value <= 0) return '0 B';
 
@@ -95,11 +41,15 @@ const formatFileSize = (bytes?: number) => {
     units.length - 1,
   );
   const normalized = value / 1024 ** unitIndex;
-  const precision = normalized >= 100 || unitIndex === 0 ? 0 : normalized >= 10 ? 1 : 2;
+  const precision =
+    normalized >= 100 || unitIndex === 0 ? 0 : normalized >= 10 ? 1 : 2;
   return `${normalized.toFixed(precision)} ${units[unitIndex]}`;
 };
 
-const formatRelativeTime = (value: string | undefined, locale: string) => {
+const formatRelativeTime = (
+  value: string | null | undefined,
+  locale: string,
+) => {
   const timestamp = parseResourceTime(value);
   if (!Number.isFinite(timestamp)) return '--';
 
@@ -159,23 +109,23 @@ export default function HomeResourceCenter() {
   const canCreate = can(YAK_OPS_PERMISSIONS.resource.create);
   const uploadInputRef = useRef<HTMLInputElement>(null);
 
-  const [resources, setResources] = useState<ResourceItem[]>([]);
+  const [overview, setOverview] = useState<HomeResourceCenterOverview>();
   const [loading, setLoading] = useState(false);
   const [failed, setFailed] = useState(false);
   const [uploading, setUploading] = useState(false);
 
-  const loadResources = useCallback(async () => {
+  const loadOverview = useCallback(async () => {
     if (!canRead) return;
 
     try {
       setLoading(true);
       setFailed(false);
-      const response = await fetchResourceTree();
-      if (response.code !== API_SUCCESS_CODE) {
+      const response = await homeResourceCenterApi.overview();
+      if (response.code !== API_SUCCESS_CODE || !response.data) {
         setFailed(true);
         return;
       }
-      setResources(response.data || []);
+      setOverview(response.data);
     } catch {
       setFailed(true);
     } finally {
@@ -184,11 +134,8 @@ export default function HomeResourceCenter() {
   }, [canRead]);
 
   useEffect(() => {
-    void loadResources();
-  }, [loadResources]);
-
-  const summary = useMemo(() => summarizeResources(resources), [resources]);
-  const recentFiles = useMemo(() => getRecentFiles(resources), [resources]);
+    void loadOverview();
+  }, [loadOverview]);
 
   const handleUpload = async (file?: File) => {
     if (!file || !canCreate) return;
@@ -207,7 +154,7 @@ export default function HomeResourceCenter() {
         response.message ||
           intl.formatMessage({ id: 'pages.home.resourceCenter.uploadSuccess' }),
       );
-      await loadResources();
+      await loadOverview();
     } catch {
       message.error(
         intl.formatMessage({ id: 'pages.home.resourceCenter.uploadFailed' }),
@@ -221,25 +168,32 @@ export default function HomeResourceCenter() {
     {
       key: 'files',
       label: intl.formatMessage({ id: 'pages.home.resourceCenter.files' }),
-      value: summary.files.toLocaleString(intl.locale),
+      value:
+        overview?.fileCount == null
+          ? '--'
+          : overview.fileCount.toLocaleString(intl.locale),
       icon: Files,
       iconClassName: 'bg-[#fff1f4] text-[#ff4d6d]',
     },
     {
       key: 'folders',
       label: intl.formatMessage({ id: 'pages.home.resourceCenter.folders' }),
-      value: summary.folders.toLocaleString(intl.locale),
+      value:
+        overview?.folderCount == null
+          ? '--'
+          : overview.folderCount.toLocaleString(intl.locale),
       icon: FolderTree,
       iconClassName: 'bg-[#f3f5f8] text-[#707681]',
     },
     {
       key: 'storage',
       label: intl.formatMessage({ id: 'pages.home.resourceCenter.storage' }),
-      value: formatFileSize(summary.totalBytes),
+      value: overview?.totalBytes == null ? '--' : formatFileSize(overview.totalBytes),
       icon: HardDrive,
       iconClassName: 'bg-[#f3f1ff] text-[#7568ed]',
     },
   ];
+  const recentFiles = overview?.recentFiles || [];
 
   return (
     <section className="flex min-h-[420px] flex-1 flex-col rounded-[22px] border border-[#f0f1f3] bg-white px-5 pb-4 pt-5">
@@ -269,7 +223,7 @@ export default function HomeResourceCenter() {
           size="medium"
           className="min-h-[300px] flex-1"
         />
-      ) : loading && resources.length === 0 ? (
+      ) : loading && !overview ? (
         <ResourceCenterSkeleton />
       ) : (
         <>
@@ -323,7 +277,7 @@ export default function HomeResourceCenter() {
                 />
                 <button
                   type="button"
-                  onClick={() => void loadResources()}
+                  onClick={() => void loadOverview()}
                   className="mt-2 border-0 bg-transparent p-0 text-[10px] font-medium text-[#6f7681] hover:text-[#252832]"
                 >
                   {intl.formatMessage({ id: 'pages.home.resourceCenter.retry' })}
@@ -333,12 +287,15 @@ export default function HomeResourceCenter() {
               <div className="mt-2 divide-y divide-[#f1f2f4]">
                 {recentFiles.map((resource) => (
                   <div
-                    key={String(resource.id)}
+                    key={resource.id}
                     className="flex min-w-0 items-center gap-3 py-2.5"
                     title={resource.fullPath || resource.name}
                   >
                     <span className="flex h-10 w-10 shrink-0 items-center justify-center rounded-[11px] bg-[#f5f6f8]">
-                      <FileSuffixIcon suffix={resource.suffix} size={18} />
+                      <FileSuffixIcon
+                        suffix={resource.suffix || undefined}
+                        size={18}
+                      />
                     </span>
                     <div className="min-w-0 flex-1">
                       <div className="truncate text-[12px] font-medium text-[#3c4049]">
@@ -350,10 +307,7 @@ export default function HomeResourceCenter() {
                         </span>
                         <span className="h-0.5 w-0.5 shrink-0 rounded-full bg-[#c7cad0]" />
                         <span className="min-w-0 truncate">
-                          {formatRelativeTime(
-                            resource.updateTime || resource.createTime,
-                            intl.locale,
-                          )}
+                          {formatRelativeTime(resource.updatedAt, intl.locale)}
                         </span>
                       </div>
                     </div>

--- a/yak-ops-ui/src/services/home/api.ts
+++ b/yak-ops-ui/src/services/home/api.ts
@@ -7,6 +7,7 @@ import type {
   HomeDataCenterPeriod,
   HomeQualityOverview,
   HomeRecentResponse,
+  HomeResourceCenterOverview,
   HomeScheduleCalendar,
   HomeScheduleResponse,
 } from './types';
@@ -15,6 +16,7 @@ const COCKPIT_PREFIX = '/api/v1/home/cockpit';
 const DATA_CENTER_PREFIX = '/api/v1/home/data-center';
 const ASSET_PREFIX = '/api/v1/home/assets';
 const QUALITY_PREFIX = '/api/v1/home/quality';
+const RESOURCE_CENTER_PREFIX = '/api/v1/home/resources';
 const SCHEDULE_CENTER_PREFIX = '/api/v1/home/schedule-center';
 
 const requireAvailableQualityOverview = (
@@ -22,6 +24,16 @@ const requireAvailableQualityOverview = (
 ): ApiResponse<HomeQualityOverview> => {
   if (response.data?.available === false) {
     throw new Error('Home quality overview unavailable');
+  }
+
+  return response;
+};
+
+const requireAvailableResourceCenterOverview = (
+  response: ApiResponse<HomeResourceCenterOverview>,
+): ApiResponse<HomeResourceCenterOverview> => {
+  if (response.data?.available === false) {
+    throw new Error('Home resource center unavailable');
   }
 
   return response;
@@ -59,6 +71,13 @@ export const homeQualityOverviewApi = {
     HttpUtils.get<HomeQualityOverview>(`${QUALITY_PREFIX}/overview`).then(
       requireAvailableQualityOverview,
     ),
+};
+
+export const homeResourceCenterApi = {
+  overview: (): Promise<ApiResponse<HomeResourceCenterOverview>> =>
+    HttpUtils.get<HomeResourceCenterOverview>(
+      `${RESOURCE_CENTER_PREFIX}/overview`,
+    ).then(requireAvailableResourceCenterOverview),
 };
 
 export const homeScheduleCenterApi = {

--- a/yak-ops-ui/src/services/home/types.ts
+++ b/yak-ops-ui/src/services/home/types.ts
@@ -199,6 +199,24 @@ export interface HomeScheduleCalendar {
   overview: HomeScheduleSummary[];
 }
 
+export interface HomeResourceCenterRecentFile {
+  id: string;
+  name: string;
+  fullPath?: string | null;
+  suffix?: string | null;
+  fileSize: number;
+  updatedAt?: string | null;
+}
+
+export interface HomeResourceCenterOverview {
+  /** False means the resource read model is temporarily unavailable, not that metrics are zero. */
+  available?: boolean;
+  fileCount: number | null;
+  folderCount: number | null;
+  totalBytes: number | null;
+  recentFiles: HomeResourceCenterRecentFile[];
+}
+
 export interface HomeCockpitHeaderStats {
   dataSourceCount: number;
   runningCount: number;


### PR DESCRIPTION
## Summary

- add a project-scoped `GET /api/v1/home/resources/overview` endpoint for the homepage resource center
- aggregate file count, folder count, total resource bytes, and the three most recently updated files from the last 7 days on the backend
- reuse the resource module's read boundary instead of transferring the full resource tree to the homepage
- keep the homepage upload action on the existing resource upload API and refresh the new overview after upload
- wire `HomeResourceCenter` to the new home API with typed frontend contracts
- preserve permission-aware loading, unavailable, retry, empty, upload, and navigation states
- add reader aggregation tests plus route/project-scope/permission architecture coverage

## API

`GET /api/v1/home/resources/overview`

The response contains:

- `available`
- `fileCount`
- `folderCount`
- `totalBytes`
- `recentFiles[]` (`id`, `name`, `fullPath`, `suffix`, `fileSize`, `updatedAt`)

The endpoint is project-scoped and requires the existing `resource:view` permission.

## Frontend integration

`HomeResourceCenter` no longer downloads `/api/v1/resources/tree` and computes summary/recent data in the browser. It now consumes the dedicated homepage projection while continuing to use the existing upload endpoint for the quick-upload action.

## Validation

- branch is based on the current `main` that already contains PR #1069
- backend aggregation and route contract tests are included
- GitHub Actions will validate the frontend build and full Maven package
