### PR TITLE
fix(ui): allow switching workflow inspector nodes

### DIFF
--- a/yak-ops-ui/src/pages/workflow/definition/components/canvas/useWorkflowInspectorBehavior.ts
+++ b/yak-ops-ui/src/pages/workflow/definition/components/canvas/useWorkflowInspectorBehavior.ts
@@ -29,11 +29,17 @@ const useWorkflowInspectorBehavior = (defaultWidth = DEFAULT_PANEL_WIDTH) => {
   useEffect(() => {
     const keepInspectorOpen = (event: MouseEvent) => {
       const target = event.target;
-      if (!(target instanceof Element) || !target.closest('.react-flow__pane')) return;
+      if (!(target instanceof Element)) return;
 
-      // React Flow clears node selection when the pane receives a click. The workflow
-      // inspector intentionally behaves like Dify: clicking empty canvas keeps the
-      // current inspector open, and only its explicit close button dismisses it.
+      // React Flow nodes live inside the pane. Let node clicks propagate so the
+      // editor can switch the inspector to the newly selected node while it is open.
+      if (target.closest('.react-flow__node')) return;
+
+      if (!target.closest('.react-flow__pane')) return;
+
+      // React Flow clears node selection when the empty pane receives a click. The
+      // workflow inspector intentionally behaves like Dify: clicking empty canvas
+      // keeps the current inspector open, and only its explicit close button dismisses it.
       event.stopPropagation();
       event.stopImmediatePropagation();
     };


### PR DESCRIPTION
## Summary

Fix the workflow definition editor so users can switch directly from one node to another while the right-side inspector is already open.

## Root cause

`useWorkflowInspectorBehavior` installs a document-level capture click handler to keep the inspector open when clicking the empty React Flow canvas. Because workflow nodes are descendants of `.react-flow__pane`, the handler also intercepted node clicks and stopped propagation before React Flow could fire `onNodeClick`.

## Changes

- Let clicks originating from `.react-flow__node` propagate normally.
- Keep the existing behavior that clicking the empty canvas does not close the inspector.
- Preserve inspector resize and minimap behavior unchanged.

## Expected behavior

- Click node A → inspector shows node A.
- Click node B while inspector is still open → inspector immediately switches to node B.
- Click empty canvas → inspector remains open.
- Click the inspector close button → inspector closes normally.

## Validation

This is a focused frontend event-handling change affecting one file. No automated test suite was run from the GitHub connector environment.