### PR TITLE
fix(ui): make workflow node action menu clickable

### DIFF
--- a/yak-ops-ui/src/pages/workflow/definition/components/canvas/node/WorkflowNodeControl.tsx
+++ b/yak-ops-ui/src/pages/workflow/definition/components/canvas/node/WorkflowNodeControl.tsx
@@ -49,7 +49,8 @@ const WorkflowNodeControl = ({
       ].join(' ')}
     >
       <div
-        className="nodrag nopan flex h-6 items-center rounded-lg border border-[rgba(22,24,35,.08)] bg-[rgba(255,255,255,.96)] px-0.5 text-[#667085] shadow-[0_3px_10px_rgba(22,24,35,.12)] backdrop-blur-sm"
+        className="nodrag nopan nowheel flex h-6 items-center rounded-lg border border-[rgba(22,24,35,.08)] bg-[rgba(255,255,255,.96)] px-0.5 text-[#667085] shadow-[0_3px_10px_rgba(22,24,35,.12)] backdrop-blur-sm"
+        onPointerDown={(event) => event.stopPropagation()}
         onMouseDown={(event) => event.stopPropagation()}
         onClick={(event) => event.stopPropagation()}
       >
@@ -70,7 +71,14 @@ const WorkflowNodeControl = ({
           <button
             type="button"
             aria-label="节点操作"
+            aria-expanded={open}
             className="flex h-5 w-5 items-center justify-center rounded-md border-0 bg-transparent p-0 text-[#667085] hover:bg-[#f2f4f7] hover:text-[#161823]"
+            onPointerDown={(event) => event.stopPropagation()}
+            onMouseDown={(event) => event.stopPropagation()}
+            onClick={(event) => {
+              event.stopPropagation();
+              setOpen((current) => !current);
+            }}
           >
             <MoreHorizontal size={14} strokeWidth={2} />
           </button>


### PR DESCRIPTION
## Summary

Fix the workflow editor node `...` action menu so it reliably opens when clicked.

## Root cause

The node action control sits inside the React Flow interaction surface. Mouse/pointer events from the small trigger can be consumed by the canvas interaction layer before Ant Design's controlled `Dropdown` reliably updates its open state.

## Changes

- stop `pointerdown` from bubbling from the node action control into React Flow
- keep existing `mousedown` / `click` isolation for the control surface
- explicitly toggle the controlled dropdown state from the `...` button click
- keep Ant Design `onOpenChange` so outside-click closing still works
- add `nowheel` and `aria-expanded` to make the control behave like a proper interactive element inside the canvas

## Expected behavior

- click a workflow node to select it
- click the top-right `...` button
- the menu opens immediately
- `复制节点` and `删除节点` still execute their existing callbacks
- clicking outside closes the menu normally
- clicking the action control does not drag, pan, or re-select the React Flow node

## Validation

Focused frontend interaction change in one file. Branch is based on current `main` (including the previous inspector node-switch fix). No automated browser test was run from the GitHub connector environment.