### PR TITLE
feat(offline-sync): add single-table first-full cursor sync

### DIFF
--- a/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-offline/src/main/java/io/yak/ops/business/sync/offline/cursor/OfflineCursorGateway.java
+++ b/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-offline/src/main/java/io/yak/ops/business/sync/offline/cursor/OfflineCursorGateway.java
@@ -20,6 +20,7 @@ public interface OfflineCursorGateway {
     NOT_CURSOR_SCOPE,
     NOT_SUCCEEDED,
     NOT_INITIALIZED,
+    INITIALIZED,
     ADVANCED,
     ALREADY_ADVANCED,
     STALE

--- a/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-offline/src/main/java/io/yak/ops/business/sync/offline/cursor/OfflineCursorManager.java
+++ b/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-offline/src/main/java/io/yak/ops/business/sync/offline/cursor/OfflineCursorManager.java
@@ -40,6 +40,9 @@ public class OfflineCursorManager implements OfflineCursorGateway {
   @Override
   public AdvanceResult advanceAfterSucceededBatch(BatchExecution batch) {
     Objects.requireNonNull(batch, "BatchExecution 不能为空");
+    if (batch.batchScope() instanceof BatchScope.IncrementalRange range) {
+      return commitIncremental(batch, range);
+    }
     if (!(batch.batchScope() instanceof BatchScope.CursorRange range)) {
       return AdvanceResult.NOT_CURSOR_SCOPE;
     }
@@ -65,6 +68,66 @@ public class OfflineCursorManager implements OfflineCursorGateway {
       return AdvanceResult.ALREADY_ADVANCED;
     }
     return AdvanceResult.STALE;
+  }
+
+  private AdvanceResult commitIncremental(
+      BatchExecution batch, BatchScope.IncrementalRange range) {
+    if (batch.status() != BatchStatus.SUCCEEDED) {
+      return AdvanceResult.NOT_SUCCEEDED;
+    }
+    if (batch.id() == null || batch.id() <= 0L) {
+      throw new IllegalArgumentException("BatchExecutionId 必须大于 0");
+    }
+
+    OfflineSyncCursor current = repository.find(batch.taskId(), range.cursorId()).orElse(null);
+    if (current == null) {
+      if (!range.bootstrapFull()) {
+        return AdvanceResult.NOT_INITIALIZED;
+      }
+      repository.commitInitialSuccess(
+          batch.taskId(),
+          range.cursorId(),
+          range.sourceColumn(),
+          range.sourceSignature(),
+          range.throughInclusive(),
+          batch.id());
+      return AdvanceResult.INITIALIZED;
+    }
+
+    current = validateRoute(current, range);
+    if (Objects.equals(current.lastSucceededBatchId(), batch.id())
+        || current.position().equals(range.throughInclusive())) {
+      return AdvanceResult.ALREADY_ADVANCED;
+    }
+    if (range.bootstrapFull() || !current.position().equals(range.afterExclusive())) {
+      return AdvanceResult.STALE;
+    }
+    if (repository.advance(
+        current, range.afterExclusive(), range.throughInclusive(), batch.id())) {
+      return AdvanceResult.ADVANCED;
+    }
+
+    OfflineSyncCursor reread = repository.find(batch.taskId(), range.cursorId()).orElse(null);
+    if (reread != null
+        && (Objects.equals(reread.lastSucceededBatchId(), batch.id())
+            || reread.position().equals(range.throughInclusive()))) {
+      return AdvanceResult.ALREADY_ADVANCED;
+    }
+    return AdvanceResult.STALE;
+  }
+
+  private OfflineSyncCursor validateRoute(
+      OfflineSyncCursor current, BatchScope.IncrementalRange range) {
+    if (!current.sourceColumn().equals(range.sourceColumn())) {
+      throw new IllegalStateException("Cursor 已绑定不同增量字段：" + range.cursorId());
+    }
+    if (current.sourceSignature() == null) {
+      return repository.bindSourceSignature(current, range.sourceSignature());
+    }
+    if (!current.sourceSignature().equals(range.sourceSignature())) {
+      throw new IllegalStateException("Cursor 已绑定不同来源路由：" + range.cursorId());
+    }
+    return current;
   }
 
   private Optional<AdvanceResult> currentState(

--- a/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-offline/src/main/java/io/yak/ops/business/sync/offline/dao/OfflineSyncCursorDao.java
+++ b/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-offline/src/main/java/io/yak/ops/business/sync/offline/dao/OfflineSyncCursorDao.java
@@ -18,4 +18,11 @@ public interface OfflineSyncCursorDao {
       String nextPosition,
       Long succeededBatchId,
       LocalDateTime updateTime);
+
+  boolean bindSourceSignature(
+      Long taskId,
+      String cursorId,
+      long expectedVersion,
+      String sourceSignature,
+      LocalDateTime updateTime);
 }

--- a/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-offline/src/main/java/io/yak/ops/business/sync/offline/dao/impl/OfflineSyncCursorDaoImpl.java
+++ b/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-offline/src/main/java/io/yak/ops/business/sync/offline/dao/impl/OfflineSyncCursorDaoImpl.java
@@ -64,4 +64,31 @@ public class OfflineSyncCursorDaoImpl implements OfflineSyncCursorDao {
             .set(OfflineSyncCursorPO::getStateVersion, expectedVersion + 1L)
             .set(OfflineSyncCursorPO::getUpdateTime, updateTime)) > 0;
   }
+
+  @Override
+  public boolean bindSourceSignature(
+      Long taskId,
+      String cursorId,
+      long expectedVersion,
+      String sourceSignature,
+      LocalDateTime updateTime) {
+    if (taskId == null
+        || taskId <= 0L
+        || !StringUtils.hasText(cursorId)
+        || expectedVersion < 1L
+        || !StringUtils.hasText(sourceSignature)) {
+      return false;
+    }
+    return mapper.update(
+            null,
+            Wrappers.<OfflineSyncCursorPO>lambdaUpdate()
+                .eq(OfflineSyncCursorPO::getJobDefinitionId, taskId)
+                .eq(OfflineSyncCursorPO::getCursorId, cursorId.trim())
+                .eq(OfflineSyncCursorPO::getStateVersion, expectedVersion)
+                .isNull(OfflineSyncCursorPO::getSourceSignature)
+                .set(OfflineSyncCursorPO::getSourceSignature, sourceSignature.trim())
+                .set(OfflineSyncCursorPO::getStateVersion, expectedVersion + 1L)
+                .set(OfflineSyncCursorPO::getUpdateTime, updateTime))
+        > 0;
+  }
 }

--- a/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-offline/src/main/java/io/yak/ops/business/sync/offline/definition/OfflineDefinitionSupport.java
+++ b/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-offline/src/main/java/io/yak/ops/business/sync/offline/definition/OfflineDefinitionSupport.java
@@ -131,6 +131,7 @@ public class OfflineDefinitionSupport {
     normalizeEndpoint(request, "source");
     normalizeEndpoint(request, "sink");
     normalizeChannel(request);
+    validateIncremental(request);
     OfflineDefinitionModelAdapter.sanitizeForPersistence(request);
     return request;
   }
@@ -154,6 +155,38 @@ public class OfflineDefinitionSupport {
     putDefault(channel, "recordsPerSecond", 10000L);
     putDefault(channel, "dirtyDataPolicy", "STOP");
     putDefault(channel, "dirtyDataLimit", 0L);
+  }
+
+  private void validateIncremental(ObjectNode request) {
+    JsonNode incremental = request.path("incremental");
+    if (!incremental.path("enabled").asBoolean(false)) return;
+    if (!"GUIDE_SINGLE".equalsIgnoreCase(request.path("basic").path("mode").asText())) {
+      throw new IllegalArgumentException("全量 + 游标增量首版仅支持单表同步");
+    }
+    if (!"MAX_TIMESTAMP".equalsIgnoreCase(incremental.path("strategy").asText())) {
+      throw new IllegalArgumentException("仅支持 MAX_TIMESTAMP 增量策略");
+    }
+    if (!"SOURCE_CURRENT_MAX".equalsIgnoreCase(
+        incremental.path("bootstrapMode").asText("SOURCE_CURRENT_MAX"))) {
+      throw new IllegalArgumentException("首版仅支持从来源当前 MAX 建立初始游标");
+    }
+    JsonNode source = request.path("source");
+    if (!"jdbc".equalsIgnoreCase(source.path("connectorId").asText())) {
+      throw new IllegalArgumentException("全量 + 游标增量首版仅支持 JDBC 来源");
+    }
+    if (!"table".equalsIgnoreCase(source.path("config").path("readMode").asText("table"))) {
+      throw new IllegalArgumentException("全量 + 游标增量暂不支持自定义 SQL");
+    }
+    if (!StringUtils.hasText(incremental.path("column").asText())) {
+      throw new IllegalArgumentException("增量字段不能为空");
+    }
+    JsonNode sinkConfig = request.path("sink").path("config");
+    if (!"upsert".equalsIgnoreCase(sinkConfig.path("writeMode").asText())) {
+      throw new IllegalArgumentException("全量 + 游标增量要求目标端使用 UPSERT");
+    }
+    if (!StringUtils.hasText(sinkConfig.path("primaryKey").asText())) {
+      throw new IllegalArgumentException("全量 + 游标增量要求目标端配置主键");
+    }
   }
 
   private void putDefault(ObjectNode target, String field, int value) {

--- a/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-offline/src/main/java/io/yak/ops/business/sync/offline/domain/OfflineSyncCursor.java
+++ b/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-offline/src/main/java/io/yak/ops/business/sync/offline/domain/OfflineSyncCursor.java
@@ -5,14 +5,26 @@ public record OfflineSyncCursor(
     long taskId,
     String cursorId,
     String sourceColumn,
+    String sourceSignature,
     String position,
     Long lastSucceededBatchId,
     long stateVersion) {
+
+  public OfflineSyncCursor(
+      long taskId,
+      String cursorId,
+      String sourceColumn,
+      String position,
+      Long lastSucceededBatchId,
+      long stateVersion) {
+    this(taskId, cursorId, sourceColumn, null, position, lastSucceededBatchId, stateVersion);
+  }
 
   public OfflineSyncCursor {
     if (taskId <= 0L) throw new IllegalArgumentException("TaskId 必须大于 0");
     cursorId = requireText(cursorId, "cursorId 不能为空");
     sourceColumn = requireText(sourceColumn, "sourceColumn 不能为空");
+    sourceSignature = normalize(sourceSignature);
     position = requireText(position, "position 不能为空");
     if (lastSucceededBatchId != null && lastSucceededBatchId <= 0L) {
       throw new IllegalArgumentException("lastSucceededBatchId 必须大于 0");
@@ -23,5 +35,9 @@ public record OfflineSyncCursor(
   private static String requireText(String value, String message) {
     if (value == null || value.trim().isEmpty()) throw new IllegalArgumentException(message);
     return value.trim();
+  }
+
+  private static String normalize(String value) {
+    return value == null || value.trim().isEmpty() ? null : value.trim();
   }
 }

--- a/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-offline/src/main/java/io/yak/ops/business/sync/offline/domain/core/BatchScope.java
+++ b/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-offline/src/main/java/io/yak/ops/business/sync/offline/domain/core/BatchScope.java
@@ -12,9 +12,11 @@ import java.util.Objects;
 /** Immutable data range owned by a BatchExecution. */
 public sealed interface BatchScope
     permits BatchScope.FullSelection,
+        BatchScope.EmptySelection,
         BatchScope.DataWindow,
         BatchScope.PartitionScope,
-        BatchScope.CursorRange {
+        BatchScope.CursorRange,
+        BatchScope.IncrementalRange {
 
   String canonicalValue();
 
@@ -33,6 +35,10 @@ public sealed interface BatchScope
     return new FullSelection();
   }
 
+  static EmptySelection emptySelection() {
+    return new EmptySelection();
+  }
+
   static DataWindow dataWindow(LocalDateTime startInclusive, LocalDateTime endExclusive) {
     return new DataWindow(startInclusive, endExclusive);
   }
@@ -46,10 +52,42 @@ public sealed interface BatchScope
     return new CursorRange(cursorId, afterExclusive, throughInclusive);
   }
 
+  static IncrementalRange incrementalRange(
+      String cursorId,
+      String sourceColumn,
+      String sourceSignature,
+      String afterExclusive,
+      String throughInclusive) {
+    return new IncrementalRange(
+        cursorId, sourceColumn, sourceSignature, afterExclusive, throughInclusive, false);
+  }
+
+  static IncrementalRange incrementalBootstrap(
+      String cursorId,
+      String sourceColumn,
+      String sourceSignature,
+      String capturedUpperBound) {
+    return new IncrementalRange(
+        cursorId,
+        sourceColumn,
+        sourceSignature,
+        capturedUpperBound,
+        capturedUpperBound,
+        true);
+  }
+
   record FullSelection() implements BatchScope {
     @Override
     public String canonicalValue() {
       return "FULL_SELECTION";
+    }
+  }
+
+  /** A frozen zero-row execution that succeeds without submitting an engine job. */
+  record EmptySelection() implements BatchScope {
+    @Override
+    public String canonicalValue() {
+      return "EMPTY_SELECTION";
     }
   }
 
@@ -121,6 +159,44 @@ public sealed interface BatchScope
           + encode(afterExclusive)
           + "|"
           + encode(throughInclusive);
+    }
+  }
+
+  /** Frozen first-full or subsequent cursor range for a regular single-table execution. */
+  record IncrementalRange(
+      String cursorId,
+      String sourceColumn,
+      String sourceSignature,
+      String afterExclusive,
+      String throughInclusive,
+      boolean bootstrapFull)
+      implements BatchScope {
+
+    public IncrementalRange {
+      cursorId = requireText(cursorId, "cursorId 不能为空");
+      sourceColumn = requireText(sourceColumn, "sourceColumn 不能为空");
+      sourceSignature = requireText(sourceSignature, "sourceSignature 不能为空");
+      afterExclusive = requireText(afterExclusive, "afterExclusive 不能为空");
+      throughInclusive = requireText(throughInclusive, "throughInclusive 不能为空");
+      if (throughInclusive.compareTo(afterExclusive) < 0) {
+        throw new IllegalArgumentException("IncrementalRange 上界不能小于下界");
+      }
+    }
+
+    @Override
+    public String canonicalValue() {
+      return "INCREMENTAL_RANGE|"
+          + encode(cursorId)
+          + "|"
+          + encode(sourceColumn)
+          + "|"
+          + encode(sourceSignature)
+          + "|"
+          + encode(afterExclusive)
+          + "|"
+          + encode(throughInclusive)
+          + "|"
+          + (bootstrapFull ? "BOOTSTRAP_FULL" : "RANGE");
     }
   }
 

--- a/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-offline/src/main/java/io/yak/ops/business/sync/offline/engine/OfflineDefinitionModelAdapter.java
+++ b/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-offline/src/main/java/io/yak/ops/business/sync/offline/engine/OfflineDefinitionModelAdapter.java
@@ -12,8 +12,8 @@ import org.springframework.util.StringUtils;
 /**
  * 将 Yak Ops 对外任务定义转换为 JobSpec 工厂使用的内部配置结构。
  *
- * <p>持久化协议保持 basic + source + sink + channel。该适配仅作用于构建副本，
- * 不会把 config、workflow 或其他执行期结构写回任务定义。</p>
+ * <p>该适配仅作用于构建副本，不会把 config、workflow 或其他执行期结构写回任务定义。
+ * Yak Ops 自有的通知、编辑器与增量游标配置也不会进入 Link-Up JobSpec。</p>
  *
  * @author weifuwan
  */
@@ -112,10 +112,10 @@ public final class OfflineDefinitionModelAdapter {
       return definition;
     }
     ObjectNode adapted = (ObjectNode) definition.deepCopy();
-    // Notification and editor metadata are Yak Ops control-plane concerns. They must never alter
-    // engine JobSpec, execution snapshots or config digests when only UI preferences change.
+    // These are Yak Ops control-plane concerns and are not part of Link-Up's JobSpec contract.
     adapted.remove("notification");
     adapted.remove("editorMeta");
+    adapted.remove("incremental");
     String mode = text(adapted.path("basic"), "mode", "GUIDE_SINGLE");
     adaptEndpoint(adapted, "source", mode, objectMapper);
     adaptEndpoint(adapted, "sink", mode, objectMapper);

--- a/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-offline/src/main/java/io/yak/ops/business/sync/offline/execution/OfflineExecutionClaimManager.java
+++ b/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-offline/src/main/java/io/yak/ops/business/sync/offline/execution/OfflineExecutionClaimManager.java
@@ -15,6 +15,7 @@ import io.yak.ops.business.sync.offline.domain.core.BatchTriggerToken;
 import io.yak.ops.business.sync.offline.domain.core.BatchTriggerToken.Parsed;
 import io.yak.ops.business.sync.offline.domain.core.ExecutionSnapshot;
 import io.yak.ops.business.sync.offline.domain.core.RetryPolicySnapshot;
+import io.yak.ops.business.sync.offline.incremental.OfflineIncrementalPlanner;
 import io.yak.ops.business.sync.offline.repository.OfflineBatchExecutionRepository;
 import io.yak.ops.business.sync.offline.repository.OfflineJobDefinitionRepository;
 import io.yak.ops.business.sync.offline.repository.OfflineJobExecutionRepository;
@@ -40,6 +41,7 @@ public class OfflineExecutionClaimManager {
   private final OfflineSyncProperties properties;
   private final OfflineExecutionAttemptFactory attemptFactory;
   private final OfflineExistingBatchClaimManager existingBatchClaimManager;
+  private final OfflineIncrementalPlanner incrementalPlanner;
 
   public OfflineExecutionClaimManager(
       OfflineJobDefinitionService definitionService,
@@ -50,7 +52,8 @@ public class OfflineExecutionClaimManager {
       OfflineBatchRuntime batchRuntime,
       OfflineSyncProperties properties,
       OfflineExecutionAttemptFactory attemptFactory,
-      OfflineExistingBatchClaimManager existingBatchClaimManager) {
+      OfflineExistingBatchClaimManager existingBatchClaimManager,
+      OfflineIncrementalPlanner incrementalPlanner) {
     this.definitionService = definitionService;
     this.definitionRepository = definitionRepository;
     this.executionRepository = executionRepository;
@@ -60,6 +63,7 @@ public class OfflineExecutionClaimManager {
     this.properties = properties;
     this.attemptFactory = attemptFactory;
     this.existingBatchClaimManager = existingBatchClaimManager;
+    this.incrementalPlanner = incrementalPlanner;
   }
 
   @Transactional(transactionManager = "offlineSyncTransactionManager", rollbackFor = Exception.class)
@@ -225,7 +229,7 @@ public class OfflineExecutionClaimManager {
       String logicalJobSpecJson,
       Parsed trigger,
       String idempotencyKey) {
-    BatchScope scope = BatchScope.fullSelection();
+    BatchScope scope = incrementalPlanner.plan(definitionId, definitionSnapshotJson);
     BatchTrigger batchTrigger =
         Objects.requireNonNull(trigger.batchTrigger(), "初始执行必须包含 BatchTrigger");
     BatchKey batchKey = trigger.batchKey();

--- a/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-offline/src/main/java/io/yak/ops/business/sync/offline/execution/OfflineExecutionCoordinator.java
+++ b/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-offline/src/main/java/io/yak/ops/business/sync/offline/execution/OfflineExecutionCoordinator.java
@@ -262,11 +262,36 @@ public class OfflineExecutionCoordinator {
       return result;
     }
 
+    if (batchScope(execution) instanceof BatchScope.EmptySelection) {
+      stateManager.recordCreated(execution);
+      AuditOperationHandle audit = auditBridge.ensureOperation(execution);
+      OfflineJobExecution result =
+          callInAuditContext(
+              audit,
+              () -> {
+                stateManager.markNoDataSucceeded(execution);
+                auditBridge.observeState(execution);
+                return execution;
+              });
+      return result;
+    }
+
     String executionJobSpec = resolveScopedExecutionJobSpec(claim);
     stateManager.recordCreated(execution);
     AuditOperationHandle audit = auditBridge.ensureOperation(execution);
     return callInAuditContext(
         audit, () -> submitClaimInContext(execution, executionJobSpec));
+  }
+
+  private BatchScope batchScope(OfflineJobExecution execution) {
+    Long batchId = execution.getBatchId();
+    if (batchId == null || batchId <= 0L) {
+      throw new IllegalStateException("运行实例未绑定 BatchExecution");
+    }
+    return batchRepository
+        .findById(batchId)
+        .orElseThrow(() -> new IllegalStateException("Attempt 绑定的 BatchExecution 不存在：" + batchId))
+        .batchScope();
   }
 
   private OfflineJobExecution submitClaimInContext(

--- a/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-offline/src/main/java/io/yak/ops/business/sync/offline/execution/OfflineExecutionStateManager.java
+++ b/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-offline/src/main/java/io/yak/ops/business/sync/offline/execution/OfflineExecutionStateManager.java
@@ -102,6 +102,39 @@ public class OfflineExecutionStateManager {
     markTerminal(execution, OfflineExecutionStatus.FAILED, message, null, retryable);
   }
 
+  /** Completes a frozen empty incremental batch locally without creating a Link-Up job. */
+  public void markNoDataSucceeded(OfflineJobExecution execution) {
+    LocalDateTime now = LocalDateTime.now();
+    String previous = execution.getStatus();
+    execution.setStartTime(now);
+    execution.setDurationMillis(0L);
+    execution.setSourceRecordCount(0L);
+    execution.setSinkAttemptedRecordCount(0L);
+    execution.setSinkSuccessRecordCount(0L);
+    execution.setSinkCommittedRecordCount(0L);
+    execution.setSourceReadBytes(0L);
+    execution.setSinkWrittenBytes(0L);
+    execution.setFailedRecordCount(0L);
+    execution.setSkippedRecordCount(0L);
+    execution.setQps(0D);
+    execution.setStatus(OfflineExecutionStatus.SUCCEEDED.name());
+    execution.setStateVersion(value(execution.getStateVersion(), 0L) + 1L);
+    execution.setErrorMessage(null);
+    execution.setEndTime(now);
+    execution.setLastSyncTime(now);
+    execution.setUpdateTime(now);
+    configureRetry(execution, OfflineExecutionStatus.SUCCEEDED, false);
+    batchRuntime.persistAttempt(execution);
+    projectTaskLastState(execution, OfflineExecutionStatus.SUCCEEDED.name());
+    record(
+        execution,
+        previous,
+        OfflineExecutionStatus.SUCCEEDED.name(),
+        "NO_DATA_SUCCEEDED",
+        "来源游标无变化，本批次无需同步",
+        null);
+  }
+
   public void markCancellationRequested(OfflineJobExecution execution) {
     execution.setCancellationRequested(true);
     execution.setUpdateTime(LocalDateTime.now());

--- a/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-offline/src/main/java/io/yak/ops/business/sync/offline/execution/adapter/OfflineBatchScopeExecutionAdapter.java
+++ b/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-offline/src/main/java/io/yak/ops/business/sync/offline/execution/adapter/OfflineBatchScopeExecutionAdapter.java
@@ -40,7 +40,9 @@ public class OfflineBatchScopeExecutionAdapter implements OfflineExecutionScopeV
 
   public String apply(long taskId, String logicalJobSpecJson, BatchScope scope) {
     validateInput(taskId, logicalJobSpecJson);
-    if (scope == null || scope instanceof BatchScope.FullSelection) {
+    if (scope == null
+        || scope instanceof BatchScope.FullSelection
+        || (scope instanceof BatchScope.IncrementalRange range && range.bootstrapFull())) {
       return logicalJobSpecJson.trim();
     }
 
@@ -124,6 +126,17 @@ public class OfflineBatchScopeExecutionAdapter implements OfflineExecutionScopeV
 
     if (scope instanceof BatchScope.CursorRange range) {
       String column = safeColumn(cursorGateway.requireSourceColumn(taskId, range.cursorId()));
+      return column
+          + " > "
+          + literal(range.afterExclusive())
+          + " AND "
+          + column
+          + " <= "
+          + literal(range.throughInclusive());
+    }
+
+    if (scope instanceof BatchScope.IncrementalRange range) {
+      String column = safeColumn(range.sourceColumn());
       return column
           + " > "
           + literal(range.afterExclusive())

--- a/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-offline/src/main/java/io/yak/ops/business/sync/offline/incremental/JdbcIdentifierQuoter.java
+++ b/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-offline/src/main/java/io/yak/ops/business/sync/offline/incremental/JdbcIdentifierQuoter.java
@@ -1,0 +1,41 @@
+package io.yak.ops.business.sync.offline.incremental;
+
+import io.yak.ops.common.enums.datasource.DataSourceDbType;
+import java.util.Arrays;
+import java.util.regex.Pattern;
+import java.util.stream.Collectors;
+
+/** Quotes validated JDBC identifiers for the catalog MAX query. */
+final class JdbcIdentifierQuoter {
+
+  private static final Pattern SAFE = Pattern.compile("[A-Za-z_][A-Za-z0-9_$]*");
+
+  private JdbcIdentifierQuoter() {}
+
+  static String quote(DataSourceDbType type, String identifier) {
+    String value = validate(identifier);
+    if (type == DataSourceDbType.SQL_SERVER) return "[" + value + "]";
+    if (type == DataSourceDbType.MYSQL
+        || type == DataSourceDbType.TIDB
+        || type == DataSourceDbType.DORIS
+        || type == DataSourceDbType.GOLDENDB
+        || type == DataSourceDbType.GBASE8A) {
+      return "`" + value + "`";
+    }
+    return "\"" + value + "\"";
+  }
+
+  static String quotePath(DataSourceDbType type, String path) {
+    return Arrays.stream(path.split("\\."))
+        .map(part -> quote(type, part))
+        .collect(Collectors.joining("."));
+  }
+
+  private static String validate(String value) {
+    String normalized = value == null ? "" : value.trim();
+    if (!SAFE.matcher(normalized).matches()) {
+      throw new IllegalArgumentException("数据库标识符不是安全标识符：" + value);
+    }
+    return normalized;
+  }
+}

--- a/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-offline/src/main/java/io/yak/ops/business/sync/offline/incremental/OfflineIncrementalPlanner.java
+++ b/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-offline/src/main/java/io/yak/ops/business/sync/offline/incremental/OfflineIncrementalPlanner.java
@@ -1,0 +1,261 @@
+package io.yak.ops.business.sync.offline.incremental;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.yak.ops.business.datasource.catalog.DataSourceCatalogReader;
+import io.yak.ops.business.datasource.domain.catalog.CatalogColumn;
+import io.yak.ops.business.datasource.domain.catalog.CatalogQueryResult;
+import io.yak.ops.business.datasource.domain.catalog.CatalogReadRequest;
+import io.yak.ops.business.datasource.domain.catalog.CatalogReadRequest.ReadMode;
+import io.yak.ops.business.sync.offline.config.ConditionalOnOfflineSyncEnabled;
+import io.yak.ops.business.sync.offline.cursor.OfflineCursorGateway;
+import io.yak.ops.business.sync.offline.domain.OfflineSyncCursor;
+import io.yak.ops.business.sync.offline.domain.core.BatchScope;
+import io.yak.ops.common.enums.datasource.DataSourceDbType;
+import java.nio.charset.StandardCharsets;
+import java.security.MessageDigest;
+import java.sql.Types;
+import java.util.HexFormat;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+import java.util.Optional;
+import java.util.regex.Pattern;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.stereotype.Component;
+import org.springframework.util.StringUtils;
+
+/** Freezes the upper bound for one single-table first-full cursor batch. */
+@ConditionalOnOfflineSyncEnabled
+@Component
+public class OfflineIncrementalPlanner {
+
+  public static final String CURSOR_ID = "timestamp-incremental";
+  private static final String UPPER_ALIAS = "yak_incremental_upper";
+  private static final Pattern SAFE_COLUMN = Pattern.compile("[A-Za-z_][A-Za-z0-9_$]*");
+  private static final Pattern SAFE_TABLE =
+      Pattern.compile("[A-Za-z_][A-Za-z0-9_$]*(\\.[A-Za-z_][A-Za-z0-9_$]*)*");
+  private static final Pattern ISO_TIME =
+      Pattern.compile(
+          "\\d{4}-\\d{2}-\\d{2}(?:[ T]\\d{2}:\\d{2}:\\d{2}(?:\\.\\d+)?(?:Z|[+-]\\d{2}:?\\d{2})?)?");
+
+  private final ObjectMapper objectMapper;
+  private final DataSourceCatalogReader catalogReader;
+  private final OfflineCursorGateway cursorGateway;
+
+  public OfflineIncrementalPlanner(
+      @Qualifier("offlineSyncJsonMapper") ObjectMapper objectMapper,
+      DataSourceCatalogReader catalogReader,
+      OfflineCursorGateway cursorGateway) {
+    this.objectMapper = objectMapper;
+    this.catalogReader = catalogReader;
+    this.cursorGateway = cursorGateway;
+  }
+
+  public BatchScope plan(long taskId, String definitionSnapshotJson) {
+    JsonNode definition = read(definitionSnapshotJson);
+    JsonNode incremental = definition.path("incremental");
+    if (!incremental.path("enabled").asBoolean(false)) {
+      return BatchScope.fullSelection();
+    }
+    validateConfiguration(definition);
+
+    long dataSourceId = positiveId(definition.path("source").path("dataSourceId"));
+    JsonNode sourceConfig = definition.path("source").path("config");
+    String table = safeTable(requiredText(sourceConfig, "table", "来源表不能为空"));
+    String column = safeColumn(requiredText(incremental, "column", "增量字段不能为空"));
+    CatalogReadRequest tableRequest =
+        new CatalogReadRequest(ReadMode.TABLE, table, null, List.of());
+    CatalogColumn metadata =
+        catalogReader.listColumn(dataSourceId, tableRequest).stream()
+            .filter(item -> item.name().equalsIgnoreCase(column))
+            .findFirst()
+            .orElseThrow(() -> new IllegalArgumentException("来源表不存在增量字段：" + column));
+    validateColumnType(metadata);
+
+    String signature = digest(dataSourceId + "|" + table + "|" + column);
+    Optional<OfflineSyncCursor> existing = cursorGateway.find(taskId, CURSOR_ID);
+    existing.ifPresent(cursor -> validateRoute(cursor, column, signature));
+    DataSourceDbType sourceType =
+        DataSourceDbType.parse(requiredText(definition.path("source"), "dbType", "来源类型不能为空"));
+    String upper = queryUpper(dataSourceId, table, column, sourceType);
+    if (upper == null) {
+      return BatchScope.emptySelection();
+    }
+    validateValue(metadata, upper);
+
+    if (existing.isEmpty()) {
+      return BatchScope.incrementalBootstrap(CURSOR_ID, column, signature, upper);
+    }
+    String lower = existing.orElseThrow().position();
+    validateValue(metadata, lower);
+    int comparison = upper.compareTo(lower);
+    if (comparison < 0) {
+      throw new IllegalStateException(
+          "来源最大游标小于已提交游标，拒绝回退：sourceMax=" + upper + ", cursor=" + lower);
+    }
+    if (comparison == 0) {
+      return BatchScope.emptySelection();
+    }
+    return BatchScope.incrementalRange(CURSOR_ID, column, signature, lower, upper);
+  }
+
+  public void validateConfiguration(JsonNode definition) {
+    JsonNode incremental = definition.path("incremental");
+    if (!incremental.path("enabled").asBoolean(false)) return;
+    if (!"GUIDE_SINGLE".equalsIgnoreCase(definition.path("basic").path("mode").asText())) {
+      throw new IllegalArgumentException("全量 + 游标增量首版仅支持单表同步");
+    }
+    if (!"MAX_TIMESTAMP".equalsIgnoreCase(incremental.path("strategy").asText())) {
+      throw new IllegalArgumentException("仅支持 MAX_TIMESTAMP 增量策略");
+    }
+    if (!"SOURCE_CURRENT_MAX".equalsIgnoreCase(
+        incremental.path("bootstrapMode").asText("SOURCE_CURRENT_MAX"))) {
+      throw new IllegalArgumentException("首版仅支持从来源当前 MAX 建立初始游标");
+    }
+    JsonNode source = definition.path("source");
+    if (!"jdbc".equalsIgnoreCase(source.path("connectorId").asText())) {
+      throw new IllegalArgumentException("全量 + 游标增量首版仅支持 JDBC 来源");
+    }
+    JsonNode sourceConfig = source.path("config");
+    if (!"table".equalsIgnoreCase(sourceConfig.path("readMode").asText("table"))) {
+      throw new IllegalArgumentException("全量 + 游标增量暂不支持自定义 SQL");
+    }
+    safeTable(requiredText(sourceConfig, "table", "来源表不能为空"));
+    safeColumn(requiredText(incremental, "column", "增量字段不能为空"));
+
+    JsonNode sinkConfig = definition.path("sink").path("config");
+    if (!"upsert".equalsIgnoreCase(sinkConfig.path("writeMode").asText())) {
+      throw new IllegalArgumentException("全量 + 游标增量要求目标端使用 UPSERT");
+    }
+    if (!StringUtils.hasText(sinkConfig.path("primaryKey").asText())) {
+      throw new IllegalArgumentException("全量 + 游标增量要求目标端配置主键");
+    }
+  }
+
+  private String queryUpper(
+      long dataSourceId, String table, String column, DataSourceDbType sourceType) {
+    String sql =
+        "SELECT MAX("
+            + JdbcIdentifierQuoter.quote(sourceType, column)
+            + ") AS "
+            + UPPER_ALIAS
+            + " FROM "
+            + JdbcIdentifierQuoter.quotePath(sourceType, table);
+    CatalogQueryResult result =
+        catalogReader.preview(
+            dataSourceId, new CatalogReadRequest(ReadMode.SQL, null, sql, List.of()));
+    if (result.rows().isEmpty()) return null;
+    Object value = valueIgnoreCase(result.rows().get(0), UPPER_ALIAS);
+    String normalized = value == null ? null : String.valueOf(value).trim();
+    return StringUtils.hasText(normalized) ? normalized : null;
+  }
+
+  private void validateColumnType(CatalogColumn column) {
+    boolean temporal =
+        switch (column.jdbcType()) {
+          case Types.DATE,
+              Types.TIME,
+              Types.TIME_WITH_TIMEZONE,
+              Types.TIMESTAMP,
+              Types.TIMESTAMP_WITH_TIMEZONE -> true;
+          default -> false;
+        };
+    String type = String.valueOf(column.typeName()).toUpperCase(Locale.ROOT);
+    boolean character =
+        column.jdbcType() == Types.CHAR
+            || column.jdbcType() == Types.VARCHAR
+            || column.jdbcType() == Types.LONGVARCHAR
+            || type.contains("CHAR")
+            || type.contains("TEXT");
+    if (!temporal && !character) {
+      throw new IllegalArgumentException("增量字段仅支持日期、时间戳或 ISO 字符时间，实际类型=" + column.typeName());
+    }
+  }
+
+  private void validateValue(CatalogColumn column, String value) {
+    String type = String.valueOf(column.typeName()).toUpperCase(Locale.ROOT);
+    boolean character =
+        column.jdbcType() == Types.CHAR
+            || column.jdbcType() == Types.VARCHAR
+            || column.jdbcType() == Types.LONGVARCHAR
+            || type.contains("CHAR")
+            || type.contains("TEXT");
+    if (character && !ISO_TIME.matcher(value).matches()) {
+      throw new IllegalArgumentException("字符型增量字段必须保存可按字典序排序的 ISO 时间值：" + value);
+    }
+  }
+
+  private void validateRoute(OfflineSyncCursor cursor, String column, String signature) {
+    if (!cursor.sourceColumn().equals(column)) {
+      throw new IllegalStateException("已有游标绑定的增量字段不同，拒绝执行");
+    }
+    if (cursor.sourceSignature() != null && !cursor.sourceSignature().equals(signature)) {
+      throw new IllegalStateException("已有游标绑定的来源路由不同，拒绝执行");
+    }
+  }
+
+  private long positiveId(JsonNode value) {
+    long id = value.asLong(0L);
+    if (id <= 0L && value.isTextual()) {
+      try {
+        id = Long.parseLong(value.asText());
+      } catch (NumberFormatException ignored) {
+        id = 0L;
+      }
+    }
+    if (id <= 0L) throw new IllegalArgumentException("增量任务缺少来源数据源");
+    return id;
+  }
+
+  private String safeColumn(String value) {
+    String normalized = value.trim();
+    if (!SAFE_COLUMN.matcher(normalized).matches()) {
+      throw new IllegalArgumentException("增量字段不是安全标识符：" + normalized);
+    }
+    return normalized;
+  }
+
+  private String safeTable(String value) {
+    String normalized = value.trim();
+    if (!SAFE_TABLE.matcher(normalized).matches()) {
+      throw new IllegalArgumentException("来源表不是安全标识符：" + normalized);
+    }
+    return normalized;
+  }
+
+  private String requiredText(JsonNode node, String field, String message) {
+    String value = node.path(field).asText();
+    if (!StringUtils.hasText(value)) throw new IllegalArgumentException(message);
+    return value.trim();
+  }
+
+  private Object valueIgnoreCase(Map<String, Object> row, String key) {
+    for (Map.Entry<String, Object> entry : row.entrySet()) {
+      if (entry.getKey().equalsIgnoreCase(key)) return entry.getValue();
+    }
+    return null;
+  }
+
+  private JsonNode read(String json) {
+    try {
+      JsonNode value = objectMapper.readTree(json);
+      if (value == null || !value.isObject()) {
+        throw new IllegalArgumentException("任务定义必须是 JSON 对象");
+      }
+      return value;
+    } catch (JsonProcessingException exception) {
+      throw new IllegalArgumentException("任务定义 JSON 已损坏", exception);
+    }
+  }
+
+  private String digest(String value) {
+    try {
+      return HexFormat.of()
+          .formatHex(MessageDigest.getInstance("SHA-256").digest(value.getBytes(StandardCharsets.UTF_8)));
+    } catch (Exception exception) {
+      throw new IllegalStateException("生成来源路由摘要失败", exception);
+    }
+  }
+}

--- a/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-offline/src/main/java/io/yak/ops/business/sync/offline/repository/OfflineBatchExecutionRepositoryAdapter.java
+++ b/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-offline/src/main/java/io/yak/ops/business/sync/offline/repository/OfflineBatchExecutionRepositoryAdapter.java
@@ -272,6 +272,9 @@ public class OfflineBatchExecutionRepositoryAdapter implements OfflineBatchExecu
     if (scope instanceof BatchScope.FullSelection) {
       return "FULL_SELECTION";
     }
+    if (scope instanceof BatchScope.EmptySelection) {
+      return "EMPTY_SELECTION";
+    }
     if (scope instanceof BatchScope.DataWindow) {
       return "DATA_WINDOW";
     }
@@ -280,6 +283,9 @@ public class OfflineBatchExecutionRepositoryAdapter implements OfflineBatchExecu
     }
     if (scope instanceof BatchScope.CursorRange) {
       return "CURSOR_RANGE";
+    }
+    if (scope instanceof BatchScope.IncrementalRange) {
+      return "INCREMENTAL_RANGE";
     }
     throw new IllegalArgumentException("不支持的 BatchScope：" + scope.getClass().getName());
   }
@@ -293,6 +299,12 @@ public class OfflineBatchExecutionRepositoryAdapter implements OfflineBatchExecu
           throw new IllegalStateException("FullSelection 持久化内容不正确");
         }
         yield BatchScope.fullSelection();
+      }
+      case "EMPTY_SELECTION" -> {
+        if (!"EMPTY_SELECTION".equals(canonical)) {
+          throw new IllegalStateException("EmptySelection 持久化内容不正确");
+        }
+        yield BatchScope.emptySelection();
       }
       case "DATA_WINDOW" -> {
         String[] parts = canonical.split("\\|", -1);
@@ -318,6 +330,30 @@ public class OfflineBatchExecutionRepositoryAdapter implements OfflineBatchExecu
           throw new IllegalStateException("CursorRange 持久化内容不正确");
         }
         yield BatchScope.cursorRange(decode(parts[1]), decode(parts[2]), decode(parts[3]));
+      }
+      case "INCREMENTAL_RANGE" -> {
+        String[] parts = canonical.split("\\|", -1);
+        if (parts.length != 7 || !"INCREMENTAL_RANGE".equals(parts[0])) {
+          throw new IllegalStateException("IncrementalRange 持久化内容不正确");
+        }
+        String cursorId = decode(parts[1]);
+        String sourceColumn = decode(parts[2]);
+        String sourceSignature = decode(parts[3]);
+        String afterExclusive = decode(parts[4]);
+        String throughInclusive = decode(parts[5]);
+        yield switch (parts[6]) {
+          case "BOOTSTRAP_FULL" ->
+              BatchScope.incrementalBootstrap(
+                  cursorId, sourceColumn, sourceSignature, throughInclusive);
+          case "RANGE" ->
+              BatchScope.incrementalRange(
+                  cursorId,
+                  sourceColumn,
+                  sourceSignature,
+                  afterExclusive,
+                  throughInclusive);
+          default -> throw new IllegalStateException("IncrementalRange 阶段不正确");
+        };
       }
       default -> throw new IllegalStateException("未知 BatchScope 类型：" + normalizedType);
     };

--- a/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-offline/src/main/java/io/yak/ops/business/sync/offline/repository/OfflineSyncCursorRepository.java
+++ b/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-offline/src/main/java/io/yak/ops/business/sync/offline/repository/OfflineSyncCursorRepository.java
@@ -14,6 +14,17 @@ public interface OfflineSyncCursorRepository {
       String sourceColumn,
       String initialPosition);
 
+  OfflineSyncCursor commitInitialSuccess(
+      long taskId,
+      String cursorId,
+      String sourceColumn,
+      String sourceSignature,
+      String initialPosition,
+      long succeededBatchId);
+
+  OfflineSyncCursor bindSourceSignature(
+      OfflineSyncCursor current, String sourceSignature);
+
   boolean advance(
       OfflineSyncCursor current,
       String expectedPosition,

--- a/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-offline/src/main/java/io/yak/ops/business/sync/offline/repository/OfflineSyncCursorRepositoryAdapter.java
+++ b/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-offline/src/main/java/io/yak/ops/business/sync/offline/repository/OfflineSyncCursorRepositoryAdapter.java
@@ -64,6 +64,84 @@ public class OfflineSyncCursorRepositoryAdapter implements OfflineSyncCursorRepo
   }
 
   @Override
+  public OfflineSyncCursor commitInitialSuccess(
+      long taskId,
+      String cursorId,
+      String sourceColumn,
+      String sourceSignature,
+      String initialPosition,
+      long succeededBatchId) {
+    requireTask(taskId);
+    if (succeededBatchId <= 0L) {
+      throw new IllegalArgumentException("BatchExecutionId 必须大于 0");
+    }
+    String normalizedId = requireText(cursorId, "cursorId 不能为空");
+    String normalizedColumn = requireText(sourceColumn, "sourceColumn 不能为空");
+    String normalizedSignature = requireText(sourceSignature, "sourceSignature 不能为空");
+    String normalizedPosition = requireText(initialPosition, "initialPosition 不能为空");
+    OfflineSyncCursor existing = toDomain(dao.select(taskId, normalizedId));
+    if (existing != null) {
+      return validateInitialCommit(
+          bindAndValidate(existing, normalizedColumn, normalizedSignature),
+          normalizedPosition,
+          succeededBatchId);
+    }
+
+    LocalDateTime now = LocalDateTime.now();
+    OfflineSyncCursorPO po = new OfflineSyncCursorPO();
+    po.setJobDefinitionId(taskId);
+    po.setCursorId(normalizedId);
+    po.setSourceColumn(normalizedColumn);
+    po.setSourceSignature(normalizedSignature);
+    po.setPositionValue(normalizedPosition);
+    po.setLastSucceededBatchId(succeededBatchId);
+    po.setStateVersion(1L);
+    po.setCreateTime(now);
+    po.setUpdateTime(now);
+    try {
+      if (dao.insert(po)) {
+        return new OfflineSyncCursor(
+            taskId,
+            normalizedId,
+            normalizedColumn,
+            normalizedSignature,
+            normalizedPosition,
+            succeededBatchId,
+            1L);
+      }
+    } catch (DuplicateKeyException ignored) {
+      // Concurrent successful bootstrap: the unique key chooses the cursor owner.
+    }
+    OfflineSyncCursor concurrent = toDomain(dao.select(taskId, normalizedId));
+    if (concurrent == null) {
+      throw new IllegalStateException("提交离线同步初始 Cursor 失败：" + normalizedId);
+    }
+    return validateInitialCommit(
+        bindAndValidate(concurrent, normalizedColumn, normalizedSignature),
+        normalizedPosition,
+        succeededBatchId);
+  }
+
+  @Override
+  public OfflineSyncCursor bindSourceSignature(
+      OfflineSyncCursor current, String sourceSignature) {
+    Objects.requireNonNull(current, "current cursor 不能为空");
+    String signature = requireText(sourceSignature, "sourceSignature 不能为空");
+    if (current.sourceSignature() != null) {
+      return validateSignature(current, signature);
+    }
+    dao.bindSourceSignature(
+        current.taskId(),
+        current.cursorId(),
+        current.stateVersion(),
+        signature,
+        LocalDateTime.now());
+    OfflineSyncCursor rebound = toDomain(dao.select(current.taskId(), current.cursorId()));
+    if (rebound == null) throw new IllegalStateException("绑定 Cursor 来源摘要后无法重读");
+    return validateSignature(rebound, signature);
+  }
+
+  @Override
   public boolean advance(
       OfflineSyncCursor current,
       String expectedPosition,
@@ -99,12 +177,36 @@ public class OfflineSyncCursorRepositoryAdapter implements OfflineSyncCursorRepo
     return cursor;
   }
 
+  private OfflineSyncCursor bindAndValidate(
+      OfflineSyncCursor cursor, String sourceColumn, String sourceSignature) {
+    validateRoute(cursor, sourceColumn);
+    return bindSourceSignature(cursor, sourceSignature);
+  }
+
+  private OfflineSyncCursor validateSignature(
+      OfflineSyncCursor cursor, String sourceSignature) {
+    if (!sourceSignature.equals(cursor.sourceSignature())) {
+      throw new IllegalStateException("Cursor 已绑定不同来源路由：" + cursor.cursorId());
+    }
+    return cursor;
+  }
+
+  private OfflineSyncCursor validateInitialCommit(
+      OfflineSyncCursor cursor, String position, long succeededBatchId) {
+    if (cursor.position().equals(position)
+        || Objects.equals(cursor.lastSucceededBatchId(), succeededBatchId)) {
+      return cursor;
+    }
+    throw new IllegalStateException("Cursor 已由其他成功 Batch 建立，当前初始上界已过期：" + cursor.cursorId());
+  }
+
   private OfflineSyncCursor toDomain(OfflineSyncCursorPO po) {
     if (po == null) return null;
     return new OfflineSyncCursor(
         positive(po.getJobDefinitionId(), "TaskId"),
         requireText(po.getCursorId(), "cursorId 不能为空"),
         requireText(po.getSourceColumn(), "sourceColumn 不能为空"),
+        po.getSourceSignature(),
         requireText(po.getPositionValue(), "positionValue 不能为空"),
         po.getLastSucceededBatchId(),
         positive(po.getStateVersion(), "stateVersion"));

--- a/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-offline/src/main/resources/db/migration/yak-offline-sync/V5__bind_offline_cursor_source_route.sql
+++ b/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-offline/src/main/resources/db/migration/yak-offline-sync/V5__bind_offline_cursor_source_route.sql
@@ -1,0 +1,3 @@
+ALTER TABLE yak_offline_sync_cursor
+    ADD COLUMN source_signature CHAR(64) NULL
+        COMMENT '游标绑定的数据源、表和字段摘要' AFTER source_column;

--- a/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-offline/src/test/java/io/yak/ops/business/sync/offline/cursor/OfflineCursorManagerTest.java
+++ b/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-offline/src/test/java/io/yak/ops/business/sync/offline/cursor/OfflineCursorManagerTest.java
@@ -59,6 +59,47 @@ class OfflineCursorManagerTest {
     verify(repository, never()).advance(any(), any(), any(), org.mockito.ArgumentMatchers.anyLong());
   }
 
+  @Test
+  void successfulBootstrapCreatesCursorOnlyAfterBatchSucceeded() {
+    OfflineSyncCursorRepository repository = Mockito.mock(OfflineSyncCursorRepository.class);
+    OfflineCursorManager manager = new OfflineCursorManager(repository);
+    BatchScope.IncrementalRange scope =
+        BatchScope.incrementalBootstrap(
+            "timestamp-incremental", "updated_at", "route", "2026-09-12 10:00:00");
+    when(repository.find(10L, "timestamp-incremental")).thenReturn(Optional.empty());
+
+    assertThat(manager.advanceAfterSucceededBatch(incrementalBatch(BatchStatus.SUCCEEDED, scope)))
+        .isEqualTo(OfflineCursorGateway.AdvanceResult.INITIALIZED);
+    verify(repository)
+        .commitInitialSuccess(
+            10L,
+            "timestamp-incremental",
+            "updated_at",
+            "route",
+            "2026-09-12 10:00:00",
+            77L);
+  }
+
+  @Test
+  void failedBootstrapDoesNotCreateCursor() {
+    OfflineSyncCursorRepository repository = Mockito.mock(OfflineSyncCursorRepository.class);
+    OfflineCursorManager manager = new OfflineCursorManager(repository);
+    BatchScope.IncrementalRange scope =
+        BatchScope.incrementalBootstrap(
+            "timestamp-incremental", "updated_at", "route", "2026-09-12 10:00:00");
+
+    assertThat(manager.advanceAfterSucceededBatch(incrementalBatch(BatchStatus.FAILED, scope)))
+        .isEqualTo(OfflineCursorGateway.AdvanceResult.NOT_SUCCEEDED);
+    verify(repository, never())
+        .commitInitialSuccess(
+            org.mockito.ArgumentMatchers.anyLong(),
+            any(),
+            any(),
+            any(),
+            any(),
+            org.mockito.ArgumentMatchers.anyLong());
+  }
+
   private BatchExecution batch(BatchStatus status, String after, String through) {
     return new BatchExecution(
         77L,
@@ -67,6 +108,20 @@ class OfflineCursorManagerTest {
             "bf-1", BatchScope.cursorRange("orders-updated", after, through).fingerprint()),
         BatchTrigger.BACKFILL,
         BatchScope.cursorRange("orders-updated", after, through),
+        new ExecutionSnapshot(
+            "{}", 1, new RetryPolicySnapshot(2, 10), "digest", "{\"kind\":\"BatchSyncJob\"}"),
+        status,
+        List.of());
+  }
+
+  private BatchExecution incrementalBatch(
+      BatchStatus status, BatchScope.IncrementalRange scope) {
+    return new BatchExecution(
+        77L,
+        10L,
+        BatchKey.manual("manual-1"),
+        BatchTrigger.MANUAL,
+        scope,
         new ExecutionSnapshot(
             "{}", 1, new RetryPolicySnapshot(2, 10), "digest", "{\"kind\":\"BatchSyncJob\"}"),
         status,

--- a/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-offline/src/test/java/io/yak/ops/business/sync/offline/engine/OfflineIncrementalJobSpecIsolationTest.java
+++ b/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-offline/src/test/java/io/yak/ops/business/sync/offline/engine/OfflineIncrementalJobSpecIsolationTest.java
@@ -1,0 +1,30 @@
+package io.yak.ops.business.sync.offline.engine;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.Test;
+
+class OfflineIncrementalJobSpecIsolationTest {
+
+  @Test
+  void incrementalControlPlaneConfigNeverEntersLinkUpJobSpec() throws Exception {
+    ObjectMapper objectMapper = new ObjectMapper();
+    JsonNode definition =
+        objectMapper.readTree(
+            """
+            {
+              "basic":{"mode":"GUIDE_SINGLE"},
+              "source":{"connectorId":"jdbc","config":{"table":"orders"}},
+              "sink":{"connectorId":"jdbc","config":{"table":"orders"}},
+              "incremental":{"enabled":true,"column":"updated_at"}
+            }
+            """);
+
+    JsonNode jobSpecInput = OfflineDefinitionModelAdapter.forJobSpec(definition, objectMapper);
+
+    assertThat(jobSpecInput.has("incremental")).isFalse();
+    assertThat(definition.has("incremental")).isTrue();
+  }
+}

--- a/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-offline/src/test/java/io/yak/ops/business/sync/offline/execution/OfflineExecutionClaimManagerTest.java
+++ b/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-offline/src/test/java/io/yak/ops/business/sync/offline/execution/OfflineExecutionClaimManagerTest.java
@@ -21,6 +21,7 @@ import io.yak.ops.business.sync.offline.domain.core.BatchStatus;
 import io.yak.ops.business.sync.offline.domain.core.BatchTrigger;
 import io.yak.ops.business.sync.offline.domain.core.ExecutionSnapshot;
 import io.yak.ops.business.sync.offline.domain.core.RetryPolicySnapshot;
+import io.yak.ops.business.sync.offline.incremental.OfflineIncrementalPlanner;
 import io.yak.ops.business.sync.offline.repository.OfflineBatchExecutionRepository;
 import io.yak.ops.business.sync.offline.repository.OfflineJobDefinitionRepository;
 import io.yak.ops.business.sync.offline.repository.OfflineJobExecutionRepository;
@@ -45,6 +46,7 @@ class OfflineExecutionClaimManagerTest {
   @Mock private OfflineBatchRuntime batchRuntime;
   @Mock private OfflineExecutionAttemptFactory attemptFactory;
   @Mock private OfflineExistingBatchClaimManager existingBatchClaimManager;
+  @Mock private OfflineIncrementalPlanner incrementalPlanner;
 
   private OfflineExecutionClaimManager manager;
 
@@ -59,7 +61,11 @@ class OfflineExecutionClaimManagerTest {
         batchRuntime,
         new OfflineSyncProperties(),
         attemptFactory,
-        existingBatchClaimManager);
+        existingBatchClaimManager,
+        incrementalPlanner);
+    org.mockito.Mockito.lenient()
+        .when(incrementalPlanner.plan(org.mockito.ArgumentMatchers.anyLong(), anyString()))
+        .thenReturn(BatchScope.fullSelection());
   }
 
   @Test
@@ -122,7 +128,12 @@ class OfflineExecutionClaimManagerTest {
 
     assertThat(result.isReused()).isFalse();
     verify(attemptFactory)
-        .create(any(BatchExecution.class), 1, "WORKFLOW", null, "attempt-123");
+        .create(
+            any(BatchExecution.class),
+            eq(1),
+            eq("WORKFLOW"),
+            eq(null),
+            eq("attempt-123"));
     verify(batchRuntime).refreshBatch(78L);
   }
 

--- a/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-offline/src/test/java/io/yak/ops/business/sync/offline/execution/OfflineExecutionCoordinatorTest.java
+++ b/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-offline/src/test/java/io/yak/ops/business/sync/offline/execution/OfflineExecutionCoordinatorTest.java
@@ -99,9 +99,9 @@ class OfflineExecutionCoordinatorTest {
     OfflineJobExecution execution = execution(99L, "CREATED");
     BatchExecution batch = frozenBatch(BatchStatus.RUNNING, BatchScope.fullSelection());
     when(claimManager.claim(10L, "WORKFLOW", null, 1))
-        .thenReturn(new OfflineExecutionClaim(null, "logical", execution));
+        .thenReturn(new OfflineExecutionClaim(null, "{}", execution));
     when(batchRepository.findById(77L)).thenReturn(Optional.of(batch));
-    when(scopeExecutionAdapter.apply(10L, "logical", batch.batchScope())).thenReturn("scoped");
+    when(scopeExecutionAdapter.apply(10L, "{}", batch.batchScope())).thenReturn("scoped");
     when(definitionService.resolveExecutionJobSpec("scoped"))
         .thenThrow(new IllegalStateException("invalid job spec"));
 
@@ -123,9 +123,9 @@ class OfflineExecutionCoordinatorTest {
     BatchScope.CursorRange range = BatchScope.cursorRange("orders", "100", "200");
     BatchExecution batch = frozenBatch(BatchStatus.RUNNING, range);
     when(claimManager.claimRetry(98L))
-        .thenReturn(new OfflineExecutionClaim(null, "logical", retry));
+        .thenReturn(new OfflineExecutionClaim(null, "{}", retry));
     when(batchRepository.findById(77L)).thenReturn(Optional.of(batch));
-    when(scopeExecutionAdapter.apply(10L, "logical", range)).thenReturn("scoped");
+    when(scopeExecutionAdapter.apply(10L, "{}", range)).thenReturn("scoped");
     when(definitionService.resolveExecutionJobSpec("scoped")).thenReturn("{}");
     when(linkUpClient.node())
         .thenThrow(new LinkUpTransportException("engine down", new ConnectException(), false));
@@ -133,7 +133,7 @@ class OfflineExecutionCoordinatorTest {
     assertThatThrownBy(() -> coordinator.retryFrom(previous))
         .isInstanceOf(LinkUpTransportException.class);
 
-    verify(scopeExecutionAdapter).apply(10L, "logical", range);
+    verify(scopeExecutionAdapter).apply(10L, "{}", range);
     verify(stateManager).markFailed(retry, "engine down", true);
     verify(auditBridge).ensureOperation(retry);
     verify(auditBridge).observeState(retry);
@@ -148,6 +148,21 @@ class OfflineExecutionCoordinatorTest {
     assertThat(coordinator.executePendingBackfill(77L)).isSameAs(existing);
 
     verifyNoInteractions(scopeExecutionAdapter, linkUpClient, stateManager, auditBridge);
+  }
+
+  @Test
+  void emptyIncrementalBatchSucceedsLocallyWithoutSubmittingLinkUpJob() {
+    OfflineJobExecution execution = execution(99L, "CREATED");
+    BatchExecution batch = frozenBatch(BatchStatus.RUNNING, BatchScope.emptySelection());
+    when(claimManager.claim(10L, "WORKFLOW", null, 1))
+        .thenReturn(new OfflineExecutionClaim(null, "{}", execution));
+    when(batchRepository.findById(77L)).thenReturn(Optional.of(batch));
+
+    assertThat(coordinator.execute(10L, "WORKFLOW", null, 1)).isSameAs(execution);
+
+    verify(stateManager).recordCreated(execution);
+    verify(stateManager).markNoDataSucceeded(execution);
+    verifyNoInteractions(linkUpClient, scopeExecutionAdapter);
   }
 
   @Test
@@ -249,7 +264,7 @@ class OfflineExecutionCoordinatorTest {
             1,
             new RetryPolicySnapshot(3, 30),
             "digest",
-            "logical"),
+            "{}"),
         status,
         List.of());
   }

--- a/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-offline/src/test/java/io/yak/ops/business/sync/offline/execution/adapter/OfflineBatchScopeExecutionAdapterTest.java
+++ b/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-offline/src/test/java/io/yak/ops/business/sync/offline/execution/adapter/OfflineBatchScopeExecutionAdapterTest.java
@@ -44,6 +44,30 @@ class OfflineBatchScopeExecutionAdapterTest {
   }
 
   @Test
+  void regularIncrementalRangeUsesItsFrozenColumnAndBounds() {
+    String scoped =
+        adapter.apply(
+            10L,
+            logicalJobSpec(null),
+            BatchScope.incrementalRange(
+                "timestamp-incremental", "updated_at", "route", "100", "200"));
+    assertThat(scoped).contains("updated_at > '100'");
+    assertThat(scoped).contains("updated_at <= '200'");
+  }
+
+  @Test
+  void bootstrapKeepsTheOriginalFullSelectionJobSpec() {
+    String logical = logicalJobSpec(null);
+    assertThat(
+            adapter.apply(
+                10L,
+                logical,
+                BatchScope.incrementalBootstrap(
+                    "timestamp-incremental", "updated_at", "route", "200")))
+        .isEqualTo(logical);
+  }
+
+  @Test
   void scopedBatchRejectsMultiTableJobSpecInsteadOfGuessingRoute() {
     String logical =
         "{\"source\":{\"connectorId\":\"jdbc\",\"options\":{\"table_list\":[{\"table_path\":\"a\"},{\"table_path\":\"b\"}],\"partition_column\":\"updated_at\"}},\"sink\":{}}";

--- a/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-offline/src/test/java/io/yak/ops/business/sync/offline/incremental/OfflineIncrementalPlannerTest.java
+++ b/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-offline/src/test/java/io/yak/ops/business/sync/offline/incremental/OfflineIncrementalPlannerTest.java
@@ -1,0 +1,152 @@
+package io.yak.ops.business.sync.offline.incremental;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.when;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.yak.ops.business.datasource.catalog.DataSourceCatalogReader;
+import io.yak.ops.business.datasource.domain.catalog.CatalogColumn;
+import io.yak.ops.business.datasource.domain.catalog.CatalogQueryResult;
+import io.yak.ops.business.datasource.domain.catalog.CatalogReadRequest;
+import io.yak.ops.business.sync.offline.cursor.OfflineCursorGateway;
+import io.yak.ops.business.sync.offline.domain.OfflineSyncCursor;
+import io.yak.ops.business.sync.offline.domain.core.BatchScope;
+import java.sql.Types;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class OfflineIncrementalPlannerTest {
+
+  @Mock private DataSourceCatalogReader catalogReader;
+  @Mock private OfflineCursorGateway cursorGateway;
+  private OfflineIncrementalPlanner planner;
+
+  @BeforeEach
+  void setUp() {
+    planner = new OfflineIncrementalPlanner(new ObjectMapper(), catalogReader, cursorGateway);
+    org.mockito.Mockito.lenient()
+        .when(catalogReader.listColumn(eq(1L), any(CatalogReadRequest.class)))
+        .thenReturn(
+            List.of(
+                new CatalogColumn(
+                    "updated_at", "TIMESTAMP", Types.TIMESTAMP, null, null, false, 1, false, null)));
+  }
+
+  @Test
+  void firstRunFreezesUpperBoundForFullBootstrap() {
+    when(cursorGateway.find(10L, OfflineIncrementalPlanner.CURSOR_ID)).thenReturn(Optional.empty());
+    upper("2026-09-12 10:00:00");
+
+    BatchScope scope = planner.plan(10L, definition());
+
+    assertThat(scope).isInstanceOf(BatchScope.IncrementalRange.class);
+    BatchScope.IncrementalRange range = (BatchScope.IncrementalRange) scope;
+    assertThat(range.bootstrapFull()).isTrue();
+    assertThat(range.throughInclusive()).isEqualTo("2026-09-12 10:00:00");
+  }
+
+  @Test
+  void subsequentRunUsesCommittedCursorAndCapturedUpperBound() {
+    when(cursorGateway.find(10L, OfflineIncrementalPlanner.CURSOR_ID))
+        .thenReturn(Optional.of(cursor("2026-09-12 09:00:00")));
+    upper("2026-09-12 10:00:00");
+
+    BatchScope.IncrementalRange range =
+        (BatchScope.IncrementalRange) planner.plan(10L, definition());
+
+    assertThat(range.bootstrapFull()).isFalse();
+    assertThat(range.afterExclusive()).isEqualTo("2026-09-12 09:00:00");
+    assertThat(range.throughInclusive()).isEqualTo("2026-09-12 10:00:00");
+  }
+
+  @Test
+  void unchangedMaxCreatesLocalZeroRowBatch() {
+    when(cursorGateway.find(10L, OfflineIncrementalPlanner.CURSOR_ID))
+        .thenReturn(Optional.of(cursor("2026-09-12 10:00:00")));
+    upper("2026-09-12 10:00:00");
+    assertThat(planner.plan(10L, definition())).isInstanceOf(BatchScope.EmptySelection.class);
+  }
+
+  @Test
+  void nullMaxCreatesLocalZeroRowBatchWithoutInitializingCursor() {
+    when(cursorGateway.find(10L, OfflineIncrementalPlanner.CURSOR_ID)).thenReturn(Optional.empty());
+    when(catalogReader.preview(eq(1L), any(CatalogReadRequest.class)))
+        .thenReturn(
+            new CatalogQueryResult(
+                List.of(),
+                List.of(Collections.singletonMap("yak_incremental_upper", null)),
+                1));
+    assertThat(planner.plan(10L, definition())).isInstanceOf(BatchScope.EmptySelection.class);
+  }
+
+  @Test
+  void lowerSourceMaxIsRejected() {
+    when(cursorGateway.find(10L, OfflineIncrementalPlanner.CURSOR_ID))
+        .thenReturn(Optional.of(cursor("2026-09-12 10:00:00")));
+    upper("2026-09-12 09:00:00");
+
+    assertThatThrownBy(() -> planner.plan(10L, definition()))
+        .isInstanceOf(IllegalStateException.class)
+        .hasMessageContaining("拒绝回退");
+  }
+
+  @Test
+  void nonUpsertTargetIsRejectedBeforeReadingMetadata() {
+    assertThatThrownBy(() -> planner.plan(10L, definition().replace("upsert", "append")))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining("UPSERT");
+  }
+
+  @Test
+  void changedSourceRouteCannotReuseCommittedCursor() {
+    OfflineSyncCursor cursor =
+        new OfflineSyncCursor(
+            10L,
+            OfflineIncrementalPlanner.CURSOR_ID,
+            "updated_at",
+            "different-route-signature",
+            "2026-09-12 09:00:00",
+            7L,
+            1L);
+    when(cursorGateway.find(10L, OfflineIncrementalPlanner.CURSOR_ID))
+        .thenReturn(Optional.of(cursor));
+
+    assertThatThrownBy(() -> planner.plan(10L, definition()))
+        .isInstanceOf(IllegalStateException.class)
+        .hasMessageContaining("来源路由不同");
+  }
+
+  private OfflineSyncCursor cursor(String position) {
+    return new OfflineSyncCursor(
+        10L, OfflineIncrementalPlanner.CURSOR_ID, "updated_at", position, 7L, 1L);
+  }
+
+  private void upper(String value) {
+    when(catalogReader.preview(eq(1L), any(CatalogReadRequest.class)))
+        .thenReturn(
+            new CatalogQueryResult(
+                List.of(), List.of(Map.of("yak_incremental_upper", value)), 1));
+  }
+
+  private String definition() {
+    return """
+        {
+          "basic":{"jobName":"orders","mode":"GUIDE_SINGLE"},
+          "source":{"connectorId":"jdbc","dbType":"MYSQL","dataSourceId":"1","config":{"readMode":"table","table":"public.orders"}},
+          "sink":{"connectorId":"jdbc","dataSourceId":"2","config":{"writeMode":"upsert","primaryKey":"id","table":"orders"}},
+          "incremental":{"enabled":true,"strategy":"MAX_TIMESTAMP","column":"updated_at","bootstrapMode":"SOURCE_CURRENT_MAX"}
+        }
+        """;
+  }
+}

--- a/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-offline/src/test/java/io/yak/ops/business/sync/offline/repository/OfflineSyncCursorRepositoryAdapterTest.java
+++ b/yak-ops-business/yak-ops-business-sync/yak-ops-business-sync-offline/src/test/java/io/yak/ops/business/sync/offline/repository/OfflineSyncCursorRepositoryAdapterTest.java
@@ -29,12 +29,12 @@ class OfflineSyncCursorRepositoryAdapterTest {
     assertThat(cursor.position()).isEqualTo("100");
     assertThat(cursor.stateVersion()).isEqualTo(1L);
     when(dao.advance(
-            10L,
-            "orders",
-            "100",
-            1L,
-            "200",
-            77L,
+            org.mockito.ArgumentMatchers.eq(10L),
+            org.mockito.ArgumentMatchers.eq("orders"),
+            org.mockito.ArgumentMatchers.eq("100"),
+            org.mockito.ArgumentMatchers.eq(1L),
+            org.mockito.ArgumentMatchers.eq("200"),
+            org.mockito.ArgumentMatchers.eq(77L),
             org.mockito.ArgumentMatchers.any()))
         .thenReturn(true);
 

--- a/yak-ops-common/src/main/java/io/yak/ops/common/bean/dto/sync/offline/OfflineJobDefinitionDTO.java
+++ b/yak-ops-common/src/main/java/io/yak/ops/common/bean/dto/sync/offline/OfflineJobDefinitionDTO.java
@@ -32,6 +32,9 @@ public class OfflineJobDefinitionDTO {
   /** 任务级通知策略；缺省/null 保留历史 Project OWNER + IN_APP 默认行为。 */
   private OfflineJobNotificationDTO notification;
 
+  /** 单表首次全量、后续按已提交上界增量的游标配置。 */
+  private OfflineJobIncrementalDTO incremental;
+
   /** UI-only metadata such as the selected EmojiIconPicker icon. */
   private OfflineJobEditorMetaDTO editorMeta;
 }

--- a/yak-ops-common/src/main/java/io/yak/ops/common/bean/dto/sync/offline/OfflineJobIncrementalDTO.java
+++ b/yak-ops-common/src/main/java/io/yak/ops/common/bean/dto/sync/offline/OfflineJobIncrementalDTO.java
@@ -1,0 +1,17 @@
+package io.yak.ops.common.bean.dto.sync.offline;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import lombok.Data;
+
+/** 单表离线同步的 MAX 时间游标配置。 */
+@JsonIgnoreProperties(ignoreUnknown = true)
+@JsonInclude(JsonInclude.Include.NON_NULL)
+@Data
+public class OfflineJobIncrementalDTO {
+
+  private Boolean enabled = false;
+  private String strategy = "MAX_TIMESTAMP";
+  private String column;
+  private String bootstrapMode = "SOURCE_CURRENT_MAX";
+}

--- a/yak-ops-common/src/main/java/io/yak/ops/common/bean/po/sync/offline/OfflineSyncCursorPO.java
+++ b/yak-ops-common/src/main/java/io/yak/ops/common/bean/po/sync/offline/OfflineSyncCursorPO.java
@@ -16,6 +16,7 @@ public class OfflineSyncCursorPO {
   private Long jobDefinitionId;
   private String cursorId;
   private String sourceColumn;
+  private String sourceSignature;
   private String positionValue;
   private Long lastSucceededBatchId;
   private Long stateVersion;

--- a/yak-ops-ui/src/pages/integration/batch-link-up/config/single/index.tsx
+++ b/yak-ops-ui/src/pages/integration/batch-link-up/config/single/index.tsx
@@ -203,6 +203,24 @@ const validateTaskConfig = (
     return 'Upsert 写入模式需要配置主键字段';
   }
 
+  if (editor.incremental?.enabled) {
+    if (String(editor.source.connectorId || '').toLowerCase() !== 'jdbc') {
+      return '全量 + 游标增量仅支持 JDBC 来源';
+    }
+    if (source.readMode === 'sql') {
+      return '全量 + 游标增量暂不支持自定义 SQL';
+    }
+    if (!editor.incremental.column?.trim()) {
+      return '请选择增量游标字段';
+    }
+    if (String(sink.writeMode || '').toLowerCase() !== 'upsert') {
+      return '全量 + 游标增量要求目标端使用 Upsert';
+    }
+    if (!sink.primaryKey?.trim()) {
+      return '全量 + 游标增量要求目标端配置主键';
+    }
+  }
+
   if (
     !editor.channel.parallelism ||
     editor.channel.parallelism < 1

--- a/yak-ops-ui/src/pages/integration/batch-link-up/detail/components/SingleTableConfigSection.tsx
+++ b/yak-ops-ui/src/pages/integration/batch-link-up/detail/components/SingleTableConfigSection.tsx
@@ -20,13 +20,16 @@ import {
   type EndpointCapabilityState,
 } from '../capabilities';
 import type { DataSourceColumnOption } from '../hooks/useDataSourceColumns';
+import type { SyncIncremental } from '../model';
 import EditorSection from './EditorSection';
 import SingleTablePreviewModal from './SingleTablePreviewModal';
 
 interface SingleTableConfigSectionProps {
   sourceDataSourceId?: string | number;
+  sourceConnectorId?: string;
   sourceConfig: Record<string, any>;
   sinkConfig: Record<string, any>;
+  incremental: SyncIncremental;
   sourceCapability: EndpointCapabilityState;
   sinkCapability: EndpointCapabilityState;
   autoCreateTableEnabled: boolean;
@@ -37,6 +40,8 @@ interface SingleTableConfigSectionProps {
   targetLoading: boolean;
   primaryKeyOptions: DataSourceColumnOption[];
   primaryKeyLoading: boolean;
+  incrementalColumnOptions: DataSourceColumnOption[];
+  incrementalColumnLoading: boolean;
   sourceReady: boolean;
   targetReady: boolean;
   allowCustomTargetName?: boolean;
@@ -46,6 +51,7 @@ interface SingleTableConfigSectionProps {
   onTargetTableSearch: (keyword: string) => void;
   onSourceChange: (patch: Record<string, any>) => void;
   onSinkChange: (patch: Record<string, any>) => void;
+  onIncrementalChange: (patch: Partial<SyncIncremental>) => void;
 }
 
 interface EndpointPanelProps {
@@ -85,8 +91,10 @@ const splitPrimaryKeys = (value: unknown): string[] =>
 
 export default function SingleTableConfigSection({
   sourceDataSourceId,
+  sourceConnectorId,
   sourceConfig,
   sinkConfig,
+  incremental,
   sourceCapability,
   sinkCapability,
   autoCreateTableEnabled,
@@ -97,6 +105,8 @@ export default function SingleTableConfigSection({
   targetLoading,
   primaryKeyOptions,
   primaryKeyLoading,
+  incrementalColumnOptions,
+  incrementalColumnLoading,
   sourceReady,
   targetReady,
   allowCustomTargetName = false,
@@ -106,6 +116,7 @@ export default function SingleTableConfigSection({
   onTargetTableSearch,
   onSourceChange,
   onSinkChange,
+  onIncrementalChange,
 }: SingleTableConfigSectionProps) {
   const [previewOpen, setPreviewOpen] = useState(false);
   const sourceReadMode = sourceConfig.readMode === 'sql' ? 'sql' : 'table';
@@ -128,6 +139,14 @@ export default function SingleTableConfigSection({
       CONNECTOR_CAPABILITY.UPSERT,
     );
   const supportsOverwrite = allowsOverwrite(sinkCapability);
+  const supportsIncremental =
+    String(sourceConnectorId || '').toLowerCase() === 'jdbc' &&
+    sourceReadMode === 'table' &&
+    supportsUpsert;
+  const cursorColumns = incrementalColumnOptions.filter((option) => {
+    const type = String(option.typeName || '').toUpperCase();
+    return /(DATE|TIME|CHAR|TEXT)/.test(type);
+  });
   const previewDisabled =
     !sourceDataSourceId ||
     (sourceReadMode === 'sql'
@@ -370,6 +389,62 @@ export default function SingleTableConfigSection({
 
           {sinkExtraParameters}
         </EndpointPanel>
+      </div>
+
+      <div className="mt-5 rounded-xl border border-[#e8eaee] bg-[#fcfcfd] p-5">
+        <div className="flex items-start justify-between gap-6">
+          <div>
+            <div className="text-[14px] font-semibold text-[#182230]">
+              全量 + 游标增量
+            </div>
+            <div className="mt-1 text-[12px] leading-5 text-[#667085]">
+              首次同步全表并记录来源当前 MAX；后续只同步 (已提交游标, 本次 MAX]。仅成功后推进游标，失败重试复用原上界。
+            </div>
+          </div>
+          <Switch
+            checked={incremental.enabled}
+            disabled={!supportsIncremental}
+            onChange={(enabled) => {
+              onIncrementalChange({
+                enabled,
+                ...(enabled ? {} : { column: '' }),
+              });
+              if (enabled && currentWriteMode !== 'upsert') {
+                onSinkChange({ writeMode: 'upsert' });
+              }
+            }}
+          />
+        </div>
+        {!supportsIncremental ? (
+          <div className="mt-3 text-[11px] leading-5 text-[#b54708]">
+            该能力要求 JDBC 单表来源，以及支持 Upsert 的目标 Connector。
+          </div>
+        ) : null}
+        {incremental.enabled ? (
+          <div className="mt-4 max-w-[520px]">
+            <FieldLabel required>增量游标字段</FieldLabel>
+            <Select
+              showSearch
+              variant="filled"
+              className="w-full"
+              value={incremental.column || undefined}
+              loading={incrementalColumnLoading}
+              disabled={!sourceConfig.table}
+              options={cursorColumns.map((option) => ({
+                label: option.description
+                  ? `${option.label} · ${option.description}`
+                  : option.label,
+                value: option.value,
+              }))}
+              optionFilterProp="label"
+              placeholder="选择日期、时间戳或 ISO 字符时间字段"
+              onChange={(column) => onIncrementalChange({ column })}
+            />
+            <div className="mt-1.5 text-[11px] leading-5 text-[#98a2b3]">
+              字符字段必须使用可按字典序排序的 ISO 时间格式；目标端须选择 Upsert 并配置主键。
+            </div>
+          </div>
+        ) : null}
       </div>
 
       <SingleTablePreviewModal

--- a/yak-ops-ui/src/pages/integration/batch-link-up/detail/components/SyncTaskEditor.tsx
+++ b/yak-ops-ui/src/pages/integration/batch-link-up/detail/components/SyncTaskEditor.tsx
@@ -12,7 +12,11 @@ import {
 import useDataSourceColumns from '../hooks/useDataSourceColumns';
 import useDataSourceTables from '../hooks/useDataSourceTables';
 import useOfflineConnectorRuntime from '../hooks/useOfflineConnectorRuntime';
-import { updateEndpointConfig, type SyncEditorState } from '../model';
+import {
+  DEFAULT_INCREMENTAL_CONFIG,
+  updateEndpointConfig,
+  type SyncEditorState,
+} from '../model';
 import ChannelConfigSection from './ChannelConfigSection';
 import FieldMappingSection, { type FieldMappingValue } from './FieldMappingSection';
 import MultiTableConfigSection from './MultiTableConfigSection';
@@ -46,6 +50,7 @@ export default function SyncTaskEditor({
 }: SyncTaskEditorProps) {
   const sourceConfig = editor.source.config || {};
   const sinkConfig = editor.sink.config || {};
+  const incremental = editor.incremental || DEFAULT_INCREMENTAL_CONFIG;
   const sourceId = editor.source.dataSourceId;
   const targetId = editor.sink.dataSourceId;
   const mappingColumns = normalizeMappings(editor.mapping?.columns);
@@ -101,8 +106,25 @@ export default function SyncTaskEditor({
     ? sourceColumnCatalog.loading
     : targetColumnCatalog.loading;
 
-  const updateSource = (patch: Record<string, any>) =>
-    onChange(updateEndpointConfig(editor, 'source', patch));
+  const updateSource = (patch: Record<string, any>) => {
+    const next = updateEndpointConfig(editor, 'source', patch);
+    const changesReadMode = Object.prototype.hasOwnProperty.call(patch, 'readMode');
+    const changesTable = Object.prototype.hasOwnProperty.call(patch, 'table');
+    onChange(
+      changesReadMode || changesTable
+        ? {
+            ...next,
+            incremental: {
+              ...incremental,
+              enabled: changesReadMode && patch.readMode === 'sql'
+                ? false
+                : incremental.enabled,
+              column: '',
+            },
+          }
+        : next,
+    );
+  };
   const updateSink = (patch: Record<string, any>) =>
     onChange(updateEndpointConfig(editor, 'sink', patch));
   const updateMapping = (columns: FieldMappingValue[]) =>
@@ -227,8 +249,10 @@ export default function SyncTaskEditor({
         ) : (
           <SingleTableConfigSection
             sourceDataSourceId={sourceId}
+            sourceConnectorId={editor.source.connectorId}
             sourceConfig={sourceConfig}
             sinkConfig={sinkConfig}
+            incremental={incremental}
             sourceCapability={sourceCapability}
             sinkCapability={sinkCapability}
             autoCreateTableEnabled={sinkAutoCreateTableEnabled}
@@ -239,6 +263,8 @@ export default function SyncTaskEditor({
             targetLoading={targetCatalog.loading}
             primaryKeyOptions={primaryKeyCatalog.columns}
             primaryKeyLoading={primaryKeyCatalog.loading}
+            incrementalColumnOptions={sourceColumnCatalog.columns}
+            incrementalColumnLoading={sourceColumnCatalog.loading}
             sourceReady={Boolean(sourceId)}
             targetReady={Boolean(targetId)}
             allowCustomTargetName={isMongoSink}
@@ -254,6 +280,12 @@ export default function SyncTaskEditor({
               )
             }
             onSinkChange={updateSink}
+            onIncrementalChange={(patch) =>
+              onChange({
+                ...editor,
+                incremental: { ...incremental, ...patch },
+              })
+            }
           />
         )}
       </div>

--- a/yak-ops-ui/src/pages/integration/batch-link-up/detail/hooks/useDataSourceColumns.ts
+++ b/yak-ops-ui/src/pages/integration/batch-link-up/detail/hooks/useDataSourceColumns.ts
@@ -7,6 +7,8 @@ export interface DataSourceColumnOption {
   value: string;
   description?: string;
   primaryKey?: boolean;
+  typeName?: string;
+  jdbcType?: number;
 }
 
 const normalizeColumns = (data: any): DataSourceColumnOption[] => {
@@ -29,6 +31,8 @@ const normalizeColumns = (data: any): DataSourceColumnOption[] => {
         label: String(value),
         description: [type, comment].filter(Boolean).join(' · ') || undefined,
         primaryKey: String(item?.fieldKey || '').toUpperCase() === 'PRI' || Boolean(item?.primaryKey),
+        typeName: type ? String(type) : undefined,
+        jdbcType: item?.jdbcType === undefined ? undefined : Number(item.jdbcType),
       };
     })
     .filter(Boolean) as DataSourceColumnOption[];

--- a/yak-ops-ui/src/pages/integration/batch-link-up/detail/model.incremental.test.ts
+++ b/yak-ops-ui/src/pages/integration/batch-link-up/detail/model.incremental.test.ts
@@ -1,0 +1,52 @@
+import {
+  buildSavePayload,
+  normalizeEditDetail,
+  type SyncEditorState,
+} from './model';
+
+const detail = (incremental?: Record<string, unknown>) => ({
+  id: '10',
+  basic: { jobName: 'orders', jobDesc: '', mode: 'GUIDE_SINGLE' },
+  source: {
+    connectorId: 'jdbc',
+    dbType: 'MYSQL',
+    dataSourceId: '1',
+    config: { readMode: 'table', table: 'orders' },
+  },
+  sink: {
+    connectorId: 'jdbc',
+    dbType: 'MYSQL',
+    dataSourceId: '2',
+    config: { table: 'orders_copy', writeMode: 'upsert', primaryKey: 'id' },
+  },
+  incremental,
+});
+
+test('old task detail defaults to disabled incremental mode', () => {
+  const editor = normalizeEditDetail(detail(), '10');
+  expect(editor.incremental).toEqual({
+    enabled: false,
+    strategy: 'MAX_TIMESTAMP',
+    column: '',
+    bootstrapMode: 'SOURCE_CURRENT_MAX',
+  });
+});
+
+test('incremental settings round-trip through editor payload', () => {
+  const editor = normalizeEditDetail(
+    detail({
+      enabled: true,
+      strategy: 'MAX_TIMESTAMP',
+      column: 'UPDATED_AT',
+      bootstrapMode: 'SOURCE_CURRENT_MAX',
+    }),
+    '10',
+  ) as SyncEditorState;
+
+  expect(buildSavePayload(editor).incremental).toEqual({
+    enabled: true,
+    strategy: 'MAX_TIMESTAMP',
+    column: 'UPDATED_AT',
+    bootstrapMode: 'SOURCE_CURRENT_MAX',
+  });
+});

--- a/yak-ops-ui/src/pages/integration/batch-link-up/detail/model.ts
+++ b/yak-ops-ui/src/pages/integration/batch-link-up/detail/model.ts
@@ -40,6 +40,13 @@ export interface SyncMapping {
   columns: SyncColumnMapping[];
 }
 
+export interface SyncIncremental {
+  enabled: boolean;
+  strategy: 'MAX_TIMESTAMP';
+  column: string;
+  bootstrapMode: 'SOURCE_CURRENT_MAX';
+}
+
 export interface SyncSchedule {
   cron: string;
   enabled: boolean;
@@ -64,6 +71,7 @@ export interface SyncEditorState {
   sink: SyncEndpoint;
   channel: SyncChannel;
   mapping: SyncMapping;
+  incremental?: SyncIncremental;
   schedule: SyncSchedule;
   notification: SyncNotification;
   state?: Record<string, any>;
@@ -91,6 +99,13 @@ export const DEFAULT_CHANNEL_CONFIG: SyncChannel = {
 
 export const DEFAULT_MAPPING_CONFIG: SyncMapping = {
   columns: [],
+};
+
+export const DEFAULT_INCREMENTAL_CONFIG: SyncIncremental = {
+  enabled: false,
+  strategy: 'MAX_TIMESTAMP',
+  column: '',
+  bootstrapMode: 'SOURCE_CURRENT_MAX',
 };
 
 export const DEFAULT_SCHEDULE_CONFIG: SyncSchedule = {
@@ -366,6 +381,7 @@ export const buildCreatePayload = (
       sink: multiDraftEndpoint(sinkEndpoint, 'sink'),
       channel: serializeChannel(DEFAULT_CHANNEL_CONFIG),
       mapping: { ...DEFAULT_MAPPING_CONFIG },
+      incremental: { ...DEFAULT_INCREMENTAL_CONFIG },
       schedule: { ...DEFAULT_SCHEDULE_CONFIG },
       notification: { ...DEFAULT_NOTIFICATION_CONFIG },
     };
@@ -378,6 +394,7 @@ export const buildCreatePayload = (
     sink: sinkEndpoint,
     channel: DEFAULT_CHANNEL_CONFIG,
     mapping: { ...DEFAULT_MAPPING_CONFIG },
+    incremental: { ...DEFAULT_INCREMENTAL_CONFIG },
     schedule: { ...DEFAULT_SCHEDULE_CONFIG },
     notification: { ...DEFAULT_NOTIFICATION_CONFIG },
   };
@@ -568,6 +585,12 @@ export const normalizeEditDetail = (
       dirtyDataPolicy: dirtyDataPolicy === 'SKIP' ? 'skip' : 'stop',
     },
     mapping: normalizeMapping(raw),
+    incremental: {
+      ...DEFAULT_INCREMENTAL_CONFIG,
+      ...(raw?.incremental || {}),
+      enabled: Boolean(raw?.incremental?.enabled),
+      column: String(raw?.incremental?.column || ''),
+    },
     schedule: normalizeSchedule(raw),
     notification: normalizeNotification(raw),
     state: raw?.state,
@@ -636,6 +659,10 @@ export const applyEndpointSelection = (
     mapping: dataSourceChanged
       ? { ...DEFAULT_MAPPING_CONFIG }
       : editor.mapping,
+    incremental:
+      dataSourceChanged && kind === 'source'
+        ? { ...DEFAULT_INCREMENTAL_CONFIG }
+        : editor.incremental,
   };
 };
 
@@ -752,6 +779,7 @@ export const buildSavePayload = (
       sink: multiSinkPayload(editor.sink),
       channel: serializeChannel(editor.channel),
       mapping,
+      incremental: { ...DEFAULT_INCREMENTAL_CONFIG },
       schedule,
       notification,
     };
@@ -764,6 +792,11 @@ export const buildSavePayload = (
     sink: endpointSavePayload(editor.sink),
     channel: editor.channel,
     mapping,
+    incremental: {
+      ...DEFAULT_INCREMENTAL_CONFIG,
+      ...(editor.incremental || {}),
+      column: String(editor.incremental?.column || '').trim(),
+    },
     schedule,
     notification,
   };


### PR DESCRIPTION
## 问题

单表离线同步目前只能每次全量读取，缺少“首次全量、后续按已成功提交游标增量读取”的轻量模式。

## 游标语义

- 首次执行前读取来源游标字段的 `MAX`，将上界冻结到 Batch；首次仍执行全量同步。
- Batch 成功后才初始化或推进游标；失败、取消、状态不明确均不推进。
- 后续使用 `column > lastCursor AND column <= capturedMax`。
- Retry 复用原 Batch 的冻结上界，不重新读取当前 `MAX`。
- `MAX` 为空或等于当前游标时，本地生成零行成功批次，不提交 Link-Up 任务，也不创建或修改游标。
- `MAX` 小于已提交游标时拒绝执行，防止回退。
- 游标绑定数据源、源表与字段摘要，避免任务改路由后误用旧游标。

## 能力边界

本 PR 仅支持 `GUIDE_SINGLE`、JDBC 表读取、日期/时间戳或可按字典序排序的 ISO 字符时间字段，并要求目标端支持 UPSERT 且已配置主键。不包含多表、指定初始游标、游标重置、Excel 导入、删除同步或执行队列改造。

`incremental` 仅属于 Yak Ops 控制面配置，不进入 Link-Up JobSpec，因此无需修改 yak-link-up。

## 兼容性

未提供 `incremental` 或 `enabled=false` 时保持原有全量行为；旧游标可继续读取，并在首次成功增量执行时绑定来源摘要。

## 测试

- 后端定向测试：41 个通过，覆盖首次成功/失败、重试冻结、后续推进、零数据、MAX 相等/回退、并发保护、来源路由变化及非法配置。
- Java 21：`yak-ops-boot -am compile` 通过。
- 前端定向 Jest：2 个通过，覆盖旧任务兼容、保存与回显。
- 前端生产构建：通过。
- 全仓 TypeScript 检查仍存在上游 main 已有的旧页面类型错误；本 PR 修改的前端文件未新增 TypeScript 错误。